### PR TITLE
fix(android): type mismatch on `PrimerErrorRN`

### DIFF
--- a/packages/sdk/android/src/main/java/com/primerioreactnative/datamodels/PrimerErrorRN.kt
+++ b/packages/sdk/android/src/main/java/com/primerioreactnative/datamodels/PrimerErrorRN.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class PrimerErrorRN(
-  val errorId: String? = null,
+  val errorId: String,
   val errorCode: String? = null,
   val description: String? = null,
   val diagnosticsId: String? = null,


### PR DESCRIPTION
This fix Android build on RN 0.76+ otherwise an error is thrown during build: 

`Type mismatch: inferred type is String? but String was expected`