### PR TITLE
Fix error when Klarna is not included in Pods

### DIFF
--- a/packages/sdk/ios/Sources/Headless Universal Checkout/Managers/Klarna/PrimerRNHeadlessUniversalCheckoutKlarnaComponent.swift
+++ b/packages/sdk/ios/Sources/Headless Universal Checkout/Managers/Klarna/PrimerRNHeadlessUniversalCheckoutKlarnaComponent.swift
@@ -12,7 +12,9 @@ import PrimerSDK
 @objc(RNTPrimerHeadlessUniversalCheckoutKlarnaComponent)
 class RNTPrimerHeadlessUniversalCheckoutKlarnaComponent: RCTEventEmitter {
     
+#if canImport(PrimerKlarnaSDK)
     private var klarnaManager: PrimerHeadlessUniversalCheckout.KlarnaManager = PrimerHeadlessUniversalCheckout.KlarnaManager()
+#endif
     var klarnaComponent: (any KlarnaComponent)?
     var clientToken: String?
     
@@ -46,12 +48,21 @@ class RNTPrimerHeadlessUniversalCheckoutKlarnaComponent: RCTEventEmitter {
                     recoverySuggestion: "'intent' can be 'CHECKOUT' or 'VAULT'.")
                 throw err
             }
-            
+#if canImport(PrimerKlarnaSDK)
             klarnaComponent = try klarnaManager.provideKlarnaComponent(with: sessionIntent)
             klarnaComponent?.stepDelegate = self
             klarnaComponent?.errorDelegate = self
             klarnaComponent?.validationDelegate = self
-            
+#else
+            let err = RNTNativeError(
+                errorId: "native-ios",
+                errorDescription: "PrimerKlarnaSDK missing",
+                recoverySuggestion: "Check if PrimerKlarnaSDK is included in your Podfile")
+
+            throw err
+#endif
+
+
             resolver(nil)
         } catch {
             rejecter(error.rnError["errorId"]!, error.rnError["description"], error)


### PR DESCRIPTION
Klarna classes were not guarded behind `#if canImport(PrimerKlarnaSDK)` so the error was present if there were no Klarna in Pods.