### PR TITLE
chore: increase CI runners back to xlarge from large

### DIFF
--- a/.github/workflows/ios-build-and-distribute.yml
+++ b/.github/workflows/ios-build-and-distribute.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
 
   build-and-upload-to-appetize:
-    runs-on: macos-26-large
+    runs-on: macos-26-xlarge
     timeout-minutes: 30
     name: Build and upload app to Appetize 🚀
     steps:

--- a/.github/workflows/rn-version-compat.yml
+++ b/.github/workflows/rn-version-compat.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   rn-compat-build-ios:
-    runs-on: macos-26-large
+    runs-on: macos-26-xlarge
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/unit-tests-and-code-quality.yml
+++ b/.github/workflows/unit-tests-and-code-quality.yml
@@ -87,7 +87,7 @@ jobs:
 
   run-unit-tests-ios:
     name: Run iOS unit tests
-    runs-on: macos-26-large
+    runs-on: macos-26-xlarge
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
## Summary
- Reverts runner downsize from PR #335: `macos-26-large` → `macos-26-xlarge` for iOS CI jobs

## Files changed
- `.github/workflows/ios-build-and-distribute.yml`
- `.github/workflows/rn-version-compat.yml`
- `.github/workflows/unit-tests-and-code-quality.yml`

## Test plan
- [ ] Verify all three affected workflows run successfully on xlarge runners