### PR TITLE
feat: add PrimerPaymentMethodList and checkout flow (ACC-6492)

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1784,7 +1784,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - react-native-safe-area-context (5.6.1):
+  - react-native-safe-area-context (5.6.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1802,8 +1802,8 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-safe-area-context/common (= 5.6.1)
-    - react-native-safe-area-context/fabric (= 5.6.1)
+    - react-native-safe-area-context/common (= 5.6.2)
+    - react-native-safe-area-context/fabric (= 5.6.2)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -1814,7 +1814,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-safe-area-context/common (5.6.1):
+  - react-native-safe-area-context/common (5.6.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1842,7 +1842,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-safe-area-context/fabric (5.6.1):
+  - react-native-safe-area-context/fabric (5.6.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2733,7 +2733,7 @@ SPEC CHECKSUMS:
   React-logger: 7aef4d74123e5e3d267e5af1fbf5135b5a0d8381
   React-Mapbuffer: 91e0eab42a6ae7f3e34091a126d70fc53bd3823e
   React-microtasksnativemodule: 1ead4fe154df3b1ba34b5a9e35ef3c4bdfa72ccb
-  react-native-safe-area-context: c6e2edd1c1da07bdce287fa9d9e60c5f7b514616
+  react-native-safe-area-context: c00143b4823773bba23f2f19f85663ae89ceb460
   react-native-segmented-control: bf6e0032726727498e18dd437ae88afcdbc18e99
   React-NativeModulesApple: eff2eba56030eb0d107b1642b8f853bc36a833ac
   React-oscompat: b12c633e9c00f1f99467b1e0e0b8038895dae436

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -15,6 +15,7 @@ import HeadlessCheckoutKlarnaScreen from './screens/HeadlessCheckoutKlarnaScreen
 import HeadlessCheckoutWithRedirect from './screens/HeadlessCheckoutWithRedirect';
 import HeadlessCheckoutStripeAchScreen from './screens/HeadlessCheckoutStripeAchScreen';
 import LocalizationDebugScreen from './screens/LocalizationDebugScreen';
+import {CheckoutComponentsListScreen} from './screens/CheckoutComponentsListScreen';
 import {LogBox} from 'react-native';
 import {
   SafeAreaProvider,
@@ -50,6 +51,11 @@ const App = () => {
           <Stack.Screen
             name="RawRetailOutlet"
             component={RawRetailOutletScreen}
+          />
+          <Stack.Screen
+            name="CheckoutComponentsList"
+            component={CheckoutComponentsListScreen}
+            options={{title: 'Checkout Components'}}
           />
           <Stack.Screen name="Klarna" component={HeadlessCheckoutKlarnaScreen} />
           <Stack.Screen

--- a/example/src/screens/CheckoutComponentsListScreen.tsx
+++ b/example/src/screens/CheckoutComponentsListScreen.tsx
@@ -1,0 +1,164 @@
+import React, {useState} from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {
+  PrimerCheckoutProvider,
+  PrimerCheckoutSheet,
+} from '@primer-io/react-native';
+import type {PrimerSettings} from '@primer-io/react-native';
+import {createClientSession} from '../network/api';
+import {appPaymentParameters} from '../models/IClientSessionRequestBody';
+import {customAppearanceMode} from './SettingsScreen';
+import {getPaymentHandlingStringVal} from '../network/Environment';
+import {STRIPE_ACH_PUBLISHABLE_KEY} from '../Keys';
+
+interface Example {
+  id: string;
+  title: string;
+  description: string;
+}
+
+const EXAMPLES: Example[] = [
+  {
+    id: 'default',
+    title: 'Default',
+    description: 'Basic checkout flow with payment method list',
+  },
+];
+
+export function CheckoutComponentsListScreen() {
+  const [loadingId, setLoadingId] = useState<string | null>(null);
+  const [checkoutToken, setCheckoutToken] = useState<string | null>(null);
+  const [sheetVisible, setSheetVisible] = useState(false);
+
+  const handleOpen = async (example: Example) => {
+    setLoadingId(example.id);
+    try {
+      const response = await createClientSession();
+      setCheckoutToken(response.clientToken);
+      setSheetVisible(true);
+    } catch (error) {
+      Alert.alert('Error', String(error));
+    } finally {
+      setLoadingId(null);
+    }
+  };
+
+  let settings: PrimerSettings = {
+    paymentHandling: getPaymentHandlingStringVal(
+      appPaymentParameters.paymentHandling,
+    ),
+    paymentMethodOptions: {
+      iOS: {
+        urlScheme: 'merchant://primer.io',
+      },
+      stripeOptions: {
+        publishableKey: STRIPE_ACH_PUBLISHABLE_KEY,
+        mandateData: {
+          merchantName: 'My Merchant Name',
+        },
+      },
+      googlePayOptions: {
+        isCaptureBillingAddressEnabled: true,
+        isExistingPaymentMethodRequired: false,
+        shippingAddressParameters: {isPhoneNumberRequired: true},
+        requireShippingMethod: false,
+        emailAddressRequired: true,
+      },
+    },
+    uiOptions: {
+      appearanceMode: customAppearanceMode,
+    },
+    debugOptions: {
+      is3DSSanityCheckEnabled: false,
+    },
+    clientSessionCachingEnabled: true,
+    apiVersion: '2.4',
+  };
+
+  if (appPaymentParameters.merchantName) {
+    settings.paymentMethodOptions!.applePayOptions = {
+      merchantIdentifier: 'merchant.checkout.team',
+      merchantName: appPaymentParameters.merchantName,
+    };
+  }
+
+  return (
+    <>
+      <ScrollView style={componentStyles.container}>
+        {EXAMPLES.map(example => {
+          const isLoading = loadingId === example.id;
+          return (
+            <TouchableOpacity
+              key={example.id}
+              style={componentStyles.item}
+              onPress={() => handleOpen(example)}
+              disabled={loadingId !== null}>
+              <View style={componentStyles.itemContent}>
+                <Text style={componentStyles.itemTitle}>{example.title}</Text>
+                <Text style={componentStyles.itemDescription}>
+                  {example.description}
+                </Text>
+              </View>
+              {isLoading && <ActivityIndicator />}
+            </TouchableOpacity>
+          );
+        })}
+      </ScrollView>
+      {checkoutToken !== null && (
+        <PrimerCheckoutProvider
+          clientToken={checkoutToken}
+          settings={settings}
+          onCheckoutComplete={checkoutData => {
+            console.log('Checkout complete:', checkoutData);
+            setSheetVisible(false);
+          }}
+          onError={error => {
+            console.error('Checkout error:', error);
+            Alert.alert('Checkout Error', error.errorId ?? 'Unknown error');
+          }}>
+          <PrimerCheckoutSheet
+            visible={sheetVisible}
+            onRequestDismiss={() => setSheetVisible(false)}
+            onDismiss={() => setCheckoutToken(null)}
+          />
+        </PrimerCheckoutProvider>
+      )}
+    </>
+  );
+}
+
+const componentStyles = StyleSheet.create({
+  container: {
+    backgroundColor: '#f5f5f5',
+    flex: 1,
+  },
+  item: {
+    alignItems: 'center',
+    backgroundColor: 'white',
+    borderBottomColor: '#e0e0e0',
+    borderBottomWidth: 1,
+    flexDirection: 'row',
+    padding: 16,
+  },
+  itemContent: {
+    flex: 1,
+  },
+  itemDescription: {
+    color: '#666',
+    fontSize: 14,
+    marginTop: 4,
+  },
+  itemTitle: {
+    color: '#212121',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/example/src/screens/SettingsScreen.tsx
+++ b/example/src/screens/SettingsScreen.tsx
@@ -1311,6 +1311,22 @@ const SettingsScreen = ({navigation}) => {
           style={{
             marginHorizontal: 24,
           }}>
+          <TouchableOpacity
+            style={{
+              ...styles.button,
+              marginTop: 12,
+              marginBottom: 8,
+              backgroundColor: '#2f98ff',
+            }}
+            onPress={() => {
+              updateAppPaymentParameters();
+              navigation.navigate('CheckoutComponentsList');
+            }}>
+            <Text style={{...styles.buttonText, color: 'white'}}>
+              Checkout Components
+            </Text>
+          </TouchableOpacity>
+
           {renderRequiredSettings()}
           {renderOptionalSettings()}
 

--- a/src/Components/PrimerCheckoutSheet.tsx
+++ b/src/Components/PrimerCheckoutSheet.tsx
@@ -1,0 +1,37 @@
+import { CheckoutSheet } from './internal/checkout-sheet/CheckoutSheet';
+import { CheckoutFlow } from './internal/checkout-flow/CheckoutFlow';
+
+export interface PrimerCheckoutSheetProps {
+  /** Whether the sheet is visible. Drives show/hide animation. */
+  visible: boolean;
+  /** Called when the sheet finishes its dismiss animation (fully hidden). */
+  onDismiss?: () => void;
+  /** Called when the user requests dismissal (backdrop tap, Android back). */
+  onRequestDismiss?: () => void;
+  /** Whether tapping the backdrop dismisses the sheet. Default: true. */
+  dismissOnBackdropPress?: boolean;
+}
+
+/**
+ * Pre-built checkout sheet that renders the full checkout flow:
+ * loading screen → method selection → payment forms.
+ *
+ * Must be rendered inside a PrimerCheckoutProvider.
+ */
+export function PrimerCheckoutSheet({
+  visible,
+  onDismiss,
+  onRequestDismiss,
+  dismissOnBackdropPress,
+}: PrimerCheckoutSheetProps) {
+  return (
+    <CheckoutSheet
+      visible={visible}
+      onDismiss={onDismiss}
+      onRequestDismiss={onRequestDismiss}
+      dismissOnBackdropPress={dismissOnBackdropPress}
+    >
+      <CheckoutFlow onCancel={onRequestDismiss} />
+    </CheckoutSheet>
+  );
+}

--- a/src/Components/PrimerPaymentMethodList.tsx
+++ b/src/Components/PrimerPaymentMethodList.tsx
@@ -1,0 +1,83 @@
+import { useMemo, useCallback } from 'react';
+import { ActivityIndicator, FlatList, View, StyleSheet } from 'react-native';
+import { useTheme } from './internal/theme';
+import type { PrimerTokens } from './internal/theme';
+import { usePaymentMethods } from './hooks/usePaymentMethods';
+import { PaymentMethodButton } from './internal/ui/PaymentMethodButton';
+import type { PaymentMethodItem } from './types/PaymentMethodTypes';
+import type { PrimerPaymentMethodListProps } from './types/PrimerPaymentMethodListTypes';
+
+export function PrimerPaymentMethodList({
+  data,
+  include,
+  exclude,
+  onSelect,
+  onLoad,
+  style,
+}: PrimerPaymentMethodListProps) {
+  const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+
+  const hook = usePaymentMethods(
+    data != null
+      ? {}
+      : {
+          include,
+          exclude,
+          onLoad,
+        }
+  );
+  const paymentMethods = data ?? hook.paymentMethods;
+  const isLoading = data != null ? false : hook.isLoading;
+
+  const handlePress = useCallback(
+    (item: PaymentMethodItem) => {
+      // TODO: Fire PAYMENT_METHOD_SELECTION analytics event when analytics bridge is available
+      onSelect(item);
+    },
+    [onSelect]
+  );
+
+  const Separator = useCallback(() => <View style={styles.separator} />, [styles.separator]);
+
+  if (isLoading) {
+    return (
+      <View style={[styles.centered, style]}>
+        <ActivityIndicator size="small" color={tokens.colors.primary} />
+      </View>
+    );
+  }
+
+  if (paymentMethods.length === 0) {
+    return <View style={style} />;
+  }
+
+  return (
+    <View style={style}>
+      <FlatList
+        data={paymentMethods}
+        keyExtractor={(item) => item.type}
+        renderItem={({ item }) => <PaymentMethodButton item={item} onPress={() => handlePress(item)} />}
+        ItemSeparatorComponent={Separator}
+        scrollEnabled={false}
+      />
+    </View>
+  );
+}
+
+function createStyles(tokens: PrimerTokens) {
+  const { spacing } = tokens;
+
+  /* eslint-disable react-native/no-unused-styles */
+  return StyleSheet.create({
+    centered: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingVertical: spacing.large,
+    },
+    separator: {
+      height: spacing.small,
+    },
+  });
+  /* eslint-enable react-native/no-unused-styles */
+}

--- a/src/Components/index.ts
+++ b/src/Components/index.ts
@@ -10,3 +10,7 @@ export type {
   UsePaymentMethodsOptions,
   UsePaymentMethodsReturn,
 } from './types/PaymentMethodTypes';
+export { PrimerPaymentMethodList } from './PrimerPaymentMethodList';
+export type { PrimerPaymentMethodListProps } from './types/PrimerPaymentMethodListTypes';
+export { PrimerCheckoutSheet } from './PrimerCheckoutSheet';
+export type { PrimerCheckoutSheetProps } from './PrimerCheckoutSheet';

--- a/src/Components/internal/checkout-flow/CheckoutFlow.tsx
+++ b/src/Components/internal/checkout-flow/CheckoutFlow.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import { NavigationProvider } from '../navigation/NavigationProvider';
+import { NavigationContainer } from '../navigation/NavigationContainer';
+import { useNavigation } from '../navigation/useNavigation';
+import { CheckoutRoute } from '../navigation/types';
+import type { CheckoutRoute as CheckoutRouteType } from '../navigation/types';
+import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
+import { LoadingScreen } from '../screens/LoadingScreen';
+import { MethodSelectionScreen } from '../screens/MethodSelectionScreen';
+import { ErrorScreen } from '../screens/ErrorScreen';
+import { CheckoutFlowContext } from './CheckoutFlowContext';
+
+const screenMap: Partial<Record<CheckoutRouteType, React.ComponentType>> = {
+  [CheckoutRoute.splash]: LoadingScreen,
+  [CheckoutRoute.methodSelection]: MethodSelectionScreen,
+  [CheckoutRoute.error]: ErrorScreen,
+};
+
+/**
+ * Watches checkout readiness and navigates from loading to method selection.
+ * Renders nothing — purely a side-effect component.
+ */
+function ReadinessTransitioner() {
+  const { isReady, isLoadingResources, error } = usePrimerCheckout();
+  const { replace } = useNavigation();
+  const hasTransitioned = useRef(false);
+
+  useEffect(() => {
+    if (hasTransitioned.current) return;
+
+    if (error) {
+      hasTransitioned.current = true;
+      replace(CheckoutRoute.error, { error });
+      return;
+    }
+
+    if (isReady && !isLoadingResources) {
+      hasTransitioned.current = true;
+      replace(CheckoutRoute.methodSelection);
+    }
+  }, [isReady, isLoadingResources, error, replace]);
+
+  return null;
+}
+
+export interface CheckoutFlowProps {
+  /** Called when the user requests to cancel/close the checkout flow */
+  onCancel?: () => void;
+}
+
+export function CheckoutFlow({ onCancel }: CheckoutFlowProps = {}) {
+  const contextValue = useMemo(() => ({ onCancel: onCancel ?? (() => {}) }), [onCancel]);
+
+  return (
+    <CheckoutFlowContext.Provider value={contextValue}>
+      <NavigationProvider initialRoute={CheckoutRoute.splash}>
+        <ReadinessTransitioner />
+        <NavigationContainer screenMap={screenMap} />
+      </NavigationProvider>
+    </CheckoutFlowContext.Provider>
+  );
+}

--- a/src/Components/internal/checkout-flow/CheckoutFlowContext.ts
+++ b/src/Components/internal/checkout-flow/CheckoutFlowContext.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react';
+
+export interface CheckoutFlowContextValue {
+  /** Called when the user requests to cancel/close the checkout flow */
+  onCancel: () => void;
+}
+
+export const CheckoutFlowContext = createContext<CheckoutFlowContextValue | null>(null);
+
+export function useCheckoutFlow(): CheckoutFlowContextValue {
+  const context = useContext(CheckoutFlowContext);
+  if (!context) {
+    throw new Error('useCheckoutFlow must be used within a CheckoutFlow');
+  }
+  return context;
+}

--- a/src/Components/internal/checkout-flow/index.ts
+++ b/src/Components/internal/checkout-flow/index.ts
@@ -1,0 +1,1 @@
+export { CheckoutFlow } from './CheckoutFlow';

--- a/src/Components/internal/checkout-sheet/CheckoutSheet.tsx
+++ b/src/Components/internal/checkout-sheet/CheckoutSheet.tsx
@@ -117,8 +117,8 @@ export function CheckoutSheet({
     });
   }, [dragValue, sheetHeight, showAnimValue, onDismiss, onRequestDismiss]);
 
-  // Handle visible prop changes
-  const prevVisibleRef = useRef(visible);
+  // Handle visible prop changes (including initial mount with visible=true)
+  const prevVisibleRef = useRef(false);
   useEffect(() => {
     if (visible && !prevVisibleRef.current) {
       setHeightRatioState(DEFAULT_HEIGHT_RATIO);
@@ -128,7 +128,7 @@ export function CheckoutSheet({
       animateOut();
     }
     prevVisibleRef.current = visible;
-  }, [visible, modalVisible, animateOut]);
+  }, [visible, modalVisible, animateOut, heightOffsetValue, screenHeight]);
 
   const handleShow = useCallback(() => {
     showAnimValue.setValue(0);

--- a/src/Components/internal/screens/MethodSelectionScreen.tsx
+++ b/src/Components/internal/screens/MethodSelectionScreen.tsx
@@ -1,0 +1,88 @@
+import { useMemo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { usePaymentMethods } from '../../hooks/usePaymentMethods';
+import { PrimerPaymentMethodList } from '../../PrimerPaymentMethodList';
+import { useCheckoutFlow } from '../checkout-flow/CheckoutFlowContext';
+import { useLocalization } from '../localization';
+import { NavigationHeader } from '../navigation/NavigationHeader';
+import { useTheme } from '../theme';
+import { PAYMENT_METHOD_BUTTON_HEIGHT } from '../ui/PaymentMethodButton';
+import { useBottomSafeArea } from './useBottomSafeArea';
+import { useStatusScreenHeight } from './useStatusScreenHeight';
+
+import type { TextStyle } from 'react-native';
+import type { PrimerTokens } from '../theme';
+import type { PaymentMethodItem } from '../../types/PaymentMethodTypes';
+
+export function MethodSelectionScreen() {
+  const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+  const { t } = useLocalization();
+  const { onCancel } = useCheckoutFlow();
+  const { paymentMethods } = usePaymentMethods();
+
+  const methodCount = paymentMethods.length;
+  const buttonGap = tokens.spacing.small;
+  const listHeight = methodCount > 0 ? methodCount * PAYMENT_METHOD_BUTTON_HEIGHT + (methodCount - 1) * buttonGap : 0;
+  const rawBottomInset = useBottomSafeArea();
+  const bottomInset = Math.max(rawBottomInset, tokens.spacing.large);
+  // Container paddingTop + NavigationHeader (singleRow paddingVertical + titleXLarge lineHeight)
+  //   + content paddingTop + sectionTitle lineHeight + content gap + list + bottom safe area
+  //   + spacing.xlarge for the sheet's drag-handle area (not part of screen content).
+  const headerArea = tokens.spacing.xxsmall * 2 + tokens.typography.titleXLarge.lineHeight;
+  const titleArea = tokens.typography.titleLarge.lineHeight;
+  const sheetHeight =
+    tokens.spacing.large +
+    headerArea +
+    tokens.spacing.xxlarge +
+    titleArea +
+    tokens.spacing.medium +
+    listHeight +
+    bottomInset +
+    tokens.spacing.xlarge;
+  useStatusScreenHeight(sheetHeight);
+
+  const handleSelect = (_method: PaymentMethodItem) => {
+    // Payment form navigation to be wired when forms are implemented
+  };
+
+  return (
+    <View style={[styles.container, { paddingBottom: bottomInset }]}>
+      <NavigationHeader
+        title={t('primer_checkout_title')}
+        rightAction={{ label: t('primer_common_button_cancel'), onPress: onCancel }}
+      />
+      <View style={styles.content}>
+        <Text style={styles.sectionTitle}>{t('primer_payment_selection_header')}</Text>
+        <PrimerPaymentMethodList data={paymentMethods} onSelect={handleSelect} />
+      </View>
+    </View>
+  );
+}
+
+function createStyles(tokens: PrimerTokens) {
+  const { colors, spacing, typography } = tokens;
+
+  /* eslint-disable react-native/no-unused-styles */
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      paddingTop: spacing.large,
+    },
+    content: {
+      gap: spacing.medium,
+      paddingHorizontal: spacing.large,
+      paddingTop: spacing.xxlarge,
+    },
+    sectionTitle: {
+      color: colors.textPrimary,
+      fontFamily: typography.titleLarge.fontFamily,
+      fontSize: typography.titleLarge.fontSize,
+      fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],
+      letterSpacing: typography.titleLarge.letterSpacing,
+      lineHeight: typography.titleLarge.lineHeight,
+    },
+  });
+  /* eslint-enable react-native/no-unused-styles */
+}

--- a/src/Components/internal/screens/index.ts
+++ b/src/Components/internal/screens/index.ts
@@ -3,3 +3,4 @@ export type { StatusScreenLayoutProps } from './StatusScreenLayout';
 export { LoadingScreen } from './LoadingScreen';
 export { SuccessScreen } from './SuccessScreen';
 export { ErrorScreen } from './ErrorScreen';
+export { MethodSelectionScreen } from './MethodSelectionScreen';

--- a/src/Components/internal/ui/PaymentMethodButton.tsx
+++ b/src/Components/internal/ui/PaymentMethodButton.tsx
@@ -1,0 +1,115 @@
+import { useMemo } from 'react';
+import { Image, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import type { TextStyle } from 'react-native';
+import { useTheme } from '../theme';
+import type { PrimerTokens } from '../theme';
+import { useLocalization } from '../localization';
+import type { PaymentMethodButtonProps } from '../../types/PrimerPaymentMethodListTypes';
+
+export const PAYMENT_METHOD_BUTTON_HEIGHT = 44;
+const BUTTON_HEIGHT = PAYMENT_METHOD_BUTTON_HEIGHT;
+
+export function PaymentMethodButton({ item, onPress }: PaymentMethodButtonProps) {
+  const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+  const { t } = useLocalization();
+
+  const isCard = item.type === 'PAYMENT_CARD';
+  // Branded button: full-color background + logo (PayPal, Klarna, iDEAL…).
+  // PAYMENT_CARD must never take this path — it always renders outlined with the
+  // "Pay with card" label, even if the native resource exposes a logo/background.
+  const isColorStyle = !isCard && item.backgroundColor != null && item.logo != null;
+  // Only the flat surcharge has a single amount we can display on the button.
+  // `perNetwork` (PAYMENT_CARD) depends on the card the user enters — skip here.
+  const surchargeLabel = item.surcharge?.kind === 'flat' ? `+${item.surcharge.amount}` : null;
+
+  if (isCard) {
+    return (
+      <TouchableOpacity style={[styles.button, styles.outlinedButton]} onPress={onPress} activeOpacity={0.7}>
+        {item.logo != null && <Image source={{ uri: item.logo }} style={styles.icon} resizeMode="contain" />}
+        <Text style={styles.outlinedText}>{t('primer_card_form_title')}</Text>
+        {surchargeLabel != null && <Text style={styles.surchargeDark}>{surchargeLabel}</Text>}
+      </TouchableOpacity>
+    );
+  }
+
+  if (isColorStyle) {
+    return (
+      <TouchableOpacity
+        style={[styles.button, { backgroundColor: item.backgroundColor }]}
+        onPress={onPress}
+        activeOpacity={0.7}
+      >
+        <Image source={{ uri: item.logo }} style={styles.logo} resizeMode="contain" />
+        {surchargeLabel != null && <Text style={styles.surchargeLight}>{surchargeLabel}</Text>}
+      </TouchableOpacity>
+    );
+  }
+
+  return (
+    <TouchableOpacity style={[styles.button, styles.outlinedButton]} onPress={onPress} activeOpacity={0.7}>
+      {item.logo != null && <Image source={{ uri: item.logo }} style={styles.logo} resizeMode="contain" />}
+      {surchargeLabel != null && <Text style={styles.surchargeDark}>{surchargeLabel}</Text>}
+    </TouchableOpacity>
+  );
+}
+
+function createStyles(tokens: PrimerTokens) {
+  const { colors, spacing, radii, borders, typography } = tokens;
+
+  /* eslint-disable react-native/no-unused-styles */
+  return StyleSheet.create({
+    button: {
+      alignItems: 'center',
+      borderRadius: radii.medium,
+      flexDirection: 'row',
+      height: BUTTON_HEIGHT,
+      justifyContent: 'center',
+      overflow: 'hidden',
+      paddingHorizontal: spacing.small,
+      width: '100%',
+    },
+    icon: {
+      height: 20,
+      marginRight: spacing.small,
+      width: 20,
+    },
+    logo: {
+      height: BUTTON_HEIGHT * 0.5,
+      width: '40%',
+    },
+    outlinedButton: {
+      backgroundColor: colors.background,
+      borderColor: colors.border,
+      borderWidth: borders.default,
+    },
+    outlinedText: {
+      color: colors.textPrimary,
+      fontFamily: typography.titleLarge.fontFamily,
+      fontSize: typography.titleLarge.fontSize,
+      fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],
+      letterSpacing: typography.titleLarge.letterSpacing,
+      lineHeight: typography.titleLarge.lineHeight,
+      textAlign: 'center',
+    },
+    surchargeDark: {
+      color: colors.textSecondary,
+      fontFamily: typography.bodySmall.fontFamily,
+      fontSize: typography.bodySmall.fontSize,
+      fontWeight: typography.bodySmall.fontWeight as TextStyle['fontWeight'],
+      marginLeft: spacing.small,
+      position: 'absolute',
+      right: spacing.small,
+    },
+    surchargeLight: {
+      color: colors.background,
+      fontFamily: typography.bodySmall.fontFamily,
+      fontSize: typography.bodySmall.fontSize,
+      fontWeight: typography.bodySmall.fontWeight as TextStyle['fontWeight'],
+      opacity: 0.8,
+      position: 'absolute',
+      right: spacing.small,
+    },
+  });
+  /* eslint-enable react-native/no-unused-styles */
+}

--- a/src/Components/types/PrimerPaymentMethodListTypes.ts
+++ b/src/Components/types/PrimerPaymentMethodListTypes.ts
@@ -1,0 +1,24 @@
+import type { ViewStyle } from 'react-native';
+import type { PaymentMethodItem } from './PaymentMethodTypes';
+
+export interface PrimerPaymentMethodListProps {
+  /** Pre-fetched payment methods. When provided, the list skips its internal usePaymentMethods() call. */
+  data?: PaymentMethodItem[];
+  /** Whitelist: only show these payment method types */
+  include?: string[];
+  /** Blacklist: hide these payment method types */
+  exclude?: string[];
+  /** Called when a payment method button is tapped */
+  onSelect: (method: PaymentMethodItem) => void;
+  /** Called when payment methods finish loading */
+  onLoad?: (methods: PaymentMethodItem[]) => void;
+  /** Container style override */
+  style?: ViewStyle;
+}
+
+export interface PaymentMethodButtonProps {
+  /** The payment method data to render */
+  item: PaymentMethodItem;
+  /** Tap handler */
+  onPress: () => void;
+}

--- a/src/__tests__/components/PrimerCheckoutProvider.test.tsx
+++ b/src/__tests__/components/PrimerCheckoutProvider.test.tsx
@@ -1,6 +1,11 @@
 // @ts-expect-error -- React 19 concurrent act environment
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
+jest.mock('../../specs/NativePrimer', () => ({
+  __esModule: true,
+  default: {},
+}));
+
 jest.mock(
   'react-native',
   () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -140,6 +140,10 @@ export type {
   UsePaymentMethodsOptions,
   UsePaymentMethodsReturn,
 } from './Components';
+export { PrimerPaymentMethodList } from './Components';
+export type { PrimerPaymentMethodListProps } from './Components';
+export { PrimerCheckoutSheet } from './Components';
+export type { PrimerCheckoutSheetProps } from './Components';
 
 export { useLocalization, translate, hasLocale } from './Components/internal/localization';
 export type { TranslationParams, LocalizationResult } from './Components/internal/localization';


### PR DESCRIPTION
## Summary

Drop-in UI for the new Checkout Components SDK.

- `PrimerPaymentMethodList` — renders payment method buttons from `usePaymentMethods()`. Card renders outlined with "Pay with card"; other methods render as filled logo buttons, with per-method surcharge and include/exclude filtering. Pass `data` to bypass the hook when methods are already fetched.
- `PrimerCheckoutSheet` — opinionated wrapper that composes `CheckoutSheet` with `CheckoutFlow` so merchants get the whole thing in one component.
- `CheckoutFlow` — shows `LoadingScreen` until the SDK is ready, then transitions to `MethodSelectionScreen`.
- `MethodSelectionScreen` — localized "Choose payment method" header, auto-sizing sheet height, bottom-inset and drag-handle spacing reserved.
- `CheckoutSheet` — fixes the open animation being skipped when the component mounts with `visible=true` (`prevVisibleRef` was seeded from the current value).
- Example app: new "Checkout Components" screen creates a session and opens the sheet.

## Jira

[ACC-6492](https://primerapi.atlassian.net/browse/ACC-6492)

## Test plan

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test` — 85/85
- [ ] Tap "Checkout Components" → "Default" → sheet opens with loading, then shows method list
- [ ] Cancel button dismisses the sheet
- [ ] Backdrop tap dismisses the sheet
- [ ] Sheet height scales to the number of methods

[ACC-6492]: https://primerapi.atlassian.net/browse/ACC-6492