### PR TITLE
feat: add analytics logging bridge

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -134,6 +134,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3"
   implementation 'io.primer:android:2.49.0'
+  implementation 'io.primer:components-analytics:3.0.0-beta.2'
   testImplementation 'io.mockk:mockk:1.14.2'
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'

--- a/android/src/main/java/com/primerioreactnative/DefaultNativePrimerModule.kt
+++ b/android/src/main/java/com/primerioreactnative/DefaultNativePrimerModule.kt
@@ -13,9 +13,11 @@ import com.primerioreactnative.datamodels.PrimerSettingsRN
 import com.primerioreactnative.datamodels.toPrimerSettings
 import com.primerioreactnative.utils.PrimerImplementedRNCallbacks
 import com.primerioreactnative.utils.errorTo
+import com.primerioreactnative.utils.toEventType
 import com.primerioreactnative.utils.toWritableMap
 import io.primer.android.Primer
 import io.primer.android.PrimerSessionIntent
+import io.primer.android.components.analytics.ComponentsAnalyticsLoggingBridge
 import io.primer.android.data.settings.PrimerSettings
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -27,6 +29,7 @@ internal open class DefaultNativePrimerModule(
     private val json: Json,
     private val eventSender: (String, WritableMap) -> Unit,
 ) {
+    private var analyticsLoggingBridge: ComponentsAnalyticsLoggingBridge? = null
     private val mListener = PrimerRNEventListener()
 
     init {
@@ -237,6 +240,50 @@ internal open class DefaultNativePrimerModule(
             promise.reject(exception.errorId, exception.description, expected)
         }
     }
+
+    // region analytics bridge
+    fun trackAnalyticsEvent(
+        eventName: String,
+        metadata: String?,
+        promise: Promise,
+    ) {
+        try {
+            val metadataMap: Map<String, String>? = metadata?.let {
+                json.decodeFromString<Map<String, String>>(it)
+            }
+            val eventType = toEventType(eventName, metadataMap) ?: return promise.resolve(null)
+            analyticsLoggingBridge?.sendEvent(eventType)
+            promise.resolve(null)
+        } catch (expected: Exception) {
+            promise.resolve(null)
+        }
+    }
+
+    fun sendLog(
+        message: String,
+        event: String,
+        promise: Promise,
+    ) {
+        try {
+            analyticsLoggingBridge?.sendInfoLog(message, event)
+            promise.resolve(null)
+        } catch (expected: Exception) {
+            promise.resolve(null)
+        }
+    }
+
+    fun setupAnalyticsLoggingBridge(
+        clientToken: String,
+        promise: Promise,
+    ) {
+        try {
+            analyticsLoggingBridge = ComponentsAnalyticsLoggingBridge.create()
+            promise.resolve(null)
+        } catch (expected: Exception) {
+            promise.reject("setup_failed", expected.message, expected)
+        }
+    }
+    // endregion
 
     private fun startSdk(settings: PrimerSettings) {
         Primer.instance.configure(settings, mListener)

--- a/android/src/main/java/com/primerioreactnative/utils/EventTypeMapper.kt
+++ b/android/src/main/java/com/primerioreactnative/utils/EventTypeMapper.kt
@@ -1,0 +1,53 @@
+package com.primerioreactnative.utils
+
+import io.primer.android.components.analytics.data.model.EventType
+
+internal fun toEventType(name: String, metadata: Map<String, String>?): EventType? {
+    return when (name) {
+        "SDK_INIT_START" -> EventType.SdkInitStart
+        "SDK_INIT_END" -> EventType.SdkInitEnd
+        "CHECKOUT_FLOW_STARTED" -> EventType.CheckoutFlowStarted
+        "PAYMENT_FLOW_EXITED" -> EventType.PaymentFlowExited
+        "PAYMENT_REATTEMPTED" -> EventType.PaymentReattempted
+
+        "PAYMENT_METHOD_SELECTION" -> {
+            val paymentMethod = metadata?.get("paymentMethod") ?: return null
+            EventType.PaymentMethodSelection(paymentMethod)
+        }
+        "PAYMENT_DETAILS_ENTERED" -> {
+            val paymentMethod = metadata?.get("paymentMethod") ?: return null
+            EventType.PaymentDetailsEntered(paymentMethod)
+        }
+        "PAYMENT_SUBMITTED" -> {
+            val paymentMethod = metadata?.get("paymentMethod") ?: return null
+            EventType.PaymentSubmitted(paymentMethod)
+        }
+        "PAYMENT_PROCESSING_STARTED" -> {
+            val paymentMethod = metadata?.get("paymentMethod") ?: return null
+            EventType.PaymentProcessingStarted(paymentMethod)
+        }
+        "PAYMENT_SUCCESS" -> {
+            val paymentMethod = metadata?.get("paymentMethod") ?: return null
+            val paymentId = metadata["paymentId"] ?: return null
+            EventType.PaymentSuccess(paymentMethod, paymentId)
+        }
+        "PAYMENT_FAILURE" -> {
+            val paymentMethod = metadata?.get("paymentMethod") ?: return null
+            val paymentId = metadata["paymentId"]
+            EventType.PaymentFailure(paymentMethod, paymentId)
+        }
+        "PAYMENT_THREEDS" -> {
+            val paymentMethod = metadata?.get("paymentMethod") ?: return null
+            val threedsProvider = metadata["threedsProvider"] ?: return null
+            val threedsResponse = metadata["threedsResponse"]
+            EventType.PaymentThreeDS(paymentMethod, threedsProvider, threedsResponse)
+        }
+        "PAYMENT_REDIRECT_TO_THIRD_PARTY" -> {
+            val paymentMethod = metadata?.get("paymentMethod") ?: return null
+            val redirectDestinationUrl = metadata["redirectDestinationUrl"] ?: return null
+            EventType.PaymentRedirect(paymentMethod, redirectDestinationUrl)
+        }
+
+        else -> null
+    }
+}

--- a/android/src/newarch/java/com/primerioreactnative/NativePrimerModule.kt
+++ b/android/src/newarch/java/com/primerioreactnative/NativePrimerModule.kt
@@ -110,6 +110,18 @@ class NativePrimerModule(private val reactContext: ReactApplicationContext, priv
     implementation.setImplementedRNCallbacks(implementedRNCallbacksStr = implementedRNCallbacks, promise = promise)
   }
 
+  override fun trackAnalyticsEvent(eventName: String, metadata: String?, promise: Promise) {
+    implementation.trackAnalyticsEvent(eventName = eventName, metadata = metadata, promise = promise)
+  }
+
+  override fun sendLog(message: String, event: String, promise: Promise) {
+    implementation.sendLog(message = message, event = event, promise = promise)
+  }
+
+  override fun setupAnalyticsLoggingBridge(clientToken: String, promise: Promise) {
+    implementation.setupAnalyticsLoggingBridge(clientToken = clientToken, promise = promise)
+  }
+
   override fun addListener(eventName: String?) = Unit
 
   override fun removeListeners(count: Double?) = Unit

--- a/android/src/oldarch/java/com/primerioreactnative/NativePrimerModule.kt
+++ b/android/src/oldarch/java/com/primerioreactnative/NativePrimerModule.kt
@@ -134,6 +134,21 @@ class NativePrimerModule(private val reactContext: ReactApplicationContext, priv
   }
 
   @ReactMethod
+  fun trackAnalyticsEvent(eventName: String, metadata: String?, promise: Promise) {
+    implementation.trackAnalyticsEvent(eventName = eventName, metadata = metadata, promise = promise)
+  }
+
+  @ReactMethod
+  fun sendLog(message: String, event: String, promise: Promise) {
+    implementation.sendLog(message = message, event = event, promise = promise)
+  }
+
+  @ReactMethod
+  fun setupAnalyticsLoggingBridge(clientToken: String, promise: Promise) {
+    implementation.setupAnalyticsLoggingBridge(clientToken = clientToken, promise = promise)
+  }
+
+  @ReactMethod
   fun addListener(eventName: String?) = Unit
 
   @ReactMethod

--- a/android/src/test/java/com/primerioreactnative/utils/EventTypeMapperTest.kt
+++ b/android/src/test/java/com/primerioreactnative/utils/EventTypeMapperTest.kt
@@ -1,0 +1,246 @@
+package com.primerioreactnative.utils
+
+import io.primer.android.components.analytics.data.model.EventType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+internal class EventTypeMapperTest {
+
+    @Nested
+    inner class `data object events` {
+        @Test
+        fun `toEventType returns SdkInitStart`() {
+            assertEquals(EventType.SdkInitStart, toEventType("SDK_INIT_START", null))
+        }
+
+        @Test
+        fun `toEventType returns SdkInitEnd`() {
+            assertEquals(EventType.SdkInitEnd, toEventType("SDK_INIT_END", null))
+        }
+
+        @Test
+        fun `toEventType returns CheckoutFlowStarted`() {
+            assertEquals(EventType.CheckoutFlowStarted, toEventType("CHECKOUT_FLOW_STARTED", null))
+        }
+
+        @Test
+        fun `toEventType returns PaymentFlowExited`() {
+            assertEquals(EventType.PaymentFlowExited, toEventType("PAYMENT_FLOW_EXITED", null))
+        }
+
+        @Test
+        fun `toEventType returns PaymentReattempted`() {
+            assertEquals(EventType.PaymentReattempted, toEventType("PAYMENT_REATTEMPTED", null))
+        }
+
+        @Test
+        fun `toEventType ignores metadata for data object events`() {
+            val metadata = mapOf("paymentMethod" to "PAYMENT_CARD")
+            assertEquals(EventType.SdkInitStart, toEventType("SDK_INIT_START", metadata))
+        }
+    }
+
+    @Nested
+    inner class `PaymentMethodSelection event` {
+        @Test
+        fun `toEventType returns PaymentMethodSelection with paymentMethod`() {
+            val metadata = mapOf("paymentMethod" to "PAYMENT_CARD")
+            assertEquals(
+                EventType.PaymentMethodSelection("PAYMENT_CARD"),
+                toEventType("PAYMENT_METHOD_SELECTION", metadata),
+            )
+        }
+
+        @Test
+        fun `toEventType returns null when paymentMethod is missing`() {
+            assertNull(toEventType("PAYMENT_METHOD_SELECTION", emptyMap()))
+        }
+
+        @Test
+        fun `toEventType returns null when metadata is null`() {
+            assertNull(toEventType("PAYMENT_METHOD_SELECTION", null))
+        }
+    }
+
+    @Nested
+    inner class `single-field data class events` {
+        @Test
+        fun `toEventType returns PaymentDetailsEntered`() {
+            val metadata = mapOf("paymentMethod" to "PAYMENT_CARD")
+            assertEquals(
+                EventType.PaymentDetailsEntered("PAYMENT_CARD"),
+                toEventType("PAYMENT_DETAILS_ENTERED", metadata),
+            )
+        }
+
+        @Test
+        fun `toEventType returns null for PaymentDetailsEntered without paymentMethod`() {
+            assertNull(toEventType("PAYMENT_DETAILS_ENTERED", null))
+        }
+
+        @Test
+        fun `toEventType returns PaymentSubmitted`() {
+            val metadata = mapOf("paymentMethod" to "PAYMENT_CARD")
+            assertEquals(
+                EventType.PaymentSubmitted("PAYMENT_CARD"),
+                toEventType("PAYMENT_SUBMITTED", metadata),
+            )
+        }
+
+        @Test
+        fun `toEventType returns null for PaymentSubmitted without paymentMethod`() {
+            assertNull(toEventType("PAYMENT_SUBMITTED", null))
+        }
+
+        @Test
+        fun `toEventType returns PaymentProcessingStarted`() {
+            val metadata = mapOf("paymentMethod" to "PAYMENT_CARD")
+            assertEquals(
+                EventType.PaymentProcessingStarted("PAYMENT_CARD"),
+                toEventType("PAYMENT_PROCESSING_STARTED", metadata),
+            )
+        }
+
+        @Test
+        fun `toEventType returns null for PaymentProcessingStarted without paymentMethod`() {
+            assertNull(toEventType("PAYMENT_PROCESSING_STARTED", null))
+        }
+    }
+
+    @Nested
+    inner class `PaymentSuccess event` {
+        @Test
+        fun `toEventType returns PaymentSuccess with paymentMethod and paymentId`() {
+            val metadata = mapOf("paymentMethod" to "PAYMENT_CARD", "paymentId" to "abc123")
+            assertEquals(
+                EventType.PaymentSuccess("PAYMENT_CARD", "abc123"),
+                toEventType("PAYMENT_SUCCESS", metadata),
+            )
+        }
+
+        @Test
+        fun `toEventType returns null when paymentId is missing`() {
+            val metadata = mapOf("paymentMethod" to "PAYMENT_CARD")
+            assertNull(toEventType("PAYMENT_SUCCESS", metadata))
+        }
+
+        @Test
+        fun `toEventType returns null when paymentMethod is missing`() {
+            val metadata = mapOf("paymentId" to "abc123")
+            assertNull(toEventType("PAYMENT_SUCCESS", metadata))
+        }
+    }
+
+    @Nested
+    inner class `PaymentFailure event` {
+        @Test
+        fun `toEventType returns PaymentFailure with paymentMethod and paymentId`() {
+            val metadata = mapOf("paymentMethod" to "PAYMENT_CARD", "paymentId" to "abc123")
+            assertEquals(
+                EventType.PaymentFailure("PAYMENT_CARD", "abc123"),
+                toEventType("PAYMENT_FAILURE", metadata),
+            )
+        }
+
+        @Test
+        fun `toEventType returns PaymentFailure with null paymentId when absent`() {
+            val metadata = mapOf("paymentMethod" to "PAYMENT_CARD")
+            assertEquals(
+                EventType.PaymentFailure("PAYMENT_CARD", null),
+                toEventType("PAYMENT_FAILURE", metadata),
+            )
+        }
+
+        @Test
+        fun `toEventType returns null when paymentMethod is missing`() {
+            assertNull(toEventType("PAYMENT_FAILURE", emptyMap()))
+        }
+    }
+
+    @Nested
+    inner class `PaymentThreeDS event` {
+        @Test
+        fun `toEventType returns PaymentThreeDS with all fields`() {
+            val metadata = mapOf(
+                "paymentMethod" to "PAYMENT_CARD",
+                "threedsProvider" to "ADYEN",
+                "threedsResponse" to "CHALLENGE",
+            )
+            assertEquals(
+                EventType.PaymentThreeDS("PAYMENT_CARD", "ADYEN", "CHALLENGE"),
+                toEventType("PAYMENT_THREEDS", metadata),
+            )
+        }
+
+        @Test
+        fun `toEventType returns PaymentThreeDS with null threedsResponse`() {
+            val metadata = mapOf(
+                "paymentMethod" to "PAYMENT_CARD",
+                "threedsProvider" to "ADYEN",
+            )
+            assertEquals(
+                EventType.PaymentThreeDS("PAYMENT_CARD", "ADYEN", null),
+                toEventType("PAYMENT_THREEDS", metadata),
+            )
+        }
+
+        @Test
+        fun `toEventType returns null when threedsProvider is missing`() {
+            val metadata = mapOf("paymentMethod" to "PAYMENT_CARD")
+            assertNull(toEventType("PAYMENT_THREEDS", metadata))
+        }
+
+        @Test
+        fun `toEventType returns null when paymentMethod is missing`() {
+            val metadata = mapOf("threedsProvider" to "ADYEN")
+            assertNull(toEventType("PAYMENT_THREEDS", metadata))
+        }
+    }
+
+    @Nested
+    inner class `PaymentRedirect event` {
+        @Test
+        fun `toEventType returns PaymentRedirect with paymentMethod and url`() {
+            val metadata = mapOf(
+                "paymentMethod" to "PAYPAL",
+                "redirectDestinationUrl" to "https://example.com",
+            )
+            assertEquals(
+                EventType.PaymentRedirect("PAYPAL", "https://example.com"),
+                toEventType("PAYMENT_REDIRECT_TO_THIRD_PARTY", metadata),
+            )
+        }
+
+        @Test
+        fun `toEventType returns null when redirectDestinationUrl is missing`() {
+            val metadata = mapOf("paymentMethod" to "PAYPAL")
+            assertNull(toEventType("PAYMENT_REDIRECT_TO_THIRD_PARTY", metadata))
+        }
+
+        @Test
+        fun `toEventType returns null when paymentMethod is missing`() {
+            val metadata = mapOf("redirectDestinationUrl" to "https://example.com")
+            assertNull(toEventType("PAYMENT_REDIRECT_TO_THIRD_PARTY", metadata))
+        }
+    }
+
+    @Nested
+    inner class `unknown and edge cases` {
+        @Test
+        fun `toEventType returns null for unknown event name`() {
+            assertNull(toEventType("UNKNOWN_EVENT", null))
+        }
+
+        @Test
+        fun `toEventType returns null for empty event name`() {
+            assertNull(toEventType("", null))
+        }
+
+        @Test
+        fun `toEventType returns null for lowercase event name`() {
+            assertNull(toEventType("sdk_init_start", null))
+        }
+    }
+}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -16,6 +16,7 @@ import HeadlessCheckoutWithRedirect from './screens/HeadlessCheckoutWithRedirect
 import HeadlessCheckoutStripeAchScreen from './screens/HeadlessCheckoutStripeAchScreen';
 import LocalizationDebugScreen from './screens/LocalizationDebugScreen';
 import {CheckoutComponentsListScreen} from './screens/CheckoutComponentsListScreen';
+import AnalyticsDebugScreen from './screens/AnalyticsDebugScreen';
 import {LogBox} from 'react-native';
 import {
   SafeAreaProvider,
@@ -70,6 +71,7 @@ const App = () => {
             name="LocalizationDebug"
             component={LocalizationDebugScreen}
           />
+          <Stack.Screen name="AnalyticsDebug" component={AnalyticsDebugScreen} />
         </Stack.Navigator>
       </NavigationContainer>
     </SafeAreaProvider>

--- a/example/src/screens/AnalyticsDebugScreen.tsx
+++ b/example/src/screens/AnalyticsDebugScreen.tsx
@@ -1,0 +1,167 @@
+import * as React from 'react';
+import {
+  ScrollView,
+  Text,
+  TouchableOpacity,
+  View,
+  useColorScheme,
+} from 'react-native';
+import {styles} from '../styles';
+import {createClientSession} from '../network/api';
+import {PrimerAnalytics, PrimerSettings, HeadlessUniversalCheckout} from '@primer-io/react-native';
+
+interface LogEntry {
+  timestamp: string;
+  action: string;
+  result: 'success' | 'error';
+  message?: string;
+}
+
+const AnalyticsDebugScreen = () => {
+  const isDarkMode = useColorScheme() === 'dark';
+  const [logs, setLogs] = React.useState<LogEntry[]>([]);
+  const [isSetup, setIsSetup] = React.useState(false);
+
+  const backgroundStyle = {
+    backgroundColor: isDarkMode ? '#000000' : '#FFFFFF',
+  };
+
+  const addLog = (action: string, result: 'success' | 'error', message?: string) => {
+    const entry: LogEntry = {
+      timestamp: new Date().toLocaleTimeString(),
+      action,
+      result,
+      message,
+    };
+    setLogs(prev => [entry, ...prev]);
+  };
+
+  const handleSetup = async () => {
+    try {
+      addLog('createClientSession', 'success', 'Fetching client token...');
+      const response = await createClientSession();
+      const clientToken = response.clientToken;
+      addLog('createClientSession', 'success', `Token: ${clientToken.substring(0, 20)}...`);
+
+      addLog('headlessStart', 'success', 'Starting headless checkout...');
+      const settings: PrimerSettings = {};
+      await HeadlessUniversalCheckout.startWithClientToken(clientToken, settings);
+      addLog('headlessStart', 'success', 'Headless checkout started');
+
+      addLog('setup', 'success', 'Setting up analytics bridge...');
+      await PrimerAnalytics.setup(clientToken);
+      addLog('setup', 'success', 'Analytics bridge ready');
+      setIsSetup(true);
+    } catch (err: any) {
+      addLog('setup', 'error', err.message || String(err));
+    }
+  };
+
+  const trackEvent = async (eventName: string, metadata?: Record<string, string>) => {
+    try {
+      await PrimerAnalytics.trackEvent(eventName, metadata);
+      const metaStr = metadata ? ` ${JSON.stringify(metadata)}` : '';
+      addLog('trackEvent', 'success', `${eventName}${metaStr}`);
+    } catch (err: any) {
+      addLog('trackEvent', 'error', err.message || String(err));
+    }
+  };
+
+  const handleSendLog = async () => {
+    try {
+      await PrimerAnalytics.sendLog('Debug test message', 'debug_test');
+      addLog('sendLog', 'success', 'message: "Debug test message", event: "debug_test"');
+    } catch (err: any) {
+      addLog('sendLog', 'error', err.message || String(err));
+    }
+  };
+
+  const eventButtons: {label: string; eventName: string; metadata?: Record<string, string>}[] = [
+    {label: 'Checkout Flow Started', eventName: 'CHECKOUT_FLOW_STARTED'},
+    {label: 'Payment Success', eventName: 'PAYMENT_SUCCESS', metadata: {paymentMethod: 'PAYMENT_CARD', paymentId: 'debug-payment-123'}},
+    {label: 'Payment Failure', eventName: 'PAYMENT_FAILURE', metadata: {paymentMethod: 'PAYMENT_CARD'}},
+  ];
+
+  return (
+    <ScrollView
+      contentInsetAdjustmentBehavior="automatic"
+      style={backgroundStyle}>
+      <View style={{marginHorizontal: 24, marginTop: 16}}>
+        <Text style={styles.sectionTitle}>Analytics Bridge Debug</Text>
+
+        <TouchableOpacity
+          style={{
+            ...styles.button,
+            marginVertical: 5,
+            backgroundColor: isSetup ? 'gray' : 'black',
+          }}
+          onPress={handleSetup}>
+          <Text style={{...styles.buttonText, color: 'white'}}>
+            {isSetup ? 'Bridge Ready' : 'Setup Bridge'}
+          </Text>
+        </TouchableOpacity>
+
+        <Text style={{...styles.heading1, marginTop: 16, marginBottom: 8}}>
+          Events
+        </Text>
+
+        {eventButtons.map((btn) => (
+          <TouchableOpacity
+            key={btn.eventName}
+            style={{
+              ...styles.button,
+              marginVertical: 3,
+              backgroundColor: isSetup ? 'black' : 'gray',
+            }}
+            disabled={!isSetup}
+            onPress={() => trackEvent(btn.eventName, btn.metadata)}>
+            <Text style={{...styles.buttonText, color: 'white', fontSize: 14}}>
+              {btn.label}
+            </Text>
+          </TouchableOpacity>
+        ))}
+
+        <Text style={{...styles.heading1, marginTop: 16, marginBottom: 8}}>
+          Logging
+        </Text>
+
+        <TouchableOpacity
+          style={{
+            ...styles.button,
+            marginVertical: 3,
+            backgroundColor: isSetup ? 'black' : 'gray',
+          }}
+          disabled={!isSetup}
+          onPress={handleSendLog}>
+          <Text style={{...styles.buttonText, color: 'white', fontSize: 14}}>
+            Send Info Log
+          </Text>
+        </TouchableOpacity>
+
+        <Text style={{...styles.heading1, marginTop: 16, marginBottom: 8}}>
+          Logs
+        </Text>
+
+        {logs.map((entry, index) => (
+          <View
+            key={index}
+            style={{
+              padding: 8,
+              marginBottom: 4,
+              backgroundColor: entry.result === 'error' ? '#ffdddd' : '#ddffdd',
+              borderRadius: 4,
+            }}>
+            <Text style={{fontSize: 12, fontWeight: '600'}}>
+              [{entry.timestamp}] {entry.action} - {entry.result}
+            </Text>
+            {entry.message && (
+              <Text style={{fontSize: 11, marginTop: 2}}>{entry.message}</Text>
+            )}
+          </View>
+        ))}
+      </View>
+    </ScrollView>
+  );
+};
+
+export default AnalyticsDebugScreen;

--- a/example/src/screens/SettingsScreen.tsx
+++ b/example/src/screens/SettingsScreen.tsx
@@ -919,6 +919,20 @@ const SettingsScreen = ({navigation}) => {
             Navigation Demo
           </Text>
         </TouchableOpacity>
+
+        <TouchableOpacity
+          style={{
+            ...styles.button,
+            marginVertical: 5,
+            backgroundColor: '#2c3e50',
+          }}
+          onPress={() => {
+            navigation.navigate('AnalyticsDebug');
+          }}>
+          <Text style={{...styles.buttonText, color: 'white'}}>
+            Analytics Debug
+          </Text>
+        </TouchableOpacity>
       </View>
     );
   };

--- a/ios/Sources/NativePrimer/RCTNativePrimer.mm
+++ b/ios/Sources/NativePrimer/RCTNativePrimer.mm
@@ -128,6 +128,26 @@ RCT_EXPORT_METHOD(cleanUp:(RCTPromiseResolveBlock)resolve
     resolve(nil);
 }
 
+RCT_EXPORT_METHOD(trackAnalyticsEvent:(NSString *)eventName
+                  metadata:(NSString *)metadata
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    [self.primer trackAnalyticsEvent:eventName metadata:metadata resolver:resolve rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(sendLog:(NSString *)message
+                  event:(NSString *)event
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    [self.primer sendLog:message event:event resolver:resolve rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(setupAnalyticsLoggingBridge:(NSString *)clientToken
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    [self.primer setupAnalyticsLoggingBridge:clientToken resolver:resolve rejecter:reject];
+}
+
 #ifdef RCT_NEW_ARCH_ENABLED
 #pragma mark - New Architecture Protocol Methods
 
@@ -182,8 +202,20 @@ RCT_EXPORT_METHOD(cleanUp:(RCTPromiseResolveBlock)resolve
 - (void)showVaultManagerWithClientToken:(nonnull NSString *)clientToken resolve:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject { 
     [self.primer showVaultManagerWithClientToken:clientToken resolver:resolve rejecter:reject];
 }
-- (void)showPaymentMethod:(nonnull NSString *)paymentMethod intent:(nonnull NSString *)intent clientToken:(nonnull NSString *)clientToken resolve:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject { 
+- (void)showPaymentMethod:(nonnull NSString *)paymentMethod intent:(nonnull NSString *)intent clientToken:(nonnull NSString *)clientToken resolve:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject {
     [self.primer showPaymentMethod:paymentMethod intent:intent clientToken:clientToken resolver:resolve rejecter:reject];
+}
+
+- (void)trackAnalyticsEvent:(nonnull NSString *)eventName metadata:(NSString *)metadata resolve:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject {
+    [self.primer trackAnalyticsEvent:eventName metadata:metadata resolver:resolve rejecter:reject];
+}
+
+- (void)sendLog:(nonnull NSString *)message event:(nonnull NSString *)event resolve:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject {
+    [self.primer sendLog:message event:event resolver:resolve rejecter:reject];
+}
+
+- (void)setupAnalyticsLoggingBridge:(nonnull NSString *)clientToken resolve:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject {
+    [self.primer setupAnalyticsLoggingBridge:clientToken resolver:resolve rejecter:reject];
 }
 
 #pragma mark - TurboModule

--- a/ios/Sources/RNTPrimer.swift
+++ b/ios/Sources/RNTPrimer.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import PrimerSDK
+@_spi(PrimerInternal) import PrimerSDK
 import UIKit
 import React
 
@@ -63,6 +63,7 @@ enum PrimerEvents: Int, CaseIterable {
     var primerDidResumeWithDecisionHandler: ((_ resumeToken: String?, _ errorMessage: String?) -> Void)?
     var primerDidFailWithErrorDecisionHandler: ((_ errorMessage: String) -> Void)?
     var implementedRNCallbacks: ImplementedRNCallbacks?
+    private var analyticsLoggingBridge: ComponentsAnalyticsLoggingBridge?
 
     // MARK: - INITIALIZATION & REACT NATIVE SUPPORT
 
@@ -339,6 +340,58 @@ enum PrimerEvents: Int, CaseIterable {
         }
     }
 
+    // MARK: - Analytics Bridge
+
+    @objc
+    public func trackAnalyticsEvent(
+        _ eventName: String,
+        metadata: String?,
+        resolver: @escaping RCTPromiseResolveBlock,
+        rejecter: @escaping RCTPromiseRejectBlock
+    ) {
+        DispatchQueue.main.async {
+            let metadataDict: [String: String]?
+            if let metadata = metadata,
+               let data = metadata.data(using: .utf8),
+               let dict = try? JSONSerialization.jsonObject(with: data) as? [String: String] {
+                metadataDict = dict
+            } else {
+                metadataDict = nil
+            }
+            Task { await self.analyticsLoggingBridge?.trackEvent(eventName, metadata: metadataDict) }
+            resolver(nil)
+        }
+    }
+
+    @objc
+    public func sendLog(
+        _ message: String,
+        event: String,
+        resolver: @escaping RCTPromiseResolveBlock,
+        rejecter: @escaping RCTPromiseRejectBlock
+    ) {
+        DispatchQueue.main.async {
+            Task { await self.analyticsLoggingBridge?.logInfo(message: message, event: event) }
+            resolver(nil)
+        }
+    }
+
+    @objc
+    public func setupAnalyticsLoggingBridge(
+        _ clientToken: String,
+        resolver: @escaping RCTPromiseResolveBlock,
+        rejecter: @escaping RCTPromiseRejectBlock
+    ) {
+        DispatchQueue.main.async {
+            let bridge = ComponentsAnalyticsLoggingBridge()
+            self.analyticsLoggingBridge = bridge
+            Task {
+                await bridge.setup(clientToken: clientToken)
+                resolver(nil)
+            }
+        }
+    }
+
     private func handleRNBridgeError(_ error: Error, checkoutData: PrimerCheckoutData?, stopOnDebug: Bool) {
         DispatchQueue.main.async {
             if stopOnDebug {
@@ -367,7 +420,10 @@ extension RNTPrimer: PrimerDelegate {
                 do {
                     let checkoutData = try JSONEncoder().encode(data)
                     let checkoutJson = try JSONSerialization.jsonObject(with: checkoutData, options: .allowFragments)
-                    self.eventDelegate.sendEvent(withName: PrimerEvents.onCheckoutComplete.stringValue, body: checkoutJson)
+                    self.eventDelegate.sendEvent(
+                        withName: PrimerEvents.onCheckoutComplete.stringValue,
+                        body: checkoutJson
+                    )
                 } catch {
                     self.handleRNBridgeError(error, checkoutData: data, stopOnDebug: true)
                 }
@@ -522,7 +578,10 @@ extension RNTPrimer: PrimerDelegate {
             }
 
             DispatchQueue.main.async {
-              self.eventDelegate.sendEvent(withName: PrimerEvents.onResumeSuccess.stringValue, body: ["resumeToken": resumeToken])
+              self.eventDelegate.sendEvent(
+                  withName: PrimerEvents.onResumeSuccess.stringValue,
+                  body: ["resumeToken": resumeToken]
+              )
             }
         } else {
             // RN dev hasn't opted in on listening the tokenization callback.

--- a/src/Components/analytics.ts
+++ b/src/Components/analytics.ts
@@ -1,0 +1,15 @@
+import RNPrimer from '../RNPrimer';
+
+export const PrimerAnalytics = {
+  setup: (clientToken: string): Promise<void> => {
+    return RNPrimer.setupAnalyticsLoggingBridge(clientToken);
+  },
+
+  trackEvent: (eventName: string, metadata?: Record<string, string>): Promise<void> => {
+    return RNPrimer.trackAnalyticsEvent(eventName, metadata ? JSON.stringify(metadata) : undefined);
+  },
+
+  sendLog: (message: string, event: string): Promise<void> => {
+    return RNPrimer.sendLog(message, event);
+  },
+};

--- a/src/RNPrimer.ts
+++ b/src/RNPrimer.ts
@@ -232,6 +232,40 @@ const RNPrimer = {
       }
     });
   },
+
+  // ANALYTICS BRIDGE
+  setupAnalyticsLoggingBridge: (clientToken: string): Promise<void> => {
+    return new Promise(async (resolve, reject) => {
+      try {
+        await NativePrimer.setupAnalyticsLoggingBridge(clientToken);
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+    });
+  },
+
+  trackAnalyticsEvent: (eventName: string, metadata?: string): Promise<void> => {
+    return new Promise(async (resolve, reject) => {
+      try {
+        await NativePrimer.trackAnalyticsEvent(eventName, metadata);
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+    });
+  },
+
+  sendLog: (message: string, event: string): Promise<void> => {
+    return new Promise(async (resolve, reject) => {
+      try {
+        await NativePrimer.sendLog(message, event);
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+    });
+  },
 };
 
 export default RNPrimer;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -158,6 +158,7 @@ export type {
   CVVInputProps,
   CardholderNameInputProps,
 } from './Components';
+export { PrimerAnalytics } from './Components/analytics';
 
 export { useLocalization, translate, hasLocale } from './Components/internal/localization';
 export type { TranslationParams, LocalizationResult } from './Components/internal/localization';

--- a/src/specs/NativePrimer.ts
+++ b/src/specs/NativePrimer.ts
@@ -31,6 +31,11 @@ export interface Spec extends TurboModule {
 
   setImplementedRNCallbacks(implementedRNCallbacks: string): Promise<void>;
 
+  // Analytics bridge
+  setupAnalyticsLoggingBridge(clientToken: string): Promise<void>;
+  trackAnalyticsEvent(eventName: string, metadata?: string): Promise<void>;
+  sendLog(message: string, event: string): Promise<void>;
+
   // Backward compat
   addListener(eventName?: string): void;
   removeListeners(count?: number): void;


### PR DESCRIPTION
## Summary

- Add `setupAnalyticsLoggingBridge`, `trackAnalyticsEvent`, and `sendLog` TurboModule bridge methods across iOS and Android (old/new arch)
- Add `PrimerAnalytics` public API with `setup`, `trackEvent`, and `sendLog` methods
- Add `ComponentsAnalyticsLoggingBridge` integration on iOS (self-contained) and Android (DI-based via headless flow)
- Add analytics debug screen in example app for manual bridge testing
- iOS setup awaits bridge initialization before resolving promise
- Android setup rejects promise on failure instead of silently swallowing

## Jira

[ACC-6493](https://primerapi.atlassian.net/browse/ACC-6493)

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 21/21 tests pass
- [x] iOS builds successfully against local SDK
- [x] Android builds successfully against local SDK
- [x] Manual verification: iOS — setup bridge, track event, send log all work
- [x] Manual verification: Android — setup bridge, track event, send log all work via headless DI flow
- [x] Manual verification: debug screen shows correct status for each action

[ACC-6493]: https://primerapi.atlassian.net/browse/ACC-6493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ