### PR TITLE
Added billing address capture bridge

### DIFF
--- a/example/ios/ReactNativeExample/ReactNativeExample.entitlements
+++ b/example/ios/ReactNativeExample/ReactNativeExample.entitlements
@@ -5,7 +5,6 @@
 	<key>com.apple.developer.in-app-payments</key>
 	<array>
 		<string>merchant.checkout.team</string>
-		<string>merchant.dx.team</string>
 	</array>
 </dict>
 </plist>

--- a/example/src/screens/CheckoutScreen.tsx
+++ b/example/src/screens/CheckoutScreen.tsx
@@ -153,6 +153,11 @@ const CheckoutScreen = (props: any) => {
             },
             klarnaOptions: {
                 recurringPaymentDescription: "Recurring payment description"
+            },
+            applePayOptions: {
+              merchantIdentifier: "merchant.checkout.team",
+              merchantName: appPaymentParameters.merchantName,
+              isCaptureBillingAddressEnabled: true
             }
         },
         uiOptions: {
@@ -174,14 +179,6 @@ const CheckoutScreen = (props: any) => {
         onError: onError,
         onDismiss: onDismiss,
     };
-
-    if (appPaymentParameters.merchantName) {
-        //@ts-ignore
-        settings.paymentMethodOptions.applePayOptions = {
-            merchantIdentifier: 'merchant.checkout.team',
-            merchantName: appPaymentParameters.merchantName
-        };
-    }
 
     const onApplePayButtonTapped = async () => {
         try {

--- a/ios/DataModels/PrimerSettingsRN.swift
+++ b/ios/DataModels/PrimerSettingsRN.swift
@@ -31,8 +31,9 @@ extension PrimerSettings {
         var applePayOptions: PrimerApplePayOptions?
         if let rnApplePayOptions = ((settingsJson["paymentMethodOptions"] as? [String: Any])?["applePayOptions"] as? [String: Any]),
            let rnApplePayMerchantIdentifier = rnApplePayOptions["merchantIdentifier"] as? String,
-           let rnApplePayMerchantName = rnApplePayOptions["merchantName"] as? String {
-            applePayOptions = PrimerApplePayOptions(merchantIdentifier: rnApplePayMerchantIdentifier, merchantName: rnApplePayMerchantName)
+           let rnApplePayMerchantName = rnApplePayOptions["merchantName"] as? String,
+           let rnApplePayIsCaptureBillingAddressEnabled = rnApplePayOptions["isCaptureBillingAddressEnabled"] as? Bool {
+            applePayOptions = PrimerApplePayOptions(merchantIdentifier: rnApplePayMerchantIdentifier, merchantName: rnApplePayMerchantName, isCaptureBillingAddressEnabled: rnApplePayIsCaptureBillingAddressEnabled)
         }
         
         var klarnaOptions: PrimerKlarnaOptions?

--- a/src/models/PrimerSettings.ts
+++ b/src/models/PrimerSettings.ts
@@ -74,6 +74,7 @@ interface IPrimerApayaOptions {
 interface IPrimerApplePayOptions {
   merchantIdentifier: string;
   merchantName: string;
+  isCaptureBillingAddressEnabled: boolean;
 }
 
 interface IPrimerCardPaymentOptions {


### PR DESCRIPTION
I'm adding the possibility of passing the `isCaptureBillingAddressEnabled` flag to RN so we can capture the billing address out of an authorized Apple Pay payment.