### PR TITLE
Tweak react native for HUC

### DIFF
--- a/src/headless_checkout/NativePrimerHeadlessUniversalCheckout.ts
+++ b/src/headless_checkout/NativePrimerHeadlessUniversalCheckout.ts
@@ -1,0 +1,86 @@
+import { NativeEventEmitter, NativeModules } from 'react-native';
+
+const { PrimerHeadlessUniversalCheckout } = NativeModules;
+
+const eventEmitter = new NativeEventEmitter(PrimerHeadlessUniversalCheckout);
+
+type EventType =
+  | 'preparationStarted'
+  | 'paymentMethodPresented'
+  | 'tokenizationStarted'
+  | 'tokenizationSucceeded'
+  | 'resume'
+  | 'error';
+
+const NativePrimerHeadlessUniversalCheckout = {
+  ///////////////////////////////////////////
+  // Event Emitter
+  ///////////////////////////////////////////
+  addListener: (eventType: EventType, listener: (...args: any[]) => any) => {
+    eventEmitter.addListener(eventType, listener);
+  },
+
+  ///////////////////////////////////////////
+  // Native API
+  ///////////////////////////////////////////
+  getAssetForPaymentMethod: (
+    paymentMethodType: string,
+    assetType: string
+  ): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      try {
+        PrimerHeadlessUniversalCheckout.getAssetFor(
+          paymentMethodType,
+          assetType,
+          (err: Error) => {
+            reject(err);
+          },
+          (url: string) => {
+            resolve(url);
+          }
+        );
+      } catch (e) {
+        reject(e);
+      }
+    });
+  },
+
+  listAvailableAssets: (): Promise<string[]> => {
+    return new Promise((resolve, reject) => {
+      try {
+        PrimerHeadlessUniversalCheckout.listAvailableAssets(
+          (assets: string[]) => {
+            resolve(assets);
+          }
+        );
+      } catch (e) {
+        reject(e);
+      }
+    });
+  },
+
+  startWithClientToken(clientToken: string, settings: any): Promise<any> {
+    return new Promise((resolve, reject) => {
+      PrimerHeadlessUniversalCheckout.startWithClientToken(
+        clientToken,
+        JSON.stringify(settings),
+        (err: Error) => {
+          console.error(err);
+          reject(err);
+        },
+        (paymentMethodTypes: string[]) => {
+          resolve({ paymentMethodTypes });
+        }
+      );
+    });
+  },
+
+  showPaymentMethod: (paymentMethod: string) =>
+    PrimerHeadlessUniversalCheckout.showPaymentMethod(paymentMethod),
+
+  resumeWithClientToken(resumeToken: string) {
+    PrimerHeadlessUniversalCheckout.resumeWithClientToken(resumeToken);
+  },
+};
+
+export default NativePrimerHeadlessUniversalCheckout;

--- a/src/headless_checkout/PrimerHeadlessUniversalCheckout.ts
+++ b/src/headless_checkout/PrimerHeadlessUniversalCheckout.ts
@@ -1,22 +1,9 @@
 import type { PrimerSettings } from 'src/models/primer-settings';
 import NativePrimerHeadlessUniversalCheckout from './NativePrimerHeadlessUniversalCheckout';
 import type {
-  PrimerError,
   PrimerHeadlessUniversalCheckoutStartResponse,
   PrimerHeadlessUniversalCheckoutCallbacks,
 } from './types';
-
-export const getAssetForPaymentMethod = (
-  paymentMethodType: string,
-  assetType: string
-): Promise<string> =>
-  NativePrimerHeadlessUniversalCheckout.getAssetForPaymentMethod(
-    paymentMethodType,
-    assetType
-  );
-
-export const listAvailableAssets = (): Promise<string[]> =>
-  NativePrimerHeadlessUniversalCheckout.listAvailableAssets();
 
 class PrimerHeadlessUniversalCheckoutClass {
   private callbacks: PrimerHeadlessUniversalCheckoutCallbacks | undefined;
@@ -105,6 +92,20 @@ class PrimerHeadlessUniversalCheckoutClass {
     return NativePrimerHeadlessUniversalCheckout.resumeWithClientToken(
       resumeToken
     );
+  }
+
+  getAssetForPaymentMethod(
+    paymentMethodType: string,
+    assetType: string
+  ): Promise<string> {
+    return NativePrimerHeadlessUniversalCheckout.getAssetForPaymentMethod(
+      paymentMethodType,
+      assetType
+    );
+  }
+
+  listAvailableAssets() {
+    return NativePrimerHeadlessUniversalCheckout.listAvailableAssets();
   }
 }
 

--- a/src/headless_checkout/PrimerHeadlessUniversalCheckout.ts
+++ b/src/headless_checkout/PrimerHeadlessUniversalCheckout.ts
@@ -1,133 +1,113 @@
-import { NativeEventEmitter, NativeModules } from "react-native";
-import type { PrimerSettings } from "src/models/primer-settings";
+import type { PrimerSettings } from 'src/models/primer-settings';
+import NativePrimerHeadlessUniversalCheckout from './NativePrimerHeadlessUniversalCheckout';
+import type {
+  PrimerError,
+  PrimerHeadlessUniversalCheckoutStartResponse,
+  PrimerHeadlessUniversalCheckoutCallbacks,
+} from './types';
 
-const { PrimerHeadlessUniversalCheckout } = NativeModules;
+export const getAssetForPaymentMethod = (
+  paymentMethodType: string,
+  assetType: string
+): Promise<string> =>
+  NativePrimerHeadlessUniversalCheckout.getAssetForPaymentMethod(
+    paymentMethodType,
+    assetType
+  );
 
-export interface IPaymentMethodsTypes {
-  paymentMethodTypes: string[];
-}
+export const listAvailableAssets = (): Promise<string[]> =>
+  NativePrimerHeadlessUniversalCheckout.listAvailableAssets();
 
-export interface IPrimerError {
-  errorId: string;
-  description: string;
-  recoverySuggestion?: string;
-}
+class PrimerHeadlessUniversalCheckoutClass {
+  private callbacks: PrimerHeadlessUniversalCheckoutCallbacks | undefined;
 
-export class PrimerHUC {
-
-  onPreparationStarted: undefined | (() => void);
-  onPaymentMethodPresented: undefined | (() => void);
-  onTokenizationStarted: undefined | (() => void);
-  onTokenizeSuccess: undefined | ((paymentMethod: any) => void);
-  onResume: undefined | ((resumeToken: string) => void);
-  onFailure: undefined | ((error: IPrimerError) => void);
-
-  private static instance: PrimerHUC;
-
-  public static getInstance(): PrimerHUC {
-    if (!PrimerHUC.instance) {
-      PrimerHUC.instance = new PrimerHUC();
-    }
-
-    return PrimerHUC.instance;
+  ///////////////////////////////////////////
+  // Init
+  ///////////////////////////////////////////
+  constructor() {
+    this.callbacks = undefined;
+    this.configureListeners();
   }
 
-  private constructor() {
-    const eventEmitter = new NativeEventEmitter(PrimerHeadlessUniversalCheckout);
-    const preparationStartedListener = eventEmitter.addListener('preparationStarted', (data) => {
-      console.log("preparationStarted");
-      if (this.onPreparationStarted) {
-        this.onPreparationStarted();
+  private configureListeners() {
+    NativePrimerHeadlessUniversalCheckout.addListener(
+      'preparationStarted',
+      () => {
+        console.log('preparationStarted');
+        this.callbacks?.onPreparationStarted?.();
       }
+    );
+
+    NativePrimerHeadlessUniversalCheckout.addListener(
+      'paymentMethodPresented',
+      () => {
+        console.log('paymentMethodPresented');
+        this.callbacks?.onPaymentMethodPresented?.();
+      }
+    );
+
+    NativePrimerHeadlessUniversalCheckout.addListener(
+      'tokenizationStarted',
+      () => {
+        console.log('tokenizationStarted');
+        this.callbacks?.onTokenizeStart?.();
+      }
+    );
+
+    NativePrimerHeadlessUniversalCheckout.addListener(
+      'tokenizationSucceeded',
+      (data) => {
+        console.log('tokenizationSucceeded', data);
+        this.callbacks?.onTokenizeSuccess?.(data.paymentMethodToken);
+      }
+    );
+
+    NativePrimerHeadlessUniversalCheckout.addListener('resume', (data) => {
+      console.log('resume', data);
+      this.callbacks?.onResumeSuccess?.(data.resumeToken);
     });
 
-    const paymentMethodPresentedListener = eventEmitter.addListener('paymentMethodPresented', (data) => {
-      console.log("paymentMethodPresented");
-
-      if (this.onPaymentMethodPresented) {
-        this.onPaymentMethodPresented();
-      }
-    });
-
-    const tokenizationStartedListener = eventEmitter.addListener('tokenizationStarted', (data) => {
-      console.log("tokenizationStarted");
-
-      if (this.onTokenizationStarted) {
-        this.onTokenizationStarted();
-      }
-    });
-
-    const tokenizationSucceededListener = eventEmitter.addListener('tokenizationSucceeded', (data) => {
-      console.log(`tokenizationSucceeded: ${JSON.stringify(data)}`);
-      const paymentMethodToken = JSON.parse(data["paymentMethodToken"]);
-
-      if (this.onTokenizeSuccess) {
-        this.onTokenizeSuccess(paymentMethodToken);
-      }
-    });
-
-    const resumeListener = eventEmitter.addListener('resume', (data) => {
-      console.log("resume");
-      if (this.onResume && data.resumeToken) {
-        this.onResume(data.resumeToken);
-      }
-    });
-
-    const errorListener = eventEmitter.addListener('error', (data) => {
-      console.log(`error: ${JSON.stringify(data)}`);
-
-      const error: IPrimerError = data["error"];
-      if (this.onFailure && error) {
-        this.onFailure(error);
-      }
+    NativePrimerHeadlessUniversalCheckout.addListener('error', (data) => {
+      console.log('error', data);
+      this.callbacks?.onFailure?.(data.error);
     });
   }
 
-  startHeadlessCheckout(clientToken: string,
-    settings: PrimerSettings,
-    errorCallback: (err: Error) => void,
-    completion: (paymentMethodTypes: IPaymentMethodsTypes) => void) {
-    PrimerHeadlessUniversalCheckout.startWithClientToken(clientToken,
-      JSON.stringify(settings),
-      (err: Error) => {
-        console.error(err);
-        errorCallback(err);
-      },
-      (paymentMethodsArr: string[]) => {
-        const onClientSessionSetupSuccessfullyRequest: IPaymentMethodsTypes = {
-          paymentMethodTypes: paymentMethodsArr
-        }
+  ///////////////////////////////////////////
+  // API
+  ///////////////////////////////////////////
+  startWithClientToken(
+    clientToken: string,
+    settings: PrimerSettings & PrimerHeadlessUniversalCheckoutCallbacks
+  ): Promise<PrimerHeadlessUniversalCheckoutStartResponse> {
+    // Copy callback
+    this.callbacks = {
+      onPreparationStarted: settings.onPreparationStarted,
+      onPaymentMethodPresented: settings.onPaymentMethodPresented,
+      onTokenizeStart: settings.onTokenizeStart,
+      onResumeSuccess: settings.onResumeSuccess,
+      onFailure: settings.onFailure,
+    };
 
-        completion(onClientSessionSetupSuccessfullyRequest);
-      })
+    return NativePrimerHeadlessUniversalCheckout.startWithClientToken(
+      clientToken,
+      settings
+    );
   }
 
   showPaymentMethod(paymentMethod: string) {
-    PrimerHeadlessUniversalCheckout.showPaymentMethod(paymentMethod);
+    return NativePrimerHeadlessUniversalCheckout.showPaymentMethod(
+      paymentMethod
+    );
   }
 
-  resumeWithToken(resumeToken: string) {
-    PrimerHeadlessUniversalCheckout.resumeWithClientToken(resumeToken);
+  resumeWithClientToken(resumeToken: string) {
+    return NativePrimerHeadlessUniversalCheckout.resumeWithClientToken(
+      resumeToken
+    );
   }
-
-  listAvailableAssets(completion: (assets: string[]) => void) {
-    PrimerHeadlessUniversalCheckout.listAvailableAssets((assets: string[]) => {
-      completion(assets);
-    })
-  }
-
-  getAssetFor(paymentMethodType: string,
-    assetType: string,
-    errorCallback: (err: Error) => void,
-    completion: (url: string) => void) {
-    PrimerHeadlessUniversalCheckout.getAssetFor(paymentMethodType,
-      assetType,
-      (err: Error) => {
-        errorCallback(err);
-      },
-      (url: string) => {
-        completion(url);
-      });
-  }
-
 }
+
+const PrimerHeadlessUniversalCheckout = new PrimerHeadlessUniversalCheckoutClass();
+
+export default PrimerHeadlessUniversalCheckout;

--- a/src/headless_checkout/types.ts
+++ b/src/headless_checkout/types.ts
@@ -1,0 +1,18 @@
+export interface PrimerHeadlessUniversalCheckoutStartResponse {
+  paymentMethodTypes: string[];
+}
+
+export interface PrimerError {
+  errorId: string;
+  description: string;
+  recoverySuggestion?: string;
+}
+
+export interface PrimerHeadlessUniversalCheckoutCallbacks {
+  onPreparationStarted?: () => void;
+  onPaymentMethodPresented?: () => void;
+  onTokenizeStart?: () => void;
+  onTokenizeSuccess?: (paymentMethod: any) => void;
+  onResumeSuccess?: (resumeToken: string) => void;
+  onFailure?: (error: PrimerError) => void;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,8 @@
-import { PrimerHUC } from './headless_checkout/PrimerHeadlessUniversalCheckout';
+import PrimerHeadlessUniversalCheckout from './headless_checkout/PrimerHeadlessUniversalCheckout';
 import type { IPrimer } from './models/primer';
 import { PrimerNativeMapping } from './Primer';
 export * from './PrimerInput';
 
 const Primer: IPrimer = PrimerNativeMapping;
 
-export { Primer, PrimerHUC };
+export { Primer, PrimerHeadlessUniversalCheckout as PrimerHUC };


### PR DESCRIPTION
* Create `NativePrimerHeadlessUniversalCheckout` as a raw adapter of the bridge
* `PrimerHeadlessUniversalCheckout` is now an object singleton
* Renamed  `getAssetFor` -> `getAssetForPaymentMethod`
* Renamed `onTokenizationStart` -> `onTokenizeStart`
* Renamed `onResume` -> `onResumeSucceed`

Note: I didn't change anything beside the wrapper. Pretty sure we have to also change the example app :) 