### PR TITLE
fix: Default to false for clientSessionCachingEnabled

### DIFF
--- a/packages/sdk/ios/Sources/DataModels/PrimerSettings+Extensions.swift
+++ b/packages/sdk/ios/Sources/DataModels/PrimerSettings+Extensions.swift
@@ -98,7 +98,7 @@ extension PrimerSettings {
                 paymentMethodOptions: paymentMethodOptions,
                 uiOptions: uiOptions,
                 debugOptions: debugOptions,
-                clientSessionCachingEnabled: clientSessionCachingEnabled)
+                clientSessionCachingEnabled: clientSessionCachingEnabled ?? false)
         }
     }
 }


### PR DESCRIPTION
This fixes a build issue in the latest release.

Appetize build should pass in this PR, indicating the fix is goof