### PR TITLE
👊 v.2.16.5

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -137,5 +137,5 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3"
-  implementation 'io.primer:android:2.16.4'
+  implementation 'io.primer:android:2.16.6'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer-io/react-native",
-  "version": "2.16.4",
+  "version": "2.16.5",
   "description": "Primer SDK for RN",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/primer-io-react-native.podspec
+++ b/primer-io-react-native.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "PrimerSDK", "2.16.4"
+  s.dependency "PrimerSDK", "2.16.5"
 end


### PR DESCRIPTION
iOS: 
- Fix an issue that prevented 3DS from working with some card networks (AMEX, Maestro, Discover, and JCB)
- Fix an issue that prevented 3DS from working when the billing address is set or updated after the SDK is initialized with a client session

Android:
- Improved internal analytics for 3DS events
- Improved internal analytics for headless integration
- Improved handling of payment cancellations for Atome
- Fixed bug that caused some of the expiry dates not being validated correctly