### PR TITLE
feat: handle Apple Pay shipping methods

### DIFF
--- a/packages/sdk/ios/Sources/DataModels/PrimerSettings+Extensions.swift
+++ b/packages/sdk/ios/Sources/DataModels/PrimerSettings+Extensions.swift
@@ -40,13 +40,15 @@ extension PrimerSettings {
                 let rnApplePayIsCaptureBillingAddressEnabled = (rnApplePayOptions["isCaptureBillingAddressEnabled"] as? Bool) ?? false
                 let rnApplePayShowApplePayForUnsupportedDevice = (rnApplePayOptions["showApplePayForUnsupportedDevice"] as? Bool) ?? true
                 let rnApplePayCheckProvidedNetworks = (rnApplePayOptions["checkProvidedNetworks"] as? Bool) ?? true
+                let rnApplePayShippingMethods = mapToPKShippingMethods(rnApplePayOptions["shippingMethods"] as? [[String : Any]])
                 
                 applePayOptions = PrimerApplePayOptions(
                     merchantIdentifier: rnApplePayMerchantIdentifier,
                     merchantName: rnApplePayMerchantName,
                     isCaptureBillingAddressEnabled: rnApplePayIsCaptureBillingAddressEnabled,
                     showApplePayForUnsupportedDevice: rnApplePayShowApplePayForUnsupportedDevice,
-                    checkProvidedNetworks: rnApplePayCheckProvidedNetworks)
+                    checkProvidedNetworks: rnApplePayCheckProvidedNetworks,
+                    shippingMethods: rnApplePayShippingMethods)
             }
 
             var klarnaOptions: PrimerKlarnaOptions?
@@ -94,5 +96,39 @@ extension PrimerSettings {
                 uiOptions: uiOptions,
                 debugOptions: debugOptions)
         }
+    }
+
+    func mapToPKShippingMethods(items: [[String: Any]]?) -> [PKShippingMethod] {
+        var shippingMethods: [PKShippingMethod] = []
+        if let items = items {
+            for item in items {
+                let label = item["label"] as? String ?? ""
+                let amount = NSDecimalNumber(string: item["amount"] as? String ?? "")
+                let identifier = item["identifier"] as? String ?? ""
+                let type = (item["type"] as? String ?? "") == "pending" ? PKPaymentSummaryItemType.pending : PKPaymentSummaryItemType.final
+                let detail = item["detail"] as? String ?? ""
+                let shippingMethod = PKShippingMethod(
+                    label: label,
+                    amount: amount,
+                    identifier: identifier,
+                    type: type,
+                    detail: detail
+                )
+                if #available(iOS 15.0, *) {
+                    if let startDate = item["startDate"] as? Double, let endDate = item["endDate"] as? Double {
+                        let startDate = Date(timeIntervalSince1970: startDate)
+                        let endDate = Date(timeIntervalSince1970: endDate)
+                        shippingMethod.dateComponentsRange = PKDateComponentsRange(
+                            start: Calendar.current.dateComponents([.calendar, .year, .month, .day],
+                                                                from: startDate),
+                            end: Calendar.current.dateComponents([.calendar, .year, .month, .day],
+                                                                from: endDate)
+                        )
+                    }
+                }
+                shippingMethods.append(shippingMethod)
+            }
+        }
+        return shippingMethods
     }
 }

--- a/packages/sdk/src/models/PrimerSettings.ts
+++ b/packages/sdk/src/models/PrimerSettings.ts
@@ -96,6 +96,24 @@ interface IPrimerApplePayOptions {
   isCaptureBillingAddressEnabled?: boolean;
   showApplePayForUnsupportedDevice?: boolean;
   checkProvidedNetworks?: boolean;
+  shippingMethods?: {
+    /** A short, localized description. */
+    label: string;
+    /** The summary item’s amount. */
+    amount: string;
+    /** A unique identifier for the shipping method. */
+    identifier: string;
+    /** The summary item’s type that indicates whether the amount is final.
+     * @default 'final'
+     */
+    type?: 'pending' | 'final';
+    /** A user-readable description of the shipping method. */
+    detail?: string;
+    /** The unix timestamp of the start date of the expected range of delivery or shipping dates for a package, or the time range when an item is available for pickup. */
+    startDate?: number;
+    /** The unix timestamp of the end date of the expected range of delivery or shipping dates for a package, or the time range when an item is available for pickup. */
+    endDate?: number;
+  }[];
 }
 
 interface IPrimerCardPaymentOptions {


### PR DESCRIPTION
This change enables the RN SDK to add `shippingMethods` when making an Apple Pay payment.

This PR first requires a new version of the iOS SDK after the merge of: https://github.com/primer-io/primer-sdk-ios/pull/938