### PR TITLE
[HOT-FIX] Add missing additional information import

### DIFF
--- a/src/Primer.ts
+++ b/src/Primer.ts
@@ -7,6 +7,7 @@ import type { PrimerClientSession } from './models/PrimerClientSession';
 import type { PrimerPaymentMethodTokenData } from './models/PrimerPaymentMethodTokenData';
 import { PrimerError } from './models/PrimerError';
 import type { IPrimer, PrimerErrorHandler, PrimerPaymentCreationHandler, PrimerResumeHandler, PrimerTokenizationHandler } from './models/PrimerInterfaces';
+import type { PrimerCheckoutAdditionalInfo } from './models/PrimerCheckoutAdditionalInfo';
 
 ///////////////////////////////////////////
 // DECISION HANDLERS


### PR DESCRIPTION
Added missing `PrimerCheckoutAdditionalInfo` which was causing Typescript linting errors when building in Jenkins.