### PR TITLE
feat: add custom payment method list example (ACC-6492)

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -15,6 +15,7 @@ import HeadlessCheckoutKlarnaScreen from './screens/HeadlessCheckoutKlarnaScreen
 import HeadlessCheckoutWithRedirect from './screens/HeadlessCheckoutWithRedirect';
 import HeadlessCheckoutStripeAchScreen from './screens/HeadlessCheckoutStripeAchScreen';
 import LocalizationDebugScreen from './screens/LocalizationDebugScreen';
+import {CheckoutComponentsListScreen} from './screens/CheckoutComponentsListScreen';
 import {LogBox} from 'react-native';
 import {
   SafeAreaProvider,
@@ -50,6 +51,11 @@ const App = () => {
           <Stack.Screen
             name="RawRetailOutlet"
             component={RawRetailOutletScreen}
+          />
+          <Stack.Screen
+            name="CheckoutComponentsList"
+            component={CheckoutComponentsListScreen}
+            options={{title: 'Checkout Components'}}
           />
           <Stack.Screen name="Klarna" component={HeadlessCheckoutKlarnaScreen} />
           <Stack.Screen

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -16,6 +16,7 @@ import HeadlessCheckoutWithRedirect from './screens/HeadlessCheckoutWithRedirect
 import HeadlessCheckoutStripeAchScreen from './screens/HeadlessCheckoutStripeAchScreen';
 import LocalizationDebugScreen from './screens/LocalizationDebugScreen';
 import {CheckoutComponentsListScreen} from './screens/CheckoutComponentsListScreen';
+import {CustomPaymentMethodListScreen} from './screens/CustomPaymentMethodListScreen';
 import {LogBox} from 'react-native';
 import {
   SafeAreaProvider,
@@ -56,6 +57,11 @@ const App = () => {
             name="CheckoutComponentsList"
             component={CheckoutComponentsListScreen}
             options={{title: 'Checkout Components'}}
+          />
+          <Stack.Screen
+            name="CustomPaymentMethodList"
+            component={CustomPaymentMethodListScreen}
+            options={{title: 'Custom Payment List'}}
           />
           <Stack.Screen name="Klarna" component={HeadlessCheckoutKlarnaScreen} />
           <Stack.Screen

--- a/example/src/screens/CheckoutComponentsListScreen.tsx
+++ b/example/src/screens/CheckoutComponentsListScreen.tsx
@@ -29,11 +29,16 @@ const EXAMPLES: Example[] = [
   {
     id: 'default',
     title: 'Default',
-    description: 'Basic checkout flow with payment method list',
+    description: 'Drop-in checkout sheet with payment method list',
+  },
+  {
+    id: 'custom',
+    title: 'Custom Payment List',
+    description: 'Custom UI using usePaymentMethods() hook',
   },
 ];
 
-export function CheckoutComponentsListScreen() {
+export function CheckoutComponentsListScreen({navigation}: any) {
   const [loadingId, setLoadingId] = useState<string | null>(null);
   const [checkoutToken, setCheckoutToken] = useState<string | null>(null);
   const [sheetVisible, setSheetVisible] = useState(false);
@@ -42,8 +47,14 @@ export function CheckoutComponentsListScreen() {
     setLoadingId(example.id);
     try {
       const response = await createClientSession();
-      setCheckoutToken(response.clientToken);
-      setSheetVisible(true);
+      if (example.id === 'custom') {
+        navigation.navigate('CustomPaymentMethodList', {
+          clientToken: response.clientToken,
+        });
+      } else {
+        setCheckoutToken(response.clientToken);
+        setSheetVisible(true);
+      }
     } catch (error) {
       Alert.alert('Error', String(error));
     } finally {

--- a/example/src/screens/CheckoutComponentsListScreen.tsx
+++ b/example/src/screens/CheckoutComponentsListScreen.tsx
@@ -1,0 +1,164 @@
+import React, {useState} from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {
+  PrimerCheckoutProvider,
+  PrimerCheckoutSheet,
+} from '@primer-io/react-native';
+import type {PrimerSettings} from '@primer-io/react-native';
+import {createClientSession} from '../network/api';
+import {appPaymentParameters} from '../models/IClientSessionRequestBody';
+import {customAppearanceMode} from './SettingsScreen';
+import {getPaymentHandlingStringVal} from '../network/Environment';
+import {STRIPE_ACH_PUBLISHABLE_KEY} from '../Keys';
+
+interface Example {
+  id: string;
+  title: string;
+  description: string;
+}
+
+const EXAMPLES: Example[] = [
+  {
+    id: 'default',
+    title: 'Default',
+    description: 'Basic checkout flow with payment method list',
+  },
+];
+
+export function CheckoutComponentsListScreen() {
+  const [loadingId, setLoadingId] = useState<string | null>(null);
+  const [checkoutToken, setCheckoutToken] = useState<string | null>(null);
+  const [sheetVisible, setSheetVisible] = useState(false);
+
+  const handleOpen = async (example: Example) => {
+    setLoadingId(example.id);
+    try {
+      const response = await createClientSession();
+      setCheckoutToken(response.clientToken);
+      setSheetVisible(true);
+    } catch (error) {
+      Alert.alert('Error', String(error));
+    } finally {
+      setLoadingId(null);
+    }
+  };
+
+  let settings: PrimerSettings = {
+    paymentHandling: getPaymentHandlingStringVal(
+      appPaymentParameters.paymentHandling,
+    ),
+    paymentMethodOptions: {
+      iOS: {
+        urlScheme: 'merchant://primer.io',
+      },
+      stripeOptions: {
+        publishableKey: STRIPE_ACH_PUBLISHABLE_KEY,
+        mandateData: {
+          merchantName: 'My Merchant Name',
+        },
+      },
+      googlePayOptions: {
+        isCaptureBillingAddressEnabled: true,
+        isExistingPaymentMethodRequired: false,
+        shippingAddressParameters: {isPhoneNumberRequired: true},
+        requireShippingMethod: false,
+        emailAddressRequired: true,
+      },
+    },
+    uiOptions: {
+      appearanceMode: customAppearanceMode,
+    },
+    debugOptions: {
+      is3DSSanityCheckEnabled: false,
+    },
+    clientSessionCachingEnabled: true,
+    apiVersion: '2.4',
+  };
+
+  if (appPaymentParameters.merchantName) {
+    settings.paymentMethodOptions!.applePayOptions = {
+      merchantIdentifier: 'merchant.checkout.team',
+      merchantName: appPaymentParameters.merchantName,
+    };
+  }
+
+  return (
+    <>
+      <ScrollView style={componentStyles.container}>
+        {EXAMPLES.map(example => {
+          const isLoading = loadingId === example.id;
+          return (
+            <TouchableOpacity
+              key={example.id}
+              style={componentStyles.item}
+              onPress={() => handleOpen(example)}
+              disabled={loadingId !== null}>
+              <View style={componentStyles.itemContent}>
+                <Text style={componentStyles.itemTitle}>{example.title}</Text>
+                <Text style={componentStyles.itemDescription}>
+                  {example.description}
+                </Text>
+              </View>
+              {isLoading && <ActivityIndicator />}
+            </TouchableOpacity>
+          );
+        })}
+      </ScrollView>
+      {checkoutToken !== null && (
+        <PrimerCheckoutProvider
+          clientToken={checkoutToken}
+          settings={settings}
+          onCheckoutComplete={checkoutData => {
+            console.log('Checkout complete:', checkoutData);
+            setSheetVisible(false);
+          }}
+          onError={error => {
+            console.error('Checkout error:', error);
+            Alert.alert('Checkout Error', error.errorId ?? 'Unknown error');
+          }}>
+          <PrimerCheckoutSheet
+            visible={sheetVisible}
+            onRequestDismiss={() => setSheetVisible(false)}
+            onDismiss={() => setCheckoutToken(null)}
+          />
+        </PrimerCheckoutProvider>
+      )}
+    </>
+  );
+}
+
+const componentStyles = StyleSheet.create({
+  container: {
+    backgroundColor: '#f5f5f5',
+    flex: 1,
+  },
+  item: {
+    alignItems: 'center',
+    backgroundColor: 'white',
+    borderBottomColor: '#e0e0e0',
+    borderBottomWidth: 1,
+    flexDirection: 'row',
+    padding: 16,
+  },
+  itemContent: {
+    flex: 1,
+  },
+  itemDescription: {
+    color: '#666',
+    fontSize: 14,
+    marginTop: 4,
+  },
+  itemTitle: {
+    color: '#212121',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/example/src/screens/CustomPaymentMethodListScreen.tsx
+++ b/example/src/screens/CustomPaymentMethodListScreen.tsx
@@ -1,0 +1,267 @@
+import React from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  Image,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {
+  PrimerCheckoutProvider,
+  usePaymentMethods,
+} from '@primer-io/react-native';
+import type {
+  PaymentMethodItem,
+  PrimerSettings,
+} from '@primer-io/react-native';
+import {appPaymentParameters} from '../models/IClientSessionRequestBody';
+import {customAppearanceMode} from './SettingsScreen';
+import {getPaymentHandlingStringVal} from '../network/Environment';
+import {STRIPE_ACH_PUBLISHABLE_KEY} from '../Keys';
+
+function CustomPaymentMethodContent() {
+  const {paymentMethods, isLoading, error, selectedMethod, selectMethod} =
+    usePaymentMethods();
+
+  if (isLoading) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" />
+        <Text style={styles.loadingText}>Loading payment methods...</Text>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.errorText}>{error.message}</Text>
+      </View>
+    );
+  }
+
+  if (paymentMethods.length === 0) {
+    return (
+      <View style={styles.centered}>
+        <Text style={styles.emptyText}>No payment methods available</Text>
+      </View>
+    );
+  }
+
+  const renderItem = ({item}: {item: PaymentMethodItem}) => {
+    const isSelected = selectedMethod?.type === item.type;
+
+    return (
+      <TouchableOpacity
+        style={[styles.methodItem, isSelected && styles.methodItemSelected]}
+        onPress={() => selectMethod(item)}
+        activeOpacity={0.7}>
+        <View style={styles.methodInfo}>
+          {item.logo != null && (
+            <Image
+              source={{uri: item.logo}}
+              style={styles.methodLogo}
+              resizeMode="contain"
+            />
+          )}
+          <View style={styles.methodText}>
+            <Text style={styles.methodName}>{item.name}</Text>
+            <Text style={styles.methodType}>{item.type}</Text>
+          </View>
+        </View>
+        <View style={styles.methodRight}>
+          {item.surcharge != null && (
+            <Text style={styles.surcharge}>+{item.surcharge}</Text>
+          )}
+          {isSelected && <Text style={styles.checkmark}>✓</Text>}
+        </View>
+      </TouchableOpacity>
+    );
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Custom Payment Method List</Text>
+      <Text style={styles.subtitle}>
+        Built with usePaymentMethods() hook + plain React Native components
+      </Text>
+      <FlatList
+        data={paymentMethods}
+        keyExtractor={item => item.type}
+        renderItem={renderItem}
+        contentContainerStyle={styles.list}
+      />
+      {selectedMethod != null && (
+        <TouchableOpacity
+          style={styles.footer}
+          activeOpacity={0.7}
+          onPress={() => {
+            Alert.alert(
+              'Pay',
+              `Initiate payment with ${selectedMethod.name}.\n\nIn a real app, you would start the payment flow here using the Headless Universal Checkout managers.`,
+            );
+          }}>
+          <Text style={styles.footerText}>
+            Pay with {selectedMethod.name}
+          </Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+export function CustomPaymentMethodListScreen({route}: any) {
+  const {clientToken} = route.params;
+
+  let settings: PrimerSettings = {
+    paymentHandling: getPaymentHandlingStringVal(
+      appPaymentParameters.paymentHandling,
+    ),
+    paymentMethodOptions: {
+      iOS: {
+        urlScheme: 'merchant://primer.io',
+      },
+      stripeOptions: {
+        publishableKey: STRIPE_ACH_PUBLISHABLE_KEY,
+        mandateData: {
+          merchantName: 'My Merchant Name',
+        },
+      },
+      googlePayOptions: {
+        isCaptureBillingAddressEnabled: true,
+        isExistingPaymentMethodRequired: false,
+        shippingAddressParameters: {isPhoneNumberRequired: true},
+        requireShippingMethod: false,
+        emailAddressRequired: true,
+      },
+    },
+    uiOptions: {
+      appearanceMode: customAppearanceMode,
+    },
+    debugOptions: {
+      is3DSSanityCheckEnabled: false,
+    },
+    clientSessionCachingEnabled: true,
+    apiVersion: '2.4',
+  };
+
+  if (appPaymentParameters.merchantName) {
+    settings.paymentMethodOptions!.applePayOptions = {
+      merchantIdentifier: 'merchant.checkout.team',
+      merchantName: appPaymentParameters.merchantName,
+    };
+  }
+
+  return (
+    <PrimerCheckoutProvider clientToken={clientToken} settings={settings}>
+      <CustomPaymentMethodContent />
+    </PrimerCheckoutProvider>
+  );
+}
+
+const styles = StyleSheet.create({
+  centered: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+    padding: 24,
+  },
+  checkmark: {
+    color: '#2f98ff',
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  container: {
+    backgroundColor: '#f5f5f5',
+    flex: 1,
+  },
+  emptyText: {
+    color: '#666',
+    fontSize: 16,
+  },
+  errorText: {
+    color: '#d32f2f',
+    fontSize: 16,
+    textAlign: 'center',
+  },
+  footer: {
+    backgroundColor: '#2f98ff',
+    padding: 16,
+  },
+  footerText: {
+    color: 'white',
+    fontSize: 16,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  list: {
+    padding: 16,
+  },
+  loadingText: {
+    color: '#666',
+    fontSize: 14,
+    marginTop: 12,
+  },
+  methodInfo: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    flex: 1,
+  },
+  methodItem: {
+    alignItems: 'center',
+    backgroundColor: 'white',
+    borderColor: '#e0e0e0',
+    borderRadius: 12,
+    borderWidth: 1,
+    flexDirection: 'row',
+    marginBottom: 8,
+    padding: 16,
+  },
+  methodItemSelected: {
+    borderColor: '#2f98ff',
+    borderWidth: 2,
+  },
+  methodLogo: {
+    height: 32,
+    marginRight: 12,
+    width: 32,
+  },
+  methodName: {
+    color: '#212121',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  methodRight: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 8,
+  },
+  methodText: {
+    flex: 1,
+  },
+  methodType: {
+    color: '#999',
+    fontSize: 12,
+    marginTop: 2,
+  },
+  subtitle: {
+    color: '#666',
+    fontSize: 13,
+    paddingHorizontal: 16,
+    paddingBottom: 8,
+  },
+  surcharge: {
+    color: '#666',
+    fontSize: 13,
+  },
+  title: {
+    color: '#212121',
+    fontSize: 20,
+    fontWeight: '700',
+    padding: 16,
+    paddingBottom: 4,
+  },
+});

--- a/example/src/screens/SettingsScreen.tsx
+++ b/example/src/screens/SettingsScreen.tsx
@@ -1311,6 +1311,22 @@ const SettingsScreen = ({navigation}) => {
           style={{
             marginHorizontal: 24,
           }}>
+          <TouchableOpacity
+            style={{
+              ...styles.button,
+              marginTop: 12,
+              marginBottom: 8,
+              backgroundColor: '#2f98ff',
+            }}
+            onPress={() => {
+              updateAppPaymentParameters();
+              navigation.navigate('CheckoutComponentsList');
+            }}>
+            <Text style={{...styles.buttonText, color: 'white'}}>
+              Checkout Components
+            </Text>
+          </TouchableOpacity>
+
           {renderRequiredSettings()}
           {renderOptionalSettings()}
 

--- a/src/Components/PrimerCheckoutSheet.tsx
+++ b/src/Components/PrimerCheckoutSheet.tsx
@@ -1,0 +1,37 @@
+import { CheckoutSheet } from './internal/checkout-sheet/CheckoutSheet';
+import { CheckoutFlow } from './internal/checkout-flow/CheckoutFlow';
+
+export interface PrimerCheckoutSheetProps {
+  /** Whether the sheet is visible. Drives show/hide animation. */
+  visible: boolean;
+  /** Called when the sheet finishes its dismiss animation (fully hidden). */
+  onDismiss?: () => void;
+  /** Called when the user requests dismissal (backdrop tap, Android back). */
+  onRequestDismiss?: () => void;
+  /** Whether tapping the backdrop dismisses the sheet. Default: true. */
+  dismissOnBackdropPress?: boolean;
+}
+
+/**
+ * Pre-built checkout sheet that renders the full checkout flow:
+ * loading screen → method selection → payment forms.
+ *
+ * Must be rendered inside a PrimerCheckoutProvider.
+ */
+export function PrimerCheckoutSheet({
+  visible,
+  onDismiss,
+  onRequestDismiss,
+  dismissOnBackdropPress,
+}: PrimerCheckoutSheetProps) {
+  return (
+    <CheckoutSheet
+      visible={visible}
+      onDismiss={onDismiss}
+      onRequestDismiss={onRequestDismiss}
+      dismissOnBackdropPress={dismissOnBackdropPress}
+    >
+      <CheckoutFlow onCancel={onRequestDismiss} />
+    </CheckoutSheet>
+  );
+}

--- a/src/Components/PrimerPaymentMethodList.tsx
+++ b/src/Components/PrimerPaymentMethodList.tsx
@@ -1,0 +1,115 @@
+import { useState, useMemo, useCallback } from 'react';
+import { ActivityIndicator, FlatList, Text, TouchableOpacity, View, StyleSheet } from 'react-native';
+import type { TextStyle } from 'react-native';
+import { useTheme } from './internal/theme';
+import type { PrimerTokens } from './internal/theme';
+import { usePaymentMethods } from './hooks/usePaymentMethods';
+import { PaymentMethodButton } from './internal/ui/PaymentMethodButton';
+import type { PaymentMethodItem } from './types/PaymentMethodTypes';
+import type { PrimerPaymentMethodListProps } from './types/PrimerPaymentMethodListTypes';
+
+export function PrimerPaymentMethodList({
+  data,
+  include,
+  exclude,
+  showCardFirst,
+  collapsedCount,
+  onSelect,
+  onLoad,
+  style,
+}: PrimerPaymentMethodListProps) {
+  const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const hook = usePaymentMethods(
+    data != null
+      ? {}
+      : {
+          include,
+          exclude,
+          showCardFirst,
+          onLoad,
+        }
+  );
+  const paymentMethods = data ?? hook.paymentMethods;
+  const isLoading = data != null ? false : hook.isLoading;
+
+  const handlePress = useCallback(
+    (item: PaymentMethodItem) => {
+      // TODO: Fire PAYMENT_METHOD_SELECTION analytics event when analytics bridge is available
+      onSelect(item);
+    },
+    [onSelect]
+  );
+
+  const toggleExpanded = useCallback(() => {
+    setIsExpanded((prev) => !prev);
+  }, []);
+
+  const Separator = useCallback(() => <View style={styles.separator} />, [styles.separator]);
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <View style={[styles.centered, style]}>
+        <ActivityIndicator size="small" color={tokens.colors.primary} />
+      </View>
+    );
+  }
+
+  // Empty state
+  if (paymentMethods.length === 0) {
+    return <View style={style} />;
+  }
+
+  // Determine visible methods based on collapse state
+  const shouldCollapse = collapsedCount != null && paymentMethods.length > collapsedCount;
+  const visibleMethods = shouldCollapse && !isExpanded ? paymentMethods.slice(0, collapsedCount) : paymentMethods;
+
+  return (
+    <View style={style}>
+      <FlatList
+        data={visibleMethods}
+        keyExtractor={(item) => item.type}
+        renderItem={({ item }) => <PaymentMethodButton item={item} onPress={() => handlePress(item)} />}
+        ItemSeparatorComponent={Separator}
+        scrollEnabled={false}
+      />
+      {shouldCollapse && (
+        <TouchableOpacity onPress={toggleExpanded} style={styles.toggleButton} activeOpacity={0.7}>
+          <Text style={styles.toggleText}>{isExpanded ? 'Show less' : 'Show more'}</Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+function createStyles(tokens: PrimerTokens) {
+  const { colors, spacing, typography } = tokens;
+
+  /* eslint-disable react-native/no-unused-styles */
+  return StyleSheet.create({
+    centered: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingVertical: spacing.large,
+    },
+    separator: {
+      height: spacing.small,
+    },
+    toggleButton: {
+      alignItems: 'center',
+      paddingVertical: spacing.medium,
+    },
+    toggleText: {
+      color: colors.textLink,
+      fontFamily: typography.bodyMedium.fontFamily,
+      fontSize: typography.bodyMedium.fontSize,
+      fontWeight: typography.bodyMedium.fontWeight as TextStyle['fontWeight'],
+      letterSpacing: typography.bodyMedium.letterSpacing,
+      lineHeight: typography.bodyMedium.lineHeight,
+    },
+  });
+  /* eslint-enable react-native/no-unused-styles */
+}

--- a/src/Components/index.ts
+++ b/src/Components/index.ts
@@ -5,3 +5,7 @@ export { usePaymentMethods } from './hooks/usePaymentMethods';
 export type { PrimerCheckoutProviderProps, PrimerCheckoutContextValue } from './types/PrimerCheckoutProviderTypes';
 export type { TranslationParams } from './internal/localization';
 export type { PaymentMethodItem, UsePaymentMethodsOptions, UsePaymentMethodsReturn } from './types/PaymentMethodTypes';
+export { PrimerPaymentMethodList } from './PrimerPaymentMethodList';
+export type { PrimerPaymentMethodListProps } from './types/PrimerPaymentMethodListTypes';
+export { PrimerCheckoutSheet } from './PrimerCheckoutSheet';
+export type { PrimerCheckoutSheetProps } from './PrimerCheckoutSheet';

--- a/src/Components/internal/checkout-flow/CheckoutFlow.tsx
+++ b/src/Components/internal/checkout-flow/CheckoutFlow.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import { NavigationProvider } from '../navigation/NavigationProvider';
+import { NavigationContainer } from '../navigation/NavigationContainer';
+import { useNavigation } from '../navigation/useNavigation';
+import { CheckoutRoute } from '../navigation/types';
+import type { CheckoutRoute as CheckoutRouteType } from '../navigation/types';
+import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
+import { LoadingScreen } from '../screens/LoadingScreen';
+import { MethodSelectionScreen } from '../screens/MethodSelectionScreen';
+import { ErrorScreen } from '../screens/ErrorScreen';
+import { CheckoutFlowContext } from './CheckoutFlowContext';
+
+function CheckoutLoadingScreen() {
+  return <LoadingScreen title="Loading your secure checkout" subtitle="This won't take long" />;
+}
+
+const screenMap: Partial<Record<CheckoutRouteType, React.ComponentType>> = {
+  [CheckoutRoute.loading]: CheckoutLoadingScreen,
+  [CheckoutRoute.methodSelection]: MethodSelectionScreen,
+  [CheckoutRoute.error]: ErrorScreen,
+};
+
+/**
+ * Watches checkout readiness and navigates from loading to method selection.
+ * Renders nothing — purely a side-effect component.
+ */
+function ReadinessTransitioner() {
+  const { isReady, isLoadingResources, error } = usePrimerCheckout();
+  const { replace } = useNavigation();
+  const hasTransitioned = useRef(false);
+
+  useEffect(() => {
+    if (hasTransitioned.current) return;
+
+    if (error) {
+      hasTransitioned.current = true;
+      replace(CheckoutRoute.error, { error });
+      return;
+    }
+
+    if (isReady && !isLoadingResources) {
+      hasTransitioned.current = true;
+      replace(CheckoutRoute.methodSelection);
+    }
+  }, [isReady, isLoadingResources, error, replace]);
+
+  return null;
+}
+
+export interface CheckoutFlowProps {
+  /** Called when the user requests to cancel/close the checkout flow */
+  onCancel?: () => void;
+}
+
+export function CheckoutFlow({ onCancel }: CheckoutFlowProps = {}) {
+  const contextValue = useMemo(() => ({ onCancel: onCancel ?? (() => {}) }), [onCancel]);
+
+  return (
+    <CheckoutFlowContext.Provider value={contextValue}>
+      <NavigationProvider initialRoute={CheckoutRoute.loading}>
+        <ReadinessTransitioner />
+        <NavigationContainer screenMap={screenMap} />
+      </NavigationProvider>
+    </CheckoutFlowContext.Provider>
+  );
+}

--- a/src/Components/internal/checkout-flow/CheckoutFlowContext.ts
+++ b/src/Components/internal/checkout-flow/CheckoutFlowContext.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react';
+
+export interface CheckoutFlowContextValue {
+  /** Called when the user requests to cancel/close the checkout flow */
+  onCancel: () => void;
+}
+
+export const CheckoutFlowContext = createContext<CheckoutFlowContextValue | null>(null);
+
+export function useCheckoutFlow(): CheckoutFlowContextValue {
+  const context = useContext(CheckoutFlowContext);
+  if (!context) {
+    throw new Error('useCheckoutFlow must be used within a CheckoutFlow');
+  }
+  return context;
+}

--- a/src/Components/internal/checkout-flow/index.ts
+++ b/src/Components/internal/checkout-flow/index.ts
@@ -1,0 +1,1 @@
+export { CheckoutFlow } from './CheckoutFlow';

--- a/src/Components/internal/checkout-sheet/CheckoutSheet.tsx
+++ b/src/Components/internal/checkout-sheet/CheckoutSheet.tsx
@@ -117,8 +117,8 @@ export function CheckoutSheet({
     });
   }, [dragValue, sheetHeight, showAnimValue, onDismiss, onRequestDismiss]);
 
-  // Handle visible prop changes
-  const prevVisibleRef = useRef(visible);
+  // Handle visible prop changes (including initial mount with visible=true)
+  const prevVisibleRef = useRef(false);
   useEffect(() => {
     if (visible && !prevVisibleRef.current) {
       setHeightRatioState(DEFAULT_HEIGHT_RATIO);
@@ -128,7 +128,7 @@ export function CheckoutSheet({
       animateOut();
     }
     prevVisibleRef.current = visible;
-  }, [visible, modalVisible, animateOut]);
+  }, [visible, modalVisible, animateOut, heightOffsetValue, screenHeight]);
 
   const handleShow = useCallback(() => {
     showAnimValue.setValue(0);

--- a/src/Components/internal/screens/LoadingScreen.tsx
+++ b/src/Components/internal/screens/LoadingScreen.tsx
@@ -11,7 +11,12 @@ import { useBottomSafeArea } from './useBottomSafeArea';
 const SPINNER_SCALE = 1.1;
 const CONTENT_HEIGHT = 246;
 
-export function LoadingScreen() {
+export interface LoadingScreenProps {
+  title?: string;
+  subtitle?: string;
+}
+
+export function LoadingScreen({ title: overrideTitle, subtitle: overrideSubtitle }: LoadingScreenProps = {}) {
   const tokens = useTheme();
   const { t } = useLocalization();
   const { route, params } = useRoute<CheckoutRoute.splash | CheckoutRoute.loading>();
@@ -25,8 +30,8 @@ export function LoadingScreen() {
   const defaultSubtitleKey =
     route === CheckoutRoute.splash ? 'primer_checkout_splash_subtitle' : 'primer_checkout_loading_subtitle';
 
-  const title = params?.title ?? t(defaultTitleKey);
-  const subtitle = params?.subtitle ?? t(defaultSubtitleKey);
+  const title = overrideTitle ?? params?.title ?? t(defaultTitleKey);
+  const subtitle = overrideSubtitle ?? params?.subtitle ?? t(defaultSubtitleKey);
 
   return (
     /* eslint-disable react-native/no-inline-styles -- screen-level layout with fixed height and icon sizing */

--- a/src/Components/internal/screens/MethodSelectionScreen.tsx
+++ b/src/Components/internal/screens/MethodSelectionScreen.tsx
@@ -1,0 +1,79 @@
+import { useMemo } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import type { TextStyle } from 'react-native';
+import { useTheme } from '../theme';
+import type { PrimerTokens } from '../theme';
+import { NavigationHeader } from '../navigation/NavigationHeader';
+import { PrimerPaymentMethodList } from '../../PrimerPaymentMethodList';
+import { usePaymentMethods } from '../../hooks/usePaymentMethods';
+import type { PaymentMethodItem } from '../../types/PaymentMethodTypes';
+import { useCheckoutFlow } from '../checkout-flow/CheckoutFlowContext';
+import { useStatusScreenHeight } from './useStatusScreenHeight';
+import { useBottomSafeArea } from './useBottomSafeArea';
+import { PAYMENT_METHOD_BUTTON_HEIGHT } from '../ui/PaymentMethodButton';
+
+export function MethodSelectionScreen() {
+  const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+  const { onCancel } = useCheckoutFlow();
+  const { paymentMethods } = usePaymentMethods();
+
+  const methodCount = paymentMethods.length;
+  const buttonGap = tokens.spacing.small;
+  const listHeight = methodCount > 0 ? methodCount * PAYMENT_METHOD_BUTTON_HEIGHT + (methodCount - 1) * buttonGap : 0;
+  const rawBottomInset = useBottomSafeArea();
+  const bottomInset = Math.max(rawBottomInset, tokens.spacing.large);
+  // Container paddingTop + NavigationHeader (singleRow paddingVertical + titleXLarge lineHeight)
+  //   + content paddingTop + sectionTitle lineHeight + content gap + list + bottom safe area
+  const headerArea = tokens.spacing.xxsmall * 2 + tokens.typography.titleXLarge.lineHeight;
+  const titleArea = tokens.typography.titleLarge.lineHeight;
+  const sheetHeight =
+    tokens.spacing.large +
+    headerArea +
+    tokens.spacing.xxlarge +
+    titleArea +
+    tokens.spacing.medium +
+    listHeight +
+    bottomInset;
+  useStatusScreenHeight(sheetHeight);
+
+  const handleSelect = (_method: PaymentMethodItem) => {
+    // Payment form navigation to be wired when forms are implemented
+  };
+
+  return (
+    <View style={styles.container}>
+      <NavigationHeader title="Pay" rightAction={{ label: 'Cancel', onPress: onCancel }} />
+      <View style={styles.content}>
+        <Text style={styles.sectionTitle}>Choose payment method</Text>
+        <PrimerPaymentMethodList data={paymentMethods} onSelect={handleSelect} />
+      </View>
+    </View>
+  );
+}
+
+function createStyles(tokens: PrimerTokens) {
+  const { colors, spacing, typography } = tokens;
+
+  /* eslint-disable react-native/no-unused-styles */
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      paddingTop: spacing.large,
+    },
+    content: {
+      gap: spacing.medium,
+      paddingHorizontal: spacing.large,
+      paddingTop: spacing.xxlarge,
+    },
+    sectionTitle: {
+      color: colors.textPrimary,
+      fontFamily: typography.titleLarge.fontFamily,
+      fontSize: typography.titleLarge.fontSize,
+      fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],
+      letterSpacing: typography.titleLarge.letterSpacing,
+      lineHeight: typography.titleLarge.lineHeight,
+    },
+  });
+  /* eslint-enable react-native/no-unused-styles */
+}

--- a/src/Components/internal/screens/index.ts
+++ b/src/Components/internal/screens/index.ts
@@ -1,5 +1,7 @@
 export { StatusScreenLayout } from './StatusScreenLayout';
 export type { StatusScreenLayoutProps } from './StatusScreenLayout';
 export { LoadingScreen } from './LoadingScreen';
+export type { LoadingScreenProps } from './LoadingScreen';
 export { SuccessScreen } from './SuccessScreen';
 export { ErrorScreen } from './ErrorScreen';
+export { MethodSelectionScreen } from './MethodSelectionScreen';

--- a/src/Components/internal/ui/PaymentMethodButton.tsx
+++ b/src/Components/internal/ui/PaymentMethodButton.tsx
@@ -1,0 +1,99 @@
+import { useMemo } from 'react';
+import { Image, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import type { TextStyle } from 'react-native';
+import { useTheme } from '../theme';
+import type { PrimerTokens } from '../theme';
+import type { PaymentMethodButtonProps } from '../../types/PrimerPaymentMethodListTypes';
+
+export const PAYMENT_METHOD_BUTTON_HEIGHT = 44;
+const BUTTON_HEIGHT = PAYMENT_METHOD_BUTTON_HEIGHT;
+
+export function PaymentMethodButton({ item, onPress }: PaymentMethodButtonProps) {
+  const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+
+  const isColorStyle = item.backgroundColor != null && item.logo != null;
+
+  const surchargeLabel = item.surcharge != null ? `+${item.surcharge}` : null;
+
+  if (isColorStyle) {
+    return (
+      <TouchableOpacity
+        style={[styles.button, { backgroundColor: item.backgroundColor }]}
+        onPress={onPress}
+        activeOpacity={0.7}
+      >
+        <Image source={{ uri: item.logo }} style={styles.logo} resizeMode="contain" />
+        {surchargeLabel != null && <Text style={styles.surchargeLight}>{surchargeLabel}</Text>}
+      </TouchableOpacity>
+    );
+  }
+
+  return (
+    <TouchableOpacity style={[styles.button, styles.outlinedButton]} onPress={onPress} activeOpacity={0.7}>
+      {item.logo != null && <Image source={{ uri: item.logo }} style={styles.icon} resizeMode="contain" />}
+      <Text style={styles.outlinedText}>Pay with {item.name.toLowerCase()}</Text>
+      {surchargeLabel != null && <Text style={styles.surchargeDark}>{surchargeLabel}</Text>}
+    </TouchableOpacity>
+  );
+}
+
+function createStyles(tokens: PrimerTokens) {
+  const { colors, spacing, radii, borders, typography } = tokens;
+
+  /* eslint-disable react-native/no-unused-styles */
+  return StyleSheet.create({
+    button: {
+      alignItems: 'center',
+      borderRadius: radii.medium,
+      flexDirection: 'row',
+      height: BUTTON_HEIGHT,
+      justifyContent: 'center',
+      overflow: 'hidden',
+      paddingHorizontal: spacing.small,
+      width: '100%',
+    },
+    icon: {
+      height: 20,
+      marginRight: spacing.small,
+      width: 20,
+    },
+    logo: {
+      height: BUTTON_HEIGHT * 0.5,
+      width: '40%',
+    },
+    outlinedButton: {
+      backgroundColor: colors.background,
+      borderColor: colors.border,
+      borderWidth: borders.default,
+    },
+    outlinedText: {
+      color: colors.textPrimary,
+      fontFamily: typography.titleLarge.fontFamily,
+      fontSize: typography.titleLarge.fontSize,
+      fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],
+      letterSpacing: typography.titleLarge.letterSpacing,
+      lineHeight: typography.titleLarge.lineHeight,
+      textAlign: 'center',
+    },
+    surchargeDark: {
+      color: colors.textSecondary,
+      fontFamily: typography.bodySmall.fontFamily,
+      fontSize: typography.bodySmall.fontSize,
+      fontWeight: typography.bodySmall.fontWeight as TextStyle['fontWeight'],
+      marginLeft: spacing.small,
+      position: 'absolute',
+      right: spacing.small,
+    },
+    surchargeLight: {
+      color: colors.background,
+      fontFamily: typography.bodySmall.fontFamily,
+      fontSize: typography.bodySmall.fontSize,
+      fontWeight: typography.bodySmall.fontWeight as TextStyle['fontWeight'],
+      opacity: 0.8,
+      position: 'absolute',
+      right: spacing.small,
+    },
+  });
+  /* eslint-enable react-native/no-unused-styles */
+}

--- a/src/Components/types/PrimerPaymentMethodListTypes.ts
+++ b/src/Components/types/PrimerPaymentMethodListTypes.ts
@@ -1,0 +1,28 @@
+import type { ViewStyle } from 'react-native';
+import type { PaymentMethodItem } from './PaymentMethodTypes';
+
+export interface PrimerPaymentMethodListProps {
+  /** Pre-fetched payment methods. When provided, the list skips its internal usePaymentMethods() call. */
+  data?: PaymentMethodItem[];
+  /** Whitelist: only show these payment method types */
+  include?: string[];
+  /** Blacklist: hide these payment method types */
+  exclude?: string[];
+  /** Sort PAYMENT_CARD to top of list (default: true) */
+  showCardFirst?: boolean;
+  /** Number of methods visible when collapsed. Undefined = show all (no collapse). */
+  collapsedCount?: number;
+  /** Called when a payment method button is tapped */
+  onSelect: (method: PaymentMethodItem) => void;
+  /** Called when payment methods finish loading */
+  onLoad?: (methods: PaymentMethodItem[]) => void;
+  /** Container style override */
+  style?: ViewStyle;
+}
+
+export interface PaymentMethodButtonProps {
+  /** The payment method data to render */
+  item: PaymentMethodItem;
+  /** Tap handler */
+  onPress: () => void;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -135,6 +135,10 @@ export { usePrimerCheckout } from './Components';
 export { usePaymentMethods } from './Components';
 export type { PrimerCheckoutProviderProps, PrimerCheckoutContextValue } from './Components';
 export type { PaymentMethodItem, UsePaymentMethodsOptions, UsePaymentMethodsReturn } from './Components';
+export { PrimerPaymentMethodList } from './Components';
+export type { PrimerPaymentMethodListProps } from './Components';
+export { PrimerCheckoutSheet } from './Components';
+export type { PrimerCheckoutSheetProps } from './Components';
 
 export { useLocalization, translate, hasLocale } from './Components/internal/localization';
 export type { TranslationParams, LocalizationResult } from './Components/internal/localization';


### PR DESCRIPTION
## Summary

- Add `CustomPaymentMethodListScreen` example demonstrating custom merchant UI using only `PrimerCheckoutProvider` + `usePaymentMethods()` hook with plain React Native components (no SDK UI components)
- Add "Custom Payment List" entry to Checkout Components list screen
- Register new screen in App.tsx navigation stack

## Jira

[ACC-6492](https://primerapi.atlassian.net/browse/ACC-6492)

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 32/32 tests pass
- [ ] Manual: Checkout Components > "Custom Payment List" > shows payment methods with custom UI
- [ ] Manual: Tapping a method highlights it with blue border and checkmark
- [ ] Manual: Changing currency in SettingsScreen changes available methods
- [ ] Manual: Selected method name shown in footer bar

[ACC-6492]: https://primerapi.atlassian.net/browse/ACC-6492