### PR TITLE
Release 2.16.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -137,5 +137,5 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3"
-  implementation 'io.primer:android:2.16.0'
+  implementation 'io.primer:android:2.16.2'
 }

--- a/example_0_70_6/ios/Podfile
+++ b/example_0_70_6/ios/Podfile
@@ -27,7 +27,7 @@ target 'example_0_70_6' do
   )
   
   pod 'primer-io-react-native', :path => '../..'
-  pod 'PrimerSDK', :git => 'https://github.com/primer-io/primer-sdk-ios.git', :branch => 'release/2.16.0'
+#  pod 'PrimerSDK', :git => 'https://github.com/primer-io/primer-sdk-ios.git', :branch => 'release/2.16.0'
   pod 'Primer3DS'
   pod 'PrimerIPay88SDK'
   pod 'PrimerKlarnaSDK'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer-io/react-native",
-  "version": "2.16.0",
+  "version": "2.16.2",
   "description": "Primer SDK for RN",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/primer-io-react-native.podspec
+++ b/primer-io-react-native.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "PrimerSDK", "2.16.0"
+  s.dependency "PrimerSDK", "2.16.2"
 end


### PR DESCRIPTION
Release 2.16.2

**iOS**
- Fix Xendit OVO redirection

**Android**
- Allow 0 amounts
- Allow 3DS for Google Pay
- Fixed `showPaymentMethod` for cards and aligned with iOS