### PR TITLE
feat: add design token system with useTheme hook (ACC-6508)

### DIFF
--- a/src/Components/PrimerCheckoutProvider.tsx
+++ b/src/Components/PrimerCheckoutProvider.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { PrimerCheckoutContext } from './internal/PrimerCheckoutContext';
+import { ThemeContext } from './internal/theme/ThemeContext';
+import { defaultDarkTokens, defaultLightTokens } from './internal/theme/tokens';
+import { mergeTokens } from './internal/theme/merge';
 import { PrimerHeadlessUniversalCheckout } from '../HeadlessUniversalCheckout/PrimerHeadlessUniversalCheckout';
 import type { PrimerSettings } from '../models/PrimerSettings';
 import type {
@@ -17,6 +20,7 @@ const initialState: PrimerCheckoutContextValue = {
 export function PrimerCheckoutProvider({
   clientToken,
   settings,
+  theme,
   onCheckoutComplete,
   onTokenizationSuccess,
   onBeforePaymentCreate,
@@ -24,6 +28,9 @@ export function PrimerCheckoutProvider({
   children,
 }: PrimerCheckoutProviderProps) {
   const [state, setState] = useState<PrimerCheckoutContextValue>(initialState);
+
+  const lightTokens = useMemo(() => mergeTokens(defaultLightTokens, theme?.light), []); // intentionally empty: theme is mount-time immutable
+  const darkTokens = useMemo(() => mergeTokens(defaultDarkTokens, theme?.dark), []); // intentionally empty: theme is mount-time immutable
 
   // Keep refs for all callbacks and settings so the useEffect doesn't depend on them
   const settingsRef = useRef(settings);
@@ -155,5 +162,9 @@ export function PrimerCheckoutProvider({
     };
   }, [clientToken]);
 
-  return <PrimerCheckoutContext.Provider value={state}>{children}</PrimerCheckoutContext.Provider>;
+  return (
+    <ThemeContext.Provider value={{ lightTokens, darkTokens }}>
+      <PrimerCheckoutContext.Provider value={state}>{children}</PrimerCheckoutContext.Provider>
+    </ThemeContext.Provider>
+  );
 }

--- a/src/Components/PrimerCheckoutProvider.tsx
+++ b/src/Components/PrimerCheckoutProvider.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { PrimerCheckoutContext } from './internal/PrimerCheckoutContext';
 import { ThemeContext } from './internal/theme/ThemeContext';
 import { defaultDarkTokens, defaultLightTokens } from './internal/theme/tokens';

--- a/src/Components/PrimerCheckoutProvider.tsx
+++ b/src/Components/PrimerCheckoutProvider.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { PrimerCheckoutContext } from './internal/PrimerCheckoutContext';
 import { ThemeContext } from './internal/theme/ThemeContext';
 import { defaultDarkTokens, defaultLightTokens } from './internal/theme/tokens';
@@ -29,8 +29,8 @@ export function PrimerCheckoutProvider({
 }: PrimerCheckoutProviderProps) {
   const [state, setState] = useState<PrimerCheckoutContextValue>(initialState);
 
-  const lightTokens = useMemo(() => mergeTokens(defaultLightTokens, theme?.light), []); // intentionally empty: theme is mount-time immutable
-  const darkTokens = useMemo(() => mergeTokens(defaultDarkTokens, theme?.dark), []); // intentionally empty: theme is mount-time immutable
+  const [lightTokens] = useState(() => mergeTokens(defaultLightTokens, theme?.light));
+  const [darkTokens] = useState(() => mergeTokens(defaultDarkTokens, theme?.dark));
 
   // Keep refs for all callbacks and settings so the useEffect doesn't depend on them
   const settingsRef = useRef(settings);

--- a/src/Components/internal/theme/ThemeContext.ts
+++ b/src/Components/internal/theme/ThemeContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+import type { PrimerTokens } from './types';
+
+interface ThemeContextValue {
+  lightTokens: PrimerTokens;
+  darkTokens: PrimerTokens;
+}
+
+export const ThemeContext = createContext<ThemeContextValue | null>(null);

--- a/src/Components/internal/theme/__tests__/merge.test.ts
+++ b/src/Components/internal/theme/__tests__/merge.test.ts
@@ -1,0 +1,68 @@
+import { mergeTokens } from '../merge';
+import { defaultLightTokens } from '../tokens';
+import type { PrimerTypographyStyle } from '../types';
+
+const base = defaultLightTokens;
+
+describe('mergeTokens', () => {
+  it('returns base unchanged (referential equality) when override is undefined', () => {
+    expect(mergeTokens(base, undefined)).toBe(base);
+  });
+
+  it('returns base unchanged (referential equality) when override is null', () => {
+    expect(mergeTokens(base, null as any)).toBe(base);
+  });
+
+  it('applies partial colors override — only specified fields change', () => {
+    const result = mergeTokens(base, { colors: { primary: '#ff0000' } });
+    expect(result.colors.primary).toBe('#ff0000');
+    expect(result.colors.background).toBe(base.colors.background);
+    expect(result.colors.textPrimary).toBe(base.colors.textPrimary);
+  });
+
+  it('falls back to base value when override color field is null', () => {
+    const result = mergeTokens(base, { colors: { primary: null as any } });
+    expect(result.colors.primary).toBe(base.colors.primary);
+  });
+
+  it('applies partial spacing override — only specified fields change', () => {
+    const result = mergeTokens(base, { spacing: { large: 24 } });
+    expect(result.spacing.large).toBe(24);
+    expect(result.spacing.small).toBe(base.spacing.small);
+    expect(result.spacing.medium).toBe(base.spacing.medium);
+  });
+
+  it('replaces entire typography style when titleXLarge is overridden', () => {
+    const customStyle: PrimerTypographyStyle = {
+      fontSize: 28,
+      fontWeight: '700',
+      lineHeight: 36,
+      letterSpacing: -1,
+      fontFamily: 'Roboto',
+    };
+    const result = mergeTokens(base, { typography: { titleXLarge: customStyle } });
+    expect(result.typography.titleXLarge).toEqual(customStyle);
+    expect(result.typography.titleLarge).toBe(base.typography.titleLarge);
+  });
+
+  it('applies overrides across all five categories simultaneously', () => {
+    const result = mergeTokens(base, {
+      colors: { primary: '#aabbcc' },
+      spacing: { large: 20 },
+      typography: { fontFamily: 'Roboto' },
+      radii: { medium: 10 },
+      borders: { strong: 3 },
+    });
+
+    expect(result.colors.primary).toBe('#aabbcc');
+    expect(result.colors.background).toBe(base.colors.background);
+    expect(result.spacing.large).toBe(20);
+    expect(result.spacing.small).toBe(base.spacing.small);
+    expect(result.typography.fontFamily).toBe('Roboto');
+    expect(result.typography.titleXLarge).toBe(base.typography.titleXLarge);
+    expect(result.radii.medium).toBe(10);
+    expect(result.radii.small).toBe(base.radii.small);
+    expect(result.borders.strong).toBe(3);
+    expect(result.borders.default).toBe(base.borders.default);
+  });
+});

--- a/src/Components/internal/theme/__tests__/useTheme.test.ts
+++ b/src/Components/internal/theme/__tests__/useTheme.test.ts
@@ -1,0 +1,131 @@
+import { createElement, type ReactNode } from 'react';
+// @ts-expect-error -- react-test-renderer has no types for React 19
+import { act, create } from 'react-test-renderer';
+import { ThemeContext } from '../ThemeContext';
+import { defaultDarkTokens, defaultLightTokens } from '../tokens';
+import { useTheme } from '../useTheme';
+import type { PrimerTokens } from '../types';
+
+let mockColorScheme: 'light' | 'dark' | null = 'light';
+
+jest.mock('react-native', () => ({
+  useColorScheme: () => mockColorScheme,
+}));
+
+function renderHook<T>(hook: () => T, Wrapper?: (props: { children: ReactNode }) => ReactNode | null) {
+  const result = { current: null as unknown as T };
+
+  function HookComponent() {
+    result.current = hook();
+    return null;
+  }
+
+  act(() => {
+    create(Wrapper ? createElement(Wrapper, { children: createElement(HookComponent) }) : createElement(HookComponent));
+  });
+
+  return { result };
+}
+
+describe('useTheme', () => {
+  beforeEach(() => {
+    mockColorScheme = 'light';
+  });
+
+  describe('outside provider', () => {
+    it('returns defaultLightTokens in light mode', () => {
+      mockColorScheme = 'light';
+      const { result } = renderHook(() => useTheme());
+      expect(result.current).toBe(defaultLightTokens);
+    });
+
+    it('returns defaultDarkTokens in dark mode', () => {
+      mockColorScheme = 'dark';
+      const { result } = renderHook(() => useTheme());
+      expect(result.current).toBe(defaultDarkTokens);
+    });
+
+    it('returns defaultLightTokens when colorScheme is null', () => {
+      mockColorScheme = null;
+      const { result } = renderHook(() => useTheme());
+      expect(result.current).toBe(defaultLightTokens);
+    });
+  });
+
+  describe('inside provider with no theme override', () => {
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(ThemeContext.Provider, {
+        value: { lightTokens: defaultLightTokens, darkTokens: defaultDarkTokens },
+        children,
+      });
+    }
+
+    it('returns defaultLightTokens in light mode', () => {
+      mockColorScheme = 'light';
+      const { result } = renderHook(() => useTheme(), Wrapper);
+      expect(result.current).toBe(defaultLightTokens);
+    });
+
+    it('returns defaultDarkTokens in dark mode', () => {
+      mockColorScheme = 'dark';
+      const { result } = renderHook(() => useTheme(), Wrapper);
+      expect(result.current).toBe(defaultDarkTokens);
+    });
+  });
+
+  describe('inside provider with light override', () => {
+    const customLightTokens: PrimerTokens = {
+      ...defaultLightTokens,
+      colors: { ...defaultLightTokens.colors, primary: '#ff6b35' },
+    };
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(ThemeContext.Provider, {
+        value: { lightTokens: customLightTokens, darkTokens: defaultDarkTokens },
+        children,
+      });
+    }
+
+    it('applies light override in light mode', () => {
+      mockColorScheme = 'light';
+      const { result } = renderHook(() => useTheme(), Wrapper);
+      expect(result.current.colors.primary).toBe('#ff6b35');
+    });
+
+    it('does not apply light override in dark mode', () => {
+      mockColorScheme = 'dark';
+      const { result } = renderHook(() => useTheme(), Wrapper);
+      expect(result.current.colors.primary).toBe(defaultDarkTokens.colors.primary);
+    });
+  });
+
+  describe('inside provider with both mode overrides', () => {
+    const customLightTokens: PrimerTokens = {
+      ...defaultLightTokens,
+      colors: { ...defaultLightTokens.colors, primary: '#ff6b35' },
+    };
+    const customDarkTokens: PrimerTokens = {
+      ...defaultDarkTokens,
+      colors: { ...defaultDarkTokens.colors, primary: '#ff8c5a' },
+    };
+
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(ThemeContext.Provider, {
+        value: { lightTokens: customLightTokens, darkTokens: customDarkTokens },
+        children,
+      });
+    }
+
+    it('returns light override in light mode', () => {
+      mockColorScheme = 'light';
+      const { result } = renderHook(() => useTheme(), Wrapper);
+      expect(result.current.colors.primary).toBe('#ff6b35');
+    });
+
+    it('returns dark override in dark mode', () => {
+      mockColorScheme = 'dark';
+      const { result } = renderHook(() => useTheme(), Wrapper);
+      expect(result.current.colors.primary).toBe('#ff8c5a');
+    });
+  });
+});

--- a/src/Components/internal/theme/index.ts
+++ b/src/Components/internal/theme/index.ts
@@ -1,0 +1,12 @@
+export { useTheme } from './useTheme';
+export type {
+  PrimerTokens,
+  PrimerColorTokens,
+  PrimerSpacingTokens,
+  PrimerTypographyTokens,
+  PrimerTypographyStyle,
+  PrimerRadiusTokens,
+  PrimerBorderTokens,
+  PrimerThemeOverride,
+} from './types';
+// NOTE: ThemeContext is intentionally NOT exported — internal to the theme module only

--- a/src/Components/internal/theme/merge.ts
+++ b/src/Components/internal/theme/merge.ts
@@ -1,0 +1,27 @@
+import type { PrimerTokens, PrimerThemeOverride } from './types';
+
+type ModeOverride = PrimerThemeOverride['light'];
+
+function stripNullish<T extends object>(obj: Partial<T>): Partial<T> {
+  const result: Partial<T> = {};
+  for (const key in obj) {
+    if (obj[key] != null) {
+      result[key] = obj[key];
+    }
+  }
+  return result;
+}
+
+export function mergeTokens(base: PrimerTokens, override: ModeOverride): PrimerTokens {
+  if (override == null) {
+    return base;
+  }
+
+  return {
+    colors: override.colors ? { ...base.colors, ...stripNullish(override.colors) } : base.colors,
+    spacing: override.spacing ? { ...base.spacing, ...stripNullish(override.spacing) } : base.spacing,
+    typography: override.typography ? { ...base.typography, ...stripNullish(override.typography) } : base.typography,
+    radii: override.radii ? { ...base.radii, ...stripNullish(override.radii) } : base.radii,
+    borders: override.borders ? { ...base.borders, ...stripNullish(override.borders) } : base.borders,
+  };
+}

--- a/src/Components/internal/theme/tokens/dark.ts
+++ b/src/Components/internal/theme/tokens/dark.ts
@@ -1,0 +1,89 @@
+import type { PrimerTokens } from '../types';
+
+// Values derived from iOS DesignTokensDark.swift (Style Dictionary generated, dark theme).
+// Source: /Users/onurvar/Projects/primer-sdk-ios/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensDark.swift
+// Spacing, typography, radii, and borders are mode-independent and match light defaults.
+export const defaultDarkTokens: PrimerTokens = {
+  colors: {
+    primary: '#2f98ff', // primerColorBrand — unchanged in dark (0.184, 0.596, 1.0)
+    background: '#171619', // dark primerColorGray000 (0.090, 0.086, 0.098)
+    surface: '#292929', // dark primerColorGray100 (0.161, 0.161, 0.161)
+    overlay: 'rgba(0,0,0,0.7)',
+    textPrimary: '#efefef', // dark primerColorGray900 (0.937, 0.937, 0.937)
+    textSecondary: '#c7c7c7', // dark primerColorGray600 (0.780, 0.780, 0.780)
+    textPlaceholder: '#767577', // dark primerColorGray500 (0.463, 0.459, 0.467)
+    textDisabled: '#858585', // dark primerColorGray400 (0.522, 0.522, 0.522)
+    textNegative: '#f6bfbf', // dark primerColorRed900 (0.965, 0.749, 0.749)
+    textLink: '#4aaeff', // dark primerColorBlue900 (0.290, 0.682, 1.0)
+    border: '#424242', // dark primerColorGray200 (0.259, 0.259, 0.259)
+    borderFocused: '#2f98ff', // dark primerColorBrand — unchanged
+    borderError: '#e46d70', // dark primerColorRed500 (0.894, 0.427, 0.439)
+    borderDisabled: '#292929', // dark primerColorGray100 (0.161, 0.161, 0.161)
+    iconPrimary: '#efefef', // dark primerColorGray900
+    iconDisabled: '#858585', // dark primerColorGray400
+    iconNegative: '#e46d70', // dark primerColorRed500
+    iconPositive: '#27b17d', // dark primerColorGreen500 (0.153, 0.694, 0.490)
+    error: '#e46d70', // dark primerColorRed500
+    success: '#27b17d', // dark primerColorGreen500
+  },
+  spacing: {
+    xxsmall: 2,
+    xsmall: 4,
+    small: 8,
+    medium: 12,
+    large: 16,
+    xlarge: 20,
+    xxlarge: 24,
+    xxxlarge: 32,
+  },
+  typography: {
+    fontFamily: 'Inter',
+    titleXLarge: {
+      fontSize: 24,
+      fontWeight: '600',
+      lineHeight: 32,
+      letterSpacing: -0.6,
+      fontFamily: 'Inter',
+    },
+    titleLarge: {
+      fontSize: 16,
+      fontWeight: '600',
+      lineHeight: 20,
+      letterSpacing: -0.2,
+      fontFamily: 'Inter',
+    },
+    bodyLarge: {
+      fontSize: 16,
+      fontWeight: '400',
+      lineHeight: 20,
+      letterSpacing: -0.2,
+      fontFamily: 'Inter',
+    },
+    bodyMedium: {
+      fontSize: 14,
+      fontWeight: '400',
+      lineHeight: 20,
+      letterSpacing: 0,
+      fontFamily: 'Inter',
+    },
+    bodySmall: {
+      fontSize: 12,
+      fontWeight: '400',
+      lineHeight: 16,
+      letterSpacing: 0,
+      fontFamily: 'Inter',
+    },
+  },
+  radii: {
+    none: 0,
+    xsmall: 2,
+    small: 4,
+    medium: 8,
+    large: 12,
+  },
+  borders: {
+    default: 1,
+    input: 1,
+    strong: 2,
+  },
+};

--- a/src/Components/internal/theme/tokens/index.ts
+++ b/src/Components/internal/theme/tokens/index.ts
@@ -1,0 +1,2 @@
+export { defaultLightTokens } from './light';
+export { defaultDarkTokens } from './dark';

--- a/src/Components/internal/theme/tokens/light.ts
+++ b/src/Components/internal/theme/tokens/light.ts
@@ -1,0 +1,88 @@
+import type { PrimerTokens } from '../types';
+
+// Values derived from iOS DesignTokens.swift (Style Dictionary generated, light theme).
+// Source: /Users/onurvar/Projects/primer-sdk-ios/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokens.swift
+export const defaultLightTokens: PrimerTokens = {
+  colors: {
+    primary: '#2f98ff', // primerColorBrand (0.184, 0.596, 1.0)
+    background: '#ffffff', // primerColorBackground (1.0, 1.0, 1.0)
+    surface: '#f5f5f5', // primerColorGray100 (0.961, 0.961, 0.961)
+    overlay: 'rgba(0,0,0,0.5)',
+    textPrimary: '#212121', // primerColorTextPrimary (0.129, 0.129, 0.129)
+    textSecondary: '#757575', // primerColorTextSecondary (0.459, 0.459, 0.459)
+    textPlaceholder: '#9e9e9e', // primerColorTextPlaceholder (0.620, 0.620, 0.620)
+    textDisabled: '#bdbdbd', // primerColorTextDisabled (0.741, 0.741, 0.741)
+    textNegative: '#b4324b', // primerColorTextNegative (0.706, 0.196, 0.294)
+    textLink: '#2270f4', // primerColorTextLink (0.133, 0.439, 0.957)
+    border: '#e0e0e0', // primerColorBorderOutlinedDefault (0.878, 0.878, 0.878)
+    borderFocused: '#2f98ff', // primerColorBorderOutlinedFocus (0.184, 0.596, 1.0)
+    borderError: '#ff7279', // primerColorBorderOutlinedError (1.0, 0.447, 0.475)
+    borderDisabled: '#eeeeee', // primerColorBorderOutlinedDisabled (0.933, 0.933, 0.933)
+    iconPrimary: '#212121', // primerColorIconPrimary (0.129, 0.129, 0.129)
+    iconDisabled: '#bdbdbd', // primerColorIconDisabled (0.741, 0.741, 0.741)
+    iconNegative: '#ff7279', // primerColorIconNegative (1.0, 0.447, 0.475)
+    iconPositive: '#3eb68f', // primerColorIconPositive (0.243, 0.714, 0.561)
+    error: '#ff7279', // primerColorRed500 (1.0, 0.447, 0.475)
+    success: '#3eb68f', // primerColorGreen500 (0.243, 0.714, 0.561)
+  },
+  spacing: {
+    xxsmall: 2, // primerSpaceXxsmall
+    xsmall: 4, // primerSpaceXsmall
+    small: 8, // primerSpaceSmall
+    medium: 12, // primerSpaceMedium
+    large: 16, // primerSpaceLarge
+    xlarge: 20, // primerSpaceXlarge
+    xxlarge: 24, // primerSpaceXxlarge
+    xxxlarge: 32, // primerSizeXlarge (scale extension: 8×base)
+  },
+  typography: {
+    fontFamily: 'Inter', // primerTypographyBrand
+    titleXLarge: {
+      fontSize: 24, // primerTypographyTitleXlargeSize
+      fontWeight: '600', // primerTypographyTitleXlargeWeight 550 → nearest RN value
+      lineHeight: 32, // primerTypographyTitleXlargeLineHeight
+      letterSpacing: -0.6, // primerTypographyTitleXlargeLetterSpacing
+      fontFamily: 'Inter', // primerTypographyTitleXlargeFont
+    },
+    titleLarge: {
+      fontSize: 16, // primerTypographyTitleLargeSize
+      fontWeight: '600', // primerTypographyTitleLargeWeight 550 → nearest RN value
+      lineHeight: 20, // primerTypographyTitleLargeLineHeight
+      letterSpacing: -0.2, // primerTypographyTitleLargeLetterSpacing
+      fontFamily: 'Inter', // primerTypographyTitleLargeFont
+    },
+    bodyLarge: {
+      fontSize: 16, // primerTypographyBodyLargeSize
+      fontWeight: '400', // primerTypographyBodyLargeWeight
+      lineHeight: 20, // primerTypographyBodyLargeLineHeight
+      letterSpacing: -0.2, // primerTypographyBodyLargeLetterSpacing
+      fontFamily: 'Inter', // primerTypographyBodyLargeFont
+    },
+    bodyMedium: {
+      fontSize: 14, // primerTypographyBodyMediumSize
+      fontWeight: '400', // primerTypographyBodyMediumWeight
+      lineHeight: 20, // primerTypographyBodyMediumLineHeight
+      letterSpacing: 0, // primerTypographyBodyMediumLetterSpacing
+      fontFamily: 'Inter', // primerTypographyBodyMediumFont
+    },
+    bodySmall: {
+      fontSize: 12, // primerTypographyBodySmallSize
+      fontWeight: '400', // primerTypographyBodySmallWeight
+      lineHeight: 16, // primerTypographyBodySmallLineHeight
+      letterSpacing: 0, // primerTypographyBodySmallLetterSpacing
+      fontFamily: 'Inter', // primerTypographyBodySmallFont
+    },
+  },
+  radii: {
+    none: 0,
+    xsmall: 2, // primerRadiusXsmall
+    small: 4, // primerRadiusSmall / primerRadiusBase
+    medium: 8, // primerRadiusMedium
+    large: 12, // primerRadiusLarge
+  },
+  borders: {
+    default: 1,
+    input: 1,
+    strong: 2,
+  },
+};

--- a/src/Components/internal/theme/types.ts
+++ b/src/Components/internal/theme/types.ts
@@ -1,0 +1,89 @@
+export interface PrimerColorTokens {
+  primary: string;
+  background: string;
+  surface: string;
+  overlay: string;
+  textPrimary: string;
+  textSecondary: string;
+  textPlaceholder: string;
+  textDisabled: string;
+  textNegative: string;
+  textLink: string;
+  border: string;
+  borderFocused: string;
+  borderError: string;
+  borderDisabled: string;
+  iconPrimary: string;
+  iconDisabled: string;
+  iconNegative: string;
+  iconPositive: string;
+  error: string;
+  success: string;
+}
+
+export interface PrimerSpacingTokens {
+  xxsmall: number;
+  xsmall: number;
+  small: number;
+  medium: number;
+  large: number;
+  xlarge: number;
+  xxlarge: number;
+  xxxlarge: number;
+}
+
+export interface PrimerTypographyStyle {
+  fontSize: number;
+  fontWeight: string;
+  lineHeight: number;
+  letterSpacing: number;
+  fontFamily: string;
+}
+
+export interface PrimerTypographyTokens {
+  fontFamily: string;
+  titleXLarge: PrimerTypographyStyle;
+  titleLarge: PrimerTypographyStyle;
+  bodyLarge: PrimerTypographyStyle;
+  bodyMedium: PrimerTypographyStyle;
+  bodySmall: PrimerTypographyStyle;
+}
+
+export interface PrimerRadiusTokens {
+  none: number;
+  xsmall: number;
+  small: number;
+  medium: number;
+  large: number;
+}
+
+export interface PrimerBorderTokens {
+  default: number;
+  input: number;
+  strong: number;
+}
+
+export interface PrimerTokens {
+  colors: PrimerColorTokens;
+  spacing: PrimerSpacingTokens;
+  typography: PrimerTypographyTokens;
+  radii: PrimerRadiusTokens;
+  borders: PrimerBorderTokens;
+}
+
+export interface PrimerThemeOverride {
+  light?: {
+    colors?: Partial<PrimerColorTokens>;
+    spacing?: Partial<PrimerSpacingTokens>;
+    typography?: Partial<PrimerTypographyTokens>;
+    radii?: Partial<PrimerRadiusTokens>;
+    borders?: Partial<PrimerBorderTokens>;
+  };
+  dark?: {
+    colors?: Partial<PrimerColorTokens>;
+    spacing?: Partial<PrimerSpacingTokens>;
+    typography?: Partial<PrimerTypographyTokens>;
+    radii?: Partial<PrimerRadiusTokens>;
+    borders?: Partial<PrimerBorderTokens>;
+  };
+}

--- a/src/Components/internal/theme/useTheme.ts
+++ b/src/Components/internal/theme/useTheme.ts
@@ -1,0 +1,15 @@
+import { useContext } from 'react';
+import { useColorScheme } from 'react-native';
+import { ThemeContext } from './ThemeContext';
+import { defaultDarkTokens, defaultLightTokens } from './tokens';
+import type { PrimerTokens } from './types';
+
+export function useTheme(): PrimerTokens {
+  const theme = useContext(ThemeContext);
+  const colorScheme = useColorScheme();
+
+  const light = theme?.lightTokens ?? defaultLightTokens;
+  const dark = theme?.darkTokens ?? defaultDarkTokens;
+
+  return colorScheme === 'dark' ? dark : light;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -134,6 +134,18 @@ export { PrimerCheckoutProvider } from './Components';
 export { usePrimerCheckout } from './Components';
 export type { PrimerCheckoutProviderProps, PrimerCheckoutContextValue } from './Components';
 
+export { useTheme } from './Components/internal/theme';
+export type {
+  PrimerTokens,
+  PrimerColorTokens,
+  PrimerSpacingTokens,
+  PrimerTypographyTokens,
+  PrimerTypographyStyle,
+  PrimerRadiusTokens,
+  PrimerBorderTokens,
+  PrimerThemeOverride,
+} from './Components/internal/theme';
+
 // must be exported in order to support the old architecture
 const nativeModule = require('./specs/NativePrimer').default;
 export default nativeModule;

--- a/src/models/components/PrimerCheckoutProviderTypes.ts
+++ b/src/models/components/PrimerCheckoutProviderTypes.ts
@@ -7,10 +7,12 @@ import type { PrimerCheckoutPaymentMethodData } from '../PrimerCheckoutPaymentMe
 import type { PrimerPaymentMethodTokenData } from '../PrimerPaymentMethodTokenData';
 import type { PrimerHeadlessUniversalCheckoutResumeHandler, PrimerPaymentCreationHandler } from '../PrimerHandlers';
 import type { IPrimerHeadlessUniversalCheckoutPaymentMethod } from '../PrimerHeadlessUniversalCheckoutPaymentMethod';
+import type { PrimerThemeOverride } from '../../Components/internal/theme/types';
 
 export interface PrimerCheckoutProviderProps {
   clientToken: string;
   settings?: PrimerSettings;
+  theme?: PrimerThemeOverride;
   onCheckoutComplete?: (checkoutData: PrimerCheckoutData) => void;
   onTokenizationSuccess?: (
     paymentMethodTokenData: PrimerPaymentMethodTokenData,


### PR DESCRIPTION
## Summary

- Add design token system with light and dark token sets aligned to Figma specifications
- Add `ThemeContext` and `useTheme` hook for consuming tokens in components
- Add `mergeTokens` utility for deep-merging custom theme overrides
- Extend `PrimerCheckoutProvider` to accept a `theme` prop and provide tokens via context

## Jira

[ACC-6508](https://primerapi.atlassian.net/browse/ACC-6508)

## Test plan

- [x] `yarn typescript` — no type errors
- [x] `yarn lint` — clean
- [x] `yarn test` — all tests pass
- [x] Unit tests verify deep merge of custom tokens over defaults
- [x] Unit tests verify `useTheme` returns resolved tokens from context

[ACC-6508]: https://primerapi.atlassian.net/browse/ACC-6508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ