### PR TITLE
Release 2.14.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -137,5 +137,5 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3"
-  implementation 'io.primer:android:2.13.1'
+  implementation 'io.primer:android:2.14.0'
 }

--- a/android/src/main/java/com/primerioreactnative/datamodels/PrimerErrorRN.kt
+++ b/android/src/main/java/com/primerioreactnative/datamodels/PrimerErrorRN.kt
@@ -14,5 +14,5 @@ enum class ErrorTypeRN(val errorId: String) {
   NativeBridgeFailed("native-bridge"),
   AssetMissing("missing-asset"),
   AssetMismatch("mismatch-asset"),
-  InvalidPaymentMethodType("invalid-payment-method-type")
+  InvalidCardNetwork("invalid-card-network")
 }

--- a/android/src/main/java/com/primerioreactnative/extensions/PrimerPaymentMethodOptionsRN.kt
+++ b/android/src/main/java/com/primerioreactnative/extensions/PrimerPaymentMethodOptionsRN.kt
@@ -5,15 +5,11 @@ import io.primer.android.data.settings.*
 
 fun PrimerPaymentMethodOptionsRN.toPrimerPaymentMethodOptions() = PrimerPaymentMethodOptions(
   androidSettingsRN.redirectScheme,
-  cardPaymentOptions.toPrimerCardPaymentOptions(),
   googlePayOptions.toPrimerGooglePayOptions(),
   klarnaOptions.toPrimerKlarnaOptions(),
   apayaOptions.toPrimerApayaOptions(),
   goCardlessOptions.toPrimerGoCardlessOptions()
 )
-
-fun PrimerCardPaymentOptionsRN.toPrimerCardPaymentOptions() =
-  PrimerCardPaymentOptions(is3DSOnVaultingEnabled)
 
 fun PrimerGooglePayOptionsRN.toPrimerGooglePayOptions() =
   PrimerGooglePayOptions(merchantName, allowedCardNetworks, buttonStyle)

--- a/ios/DataModels/PrimerSettingsRN.swift
+++ b/ios/DataModels/PrimerSettingsRN.swift
@@ -41,11 +41,6 @@ extension PrimerSettings {
             klarnaOptions = PrimerKlarnaOptions(recurringPaymentDescription: rnKlarnaRecurringPaymentDescription)
         }
         
-        var cardPaymentOptions: PrimerCardPaymentOptions?
-        if let rnIs3DSOnVaultingEnabled = ((settingsJson["paymentMethodOptions"] as? [String: Any])?["cardPaymentOptions"] as? [String: Any])?["is3DSOnVaultingEnabled"] as? Bool {
-            cardPaymentOptions = PrimerCardPaymentOptions(is3DSOnVaultingEnabled: rnIs3DSOnVaultingEnabled)
-        }
-        
         var uiOptions: PrimerUIOptions?
         if let rnUIOptions = settingsJson["uiOptions"] as? [String: Any] {
             
@@ -71,8 +66,7 @@ extension PrimerSettings {
         let paymentMethodOptions = PrimerPaymentMethodOptions(
             urlScheme: rnUrlScheme,
             applePayOptions: applePayOptions,
-            klarnaOptions: klarnaOptions,
-            cardPaymentOptions: cardPaymentOptions)
+            klarnaOptions: klarnaOptions)
         
         let settings = PrimerSettings(
             paymentHandling: paymentHandling,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer-io/react-native",
-  "version": "2.14.0",
+  "version": "2.13.2",
   "description": "Primer SDK for RN",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer-io/react-native",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "description": "Primer SDK for RN",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/primer-io-react-native.podspec
+++ b/primer-io-react-native.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "PrimerSDK", "2.13.1"
+  s.dependency "PrimerSDK", "2.14.0"
 end

--- a/src/headless_checkout/RNPrimerHeadlessUniversalCheckout.ts
+++ b/src/headless_checkout/RNPrimerHeadlessUniversalCheckout.ts
@@ -86,7 +86,7 @@ const RNPrimerHeadlessUniversalCheckout = {
   ): Promise<string> => {
     return new Promise((resolve, reject) => {
       try {
-        PrimerHeadlessUniversalCheckout.getAssetForPaymentMethodType(
+        PrimerHeadlessUniversalCheckout.getAssetForCardNetwork(
           cardNetwork,
           assetType,
           (err: Error) => {

--- a/src/models/PrimerSettings.ts
+++ b/src/models/PrimerSettings.ts
@@ -61,7 +61,12 @@ interface IPrimerPaymentMethodOptions {
   },
   apayaOptions?: IPrimerApayaOptions;
   applePayOptions?: IPrimerApplePayOptions;
+
+  /**
+  * @obsoleted The IPrimerCardPaymentOptions is obsoleted on v.2.14.0
+  */
   cardPaymentOptions?: IPrimerCardPaymentOptions;
+  
   goCardlessOptions?: IPrimerGoCardlessOptions;
   googlePayOptions?: IPrimerGooglePayOptions;
   klarnaOptions?: IPrimerKlarnaOptions;


### PR DESCRIPTION
# What this PR does

- Obsoleting 3DS Vaulting
- iOS: Fixing `await HeadlessUniversalCheckoutRawDataManager.setRawData(cardData) never results in the onValidation callback`
- iOS: Fixing `on PAYMENT_CARD only the fields: CARD FIELDS: ["CARD_NUMBER", "EXPIRY_DATE", "CVV"] (not name on card) are returned` 
- Android: Fixed card network assets fetching