### PR TITLE
Map RN theme colors to android theme model

### DIFF
--- a/packages/sdk/android/build.gradle
+++ b/packages/sdk/android/build.gradle
@@ -29,6 +29,7 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
+  group 'io.primer'
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
@@ -136,5 +137,5 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3"
-  implementation 'io.primer:android:2.27.0'
+  implementation 'io.primer:android:2.27.3'
 }

--- a/packages/sdk/android/src/main/java/com/primerioreactnative/datamodels/PrimerSettingsRN.kt
+++ b/packages/sdk/android/src/main/java/com/primerioreactnative/datamodels/PrimerSettingsRN.kt
@@ -7,6 +7,7 @@ import com.primerioreactnative.extensions.toPrimerUIOptions
 import io.primer.android.data.settings.GooglePayButtonStyle
 import io.primer.android.data.settings.PrimerPaymentHandling
 import io.primer.android.data.settings.PrimerSettings
+import io.primer.android.ui.settings.PrimerTheme
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -44,7 +45,68 @@ data class PrimerUIOptionsRN(
   var isInitScreenEnabled: Boolean = true,
   var isSuccessScreenEnabled: Boolean = true,
   var isErrorScreenEnabled: Boolean = true,
+  var theme: PrimerThemeRN = PrimerThemeRN()
 )
+
+@Serializable
+data class PrimerThemeRN(
+  val colors: ColorThemeRN? = null,
+  val darkModeColors: ColorThemeRN? = null
+) {
+  fun toPrimerTheme(): PrimerTheme {
+    val isDarkMode = false
+
+    return PrimerTheme.buildRN(
+      isDarkMode = isDarkMode,
+      mainColor = when {
+        isDarkMode -> darkModeColors?.mainColor?.toHexStrColor()
+        else -> colors?.mainColor?.toHexStrColor()
+      },
+      backgroundColor = when {
+        isDarkMode -> darkModeColors?.background?.toHexStrColor()
+        else -> colors?.background?.toHexStrColor()
+      },
+      disabledColor = when {
+        isDarkMode -> darkModeColors?.disabled?.toHexStrColor()
+        else -> colors?.disabled?.toHexStrColor()
+      },
+      textColor = when {
+        isDarkMode -> darkModeColors?.text?.toHexStrColor()
+        else -> colors?.text?.toHexStrColor()
+      },
+      bordersColor = when {
+        isDarkMode -> darkModeColors?.borders?.toHexStrColor()
+        else -> colors?.borders?.toHexStrColor()
+      },
+      errorColor = when {
+        isDarkMode -> darkModeColors?.error?.toHexStrColor()
+        else -> colors?.error?.toHexStrColor()
+      }
+    )
+  }
+}
+
+@Serializable
+data class ColorThemeRN(
+  val mainColor: ColorRN? = null,
+  val contrastingColor: ColorRN? = null,
+  val background: ColorRN? = null,
+  val text: ColorRN? = null,
+  val contrastingText: ColorRN? = null,
+  val borders: ColorRN? = null, // or main color
+  val disabled: ColorRN? = null,
+  val error: ColorRN? = null,
+)
+
+@Serializable
+data class ColorRN(
+  val alpha: Int = 0,
+  val red: Int = 0,
+  val green: Int = 0,
+  val blue: Int = 0
+) {
+  fun toHexStrColor() = String.format("#%02X%02X%02X%02X", alpha, red, green, blue)
+}
 
 @Serializable
 data class PrimerDebugOptionsRN(val is3DSSanityCheckEnabled: Boolean = true)

--- a/packages/sdk/android/src/main/java/com/primerioreactnative/datamodels/PrimerSettingsRN.kt
+++ b/packages/sdk/android/src/main/java/com/primerioreactnative/datamodels/PrimerSettingsRN.kt
@@ -56,7 +56,7 @@ data class PrimerThemeRN(
   fun toPrimerTheme(): PrimerTheme {
     val isDarkMode = false
 
-    return PrimerTheme.buildRN(
+    return PrimerTheme.buildWithDynamicValues(
       isDarkMode = isDarkMode,
       mainColor = when {
         isDarkMode -> darkModeColors?.mainColor?.toHexStrColor()

--- a/packages/sdk/android/src/main/java/com/primerioreactnative/extensions/PrimerUIOptionsRN.kt
+++ b/packages/sdk/android/src/main/java/com/primerioreactnative/extensions/PrimerUIOptionsRN.kt
@@ -1,7 +1,6 @@
 package com.primerioreactnative.extensions
 
 import com.primerioreactnative.datamodels.PrimerUIOptionsRN
-import io.primer.android.ui.settings.PrimerTheme
 import io.primer.android.ui.settings.PrimerUIOptions
 
 internal fun PrimerUIOptionsRN.toPrimerUIOptions() =
@@ -9,5 +8,5 @@ internal fun PrimerUIOptionsRN.toPrimerUIOptions() =
     isInitScreenEnabled,
     isSuccessScreenEnabled,
     isErrorScreenEnabled,
-    PrimerTheme.build()
+    theme.toPrimerTheme()
   )


### PR DESCRIPTION
Added logic that maps the RN theme to primer sdk theme model. 
In order for this to work, the primer sdk version needs to be at least 2.27.3 so that it contains the required changes is needed (the one where PrimerTheme..buildWithDynamicValues() method exists)
