### PR TITLE
Android SDK version bump with fix di initialization

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -137,5 +137,5 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3"
-  implementation 'io.primer:android:2.13.0'
+  implementation 'io.primer:android:2.13.1'
 }


### PR DESCRIPTION
- Fix DI initialization for Drop-In flow.
- Depends on this releasing https://github.com/primer-io/primer-sdk-android/pull/322 