### PR TITLE
[IE-56] Add renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,24 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
-  "bumpVersion": "patch",
-  "regexManagers": [{
-    "fileMatch": ["\\.podspec"],
-    "matchStrings": ["s\\.dependency\\s+\"(?<depName>.+?)\",\\s*\"(?<currentValue>.+?)\""],
-    "datasourceTemplate": "pod"
-  }]
+  "extends": ["config:base", ":disableRateLimiting", "group:all"],
+  "recreateClosed": true,
+  "regexManagers": [
+    {
+      "fileMatch": ["\\.podspec"],
+      "matchStrings": ["s\\.dependency\\s+\"(?<depName>.+?)\",\\s*\"(?<currentValue>.+?)\""],
+      "datasourceTemplate": "pod"
+    }
+  ],
+  "packageRules": [
+    {
+      "packagePatterns": ["*"],
+      "excludePackagePatterns": ["PrimerSDK", "io.primer:android"],
+      "enabled": false
+    }
+  ],
+  "postUpgradeTasks": {
+    "commands": ["npm version patch --no-git-tag-version"],
+    "fileFilters": ["**"],
+    "executionMode": "branch"
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "bumpVersion": "patch",
+  "regexManagers": [{
+    "fileMatch": ["\\.podspec"],
+    "matchStrings": ["s\\.dependency\\s+\"(?<depName>.+?)\",\\s*\"(?<currentValue>.+?)\""],
+    "datasourceTemplate": "pod"
+  }]
+}


### PR DESCRIPTION
I have succesfully tested that Renovate is capable of automating the dependency upgrades as well as version bumps, as described in the relevant slack thread.

This MR implements the renovate.json file, so we can do a live test and see what the team thinks :)

This'll be included in the RFC as well, but for an early peek here's a video of what this config file allows: https://www.loom.com/share/11c1e7d48590436dba54733773803cae