### PR TITLE
feat: capture shipping address from Apple Pay

### DIFF
--- a/packages/example/src/screens/CheckoutScreen.tsx
+++ b/packages/example/src/screens/CheckoutScreen.tsx
@@ -240,6 +240,7 @@ const CheckoutScreen = (props: any) => {
                 merchantIdentifier: "merchant.checkout.team",
                 merchantName: appPaymentParameters.merchantName || "Merchant name",
                 isCaptureBillingAddressEnabled: true,
+                isCaptureShippingAddressEnabled: true,
                 showApplePayForUnsupportedDevice: true,
                 checkProvidedNetworks: false
             },

--- a/packages/sdk/ios/Sources/DataModels/PrimerSettings+Extensions.swift
+++ b/packages/sdk/ios/Sources/DataModels/PrimerSettings+Extensions.swift
@@ -38,6 +38,7 @@ extension PrimerSettings {
                let rnApplePayMerchantName = rnApplePayOptions["merchantName"] as? String
             {
                 let rnApplePayIsCaptureBillingAddressEnabled = (rnApplePayOptions["isCaptureBillingAddressEnabled"] as? Bool) ?? false
+                let rnApplePayIsCaptureShippingAddressEnabled = (rnApplePayOptions["isCaptureShippingAddressEnabled"] as? Bool) ?? false
                 let rnApplePayShowApplePayForUnsupportedDevice = (rnApplePayOptions["showApplePayForUnsupportedDevice"] as? Bool) ?? true
                 let rnApplePayCheckProvidedNetworks = (rnApplePayOptions["checkProvidedNetworks"] as? Bool) ?? true
                 
@@ -45,6 +46,7 @@ extension PrimerSettings {
                     merchantIdentifier: rnApplePayMerchantIdentifier,
                     merchantName: rnApplePayMerchantName,
                     isCaptureBillingAddressEnabled: rnApplePayIsCaptureBillingAddressEnabled,
+                    isCaptureShippingAddressEnabled: rnApplePayIsCaptureShippingAddressEnabled,
                     showApplePayForUnsupportedDevice: rnApplePayShowApplePayForUnsupportedDevice,
                     checkProvidedNetworks: rnApplePayCheckProvidedNetworks)
             }

--- a/packages/sdk/src/models/PrimerSettings.ts
+++ b/packages/sdk/src/models/PrimerSettings.ts
@@ -94,6 +94,7 @@ interface IPrimerApplePayOptions {
   merchantIdentifier: string;
   merchantName: string;
   isCaptureBillingAddressEnabled?: boolean;
+  isCaptureShippingAddressEnabled?: boolean;
   showApplePayForUnsupportedDevice?: boolean;
   checkProvidedNetworks?: boolean;
 }


### PR DESCRIPTION
This change enables the RN SDK to request a `shippingAddress` when making an Apple Pay payment.

This PR first requires a new version of the iOS SDK after the merge of: https://github.com/primer-io/primer-sdk-ios/pull/936