### PR TITLE
feat: add useCardForm() hook with tokenization and 3DS (ACC-6925)

### DIFF
--- a/src/Components/PrimerCheckoutProvider.tsx
+++ b/src/Components/PrimerCheckoutProvider.tsx
@@ -1,17 +1,51 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { PrimerCheckoutContext } from './internal/PrimerCheckoutContext';
 import { ThemeContext } from './internal/theme/ThemeContext';
 import { defaultDarkTokens, defaultLightTokens } from './internal/theme/tokens';
 import { mergeTokens } from './internal/theme/merge';
 import { PrimerHeadlessUniversalCheckout } from '../HeadlessUniversalCheckout/PrimerHeadlessUniversalCheckout';
 import PrimerHeadlessUniversalCheckoutAssetsManager from '../HeadlessUniversalCheckout/Managers/AssetsManager';
-import { toError } from './internal/utils/errors';
+import PrimerHeadlessUniversalCheckoutRawDataManager from '../HeadlessUniversalCheckout/Managers/PaymentMethodManagers/RawDataManager';
 import type { PrimerSettings } from '../models/PrimerSettings';
-import type { PrimerCheckoutProviderProps, PrimerCheckoutContextValue } from './types/PrimerCheckoutProviderTypes';
+import { PrimerError } from '../models/PrimerError';
+import type { PrimerRawData } from '../models/PrimerRawData';
+import type { PrimerBinData } from '../models/PrimerBinData';
+import type {
+  PrimerCheckoutProviderProps,
+  PrimerCheckoutContextValue,
+  PaymentOutcome,
+  CardFormState,
+} from './types/PrimerCheckoutProviderTypes';
+import type { CardFormErrors } from './types/CardFormTypes';
+import { fmt } from './internal/debug';
+import { toError } from './internal/utils/errors';
+
+const LOG = '[PrimerCheckoutProvider]';
 
 const assetsManager = new PrimerHeadlessUniversalCheckoutAssetsManager();
 
-const initialState: PrimerCheckoutContextValue = {
+const initialCardFormState: CardFormState = {
+  isValid: false,
+  errors: {},
+  binData: null,
+  metadata: null,
+  requiredFields: [],
+};
+
+interface InternalState {
+  isReady: boolean;
+  error: PrimerError | null;
+  clientSession: PrimerCheckoutContextValue['clientSession'];
+  availablePaymentMethods: PrimerCheckoutContextValue['availablePaymentMethods'];
+  paymentMethodResources: PrimerCheckoutContextValue['paymentMethodResources'];
+  isLoadingResources: boolean;
+  resourcesError: Error | null;
+  paymentOutcome: PaymentOutcome | null;
+  activeMethod: string | null;
+  cardFormState: CardFormState;
+}
+
+const initialState: InternalState = {
   isReady: false,
   error: null,
   clientSession: null,
@@ -19,7 +53,30 @@ const initialState: PrimerCheckoutContextValue = {
   paymentMethodResources: [],
   isLoadingResources: false,
   resourcesError: null,
+  paymentOutcome: null,
+  activeMethod: null,
+  cardFormState: initialCardFormState,
 };
+
+/** Map native validation errors to per-field typed errors the UI can render. */
+function parseValidationErrors(errors: PrimerError[] | undefined): CardFormErrors {
+  const fieldErrors: CardFormErrors = {};
+  if (!errors) return fieldErrors;
+  for (const error of errors) {
+    const id = (error.errorId ?? '').toLowerCase();
+    const description = error.description ?? error.message ?? 'Invalid';
+    if (id.includes('card') && id.includes('number')) {
+      fieldErrors.cardNumber = description;
+    } else if (id.includes('expir') || id.includes('expiry')) {
+      fieldErrors.expiryDate = description;
+    } else if (id.includes('cvv') || id.includes('cvc')) {
+      fieldErrors.cvv = description;
+    } else if (id.includes('cardholder') || id.includes('name')) {
+      fieldErrors.cardholderName = description;
+    }
+  }
+  return fieldErrors;
+}
 
 export function PrimerCheckoutProvider({
   clientToken,
@@ -31,12 +88,12 @@ export function PrimerCheckoutProvider({
   onError,
   children,
 }: PrimerCheckoutProviderProps) {
-  const [state, setState] = useState<PrimerCheckoutContextValue>(initialState);
+  const [state, setState] = useState<InternalState>(initialState);
 
   const [lightTokens] = useState(() => mergeTokens(defaultLightTokens, theme?.light));
   const [darkTokens] = useState(() => mergeTokens(defaultDarkTokens, theme?.dark));
 
-  // Keep refs for all callbacks and settings so the useEffect doesn't depend on them
+  // Refs keep init useEffect deps to [clientToken] only.
   const settingsRef = useRef(settings);
   settingsRef.current = settings;
   const onCheckoutCompleteRef = useRef(onCheckoutComplete);
@@ -48,6 +105,25 @@ export function PrimerCheckoutProvider({
   const onErrorRef = useRef(onError);
   onErrorRef.current = onError;
 
+  // Snapshot of current state for stable callbacks that need activeMethod.
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  // Native manager. Lifecycle is driven by `state.activeMethod` — the method the user
+  // picked on the selection screen — so it survives the card-form view mount/unmount.
+  const managerRef = useRef<PrimerHeadlessUniversalCheckoutRawDataManager | null>(null);
+  // Stashed so `retry()` can re-submit without needing the view to re-enter the form.
+  // Compensates for an iOS native bug (see TODO in `retry`), not a JS-side concern.
+  const lastRawDataRef = useRef<PrimerRawData | null>(null);
+  const lastManagerCallbacksRef = useRef<{
+    onValidation: (isValid: boolean, errors: PrimerError[] | undefined) => void;
+    onBinDataChange: (binData: PrimerBinData) => void;
+    onMetadataChange: (metadata: unknown) => void;
+  } | null>(null);
+
+  // -----------------------------------------------------------------------
+  // Session init — create headless checkout + wire session-level callbacks.
+  // -----------------------------------------------------------------------
   useEffect(() => {
     setState(initialState);
     let cancelled = false;
@@ -55,9 +131,6 @@ export function PrimerCheckoutProvider({
     async function init() {
       const userCallbacks = settingsRef.current?.headlessUniversalCheckoutCallbacks;
 
-      // Only define callbacks that are actually needed — native SDK checks for presence
-      // and handler-based ones (onTokenizationSuccess, onCheckoutResume, onBeforePaymentCreate)
-      // will hang the flow if defined but no handler is invoked.
       const callbacks: PrimerSettings['headlessUniversalCheckoutCallbacks'] = {
         onAvailablePaymentMethodsLoad: (availablePaymentMethods) => {
           // Flip isLoadingResources: true atomically with the new list so the hook
@@ -78,9 +151,27 @@ export function PrimerCheckoutProvider({
           settingsRef.current?.headlessUniversalCheckoutCallbacks?.onClientSessionUpdate?.(clientSession);
         },
         onError: (error, checkoutData) => {
-          setState((prev) => ({ ...prev, error }));
+          setState((prev) => {
+            // Init-time errors → `error`. Payment-time errors → `paymentOutcome`.
+            if (prev.isReady) {
+              return {
+                ...prev,
+                paymentOutcome: { status: 'error', error, data: checkoutData ?? null },
+              };
+            }
+            return { ...prev, error };
+          });
           onErrorRef.current?.(error, checkoutData);
           settingsRef.current?.headlessUniversalCheckoutCallbacks?.onError?.(error, checkoutData);
+        },
+        // Always-subscribed so paymentOutcome fires regardless of merchant callbacks.
+        onCheckoutComplete: (checkoutData) => {
+          setState((prev) => ({
+            ...prev,
+            paymentOutcome: { status: 'success', data: checkoutData },
+          }));
+          onCheckoutCompleteRef.current?.(checkoutData);
+          settingsRef.current?.headlessUniversalCheckoutCallbacks?.onCheckoutComplete?.(checkoutData);
         },
       };
 
@@ -107,14 +198,6 @@ export function PrimerCheckoutProvider({
           );
         };
       }
-
-      if (onCheckoutCompleteRef.current || userCallbacks?.onCheckoutComplete) {
-        callbacks.onCheckoutComplete = (checkoutData) => {
-          onCheckoutCompleteRef.current?.(checkoutData);
-          settingsRef.current?.headlessUniversalCheckoutCallbacks?.onCheckoutComplete?.(checkoutData);
-        };
-      }
-
       if (userCallbacks?.onTokenizationStart) {
         callbacks.onTokenizationStart = (paymentMethodType) => {
           settingsRef.current?.headlessUniversalCheckoutCallbacks?.onTokenizationStart?.(paymentMethodType);
@@ -160,6 +243,7 @@ export function PrimerCheckoutProvider({
           ...prev,
           isReady: true,
           availablePaymentMethods: methods,
+          paymentMethodResources: [],
           isLoadingResources: true,
           resourcesError: null,
         }));
@@ -167,6 +251,7 @@ export function PrimerCheckoutProvider({
     }
 
     init().catch((err) => {
+      console.error(`${LOG} init failed ${fmt(err)}`);
       if (!cancelled) {
         setState((prev) => ({ ...prev, error: err }));
       }
@@ -178,7 +263,10 @@ export function PrimerCheckoutProvider({
     };
   }, [clientToken]);
 
-  // Re-fetch payment method resources whenever the set of available method types changes.
+  // -----------------------------------------------------------------------
+  // Payment method resource fetch — re-runs whenever the set of available
+  // method types changes (init, or onAvailablePaymentMethodsLoad firing post-ready).
+  // -----------------------------------------------------------------------
   const methodTypesSignature = useMemo(
     () =>
       state.availablePaymentMethods
@@ -218,6 +306,7 @@ export function PrimerCheckoutProvider({
         }
       })
       .catch((err) => {
+        console.warn(`${LOG} resources load failed ${fmt(err)}`);
         if (!cancelled) {
           setState((prev) => ({ ...prev, isLoadingResources: false, resourcesError: toError(err) }));
         }
@@ -228,9 +317,168 @@ export function PrimerCheckoutProvider({
     };
   }, [state.isReady, methodTypesSignature]);
 
+  // -----------------------------------------------------------------------
+  // Raw-data manager lifecycle.
+  //
+  // The effect creates a manager for the current `activeMethod` and tears it down in
+  // cleanup. Because `activeMethod` is set by the method-selection screen (user intent)
+  // rather than the card-form view's mount/unmount, the manager survives nav transitions
+  // through processing/success/error — exactly when retry needs it alive.
+  //
+  // The single cleanup handles all three teardown paths:
+  //   • method change     — effect re-runs, cleanup destroys old, body builds new
+  //   • session end       — `isReady` or `activeMethod` flips, effect re-runs, cleanup destroys
+  //   • provider unmount  — final cleanup destroys
+  // -----------------------------------------------------------------------
+  useEffect(() => {
+    if (!state.isReady || !state.activeMethod) {
+      return;
+    }
+
+    const method = state.activeMethod;
+    let cancelled = false;
+    const m = new PrimerHeadlessUniversalCheckoutRawDataManager();
+    managerRef.current = m;
+
+    const callbacks = {
+      onValidation: (isValid: boolean, errors: PrimerError[] | undefined) => {
+        const parsed = parseValidationErrors(errors);
+        setState((prev) => ({
+          ...prev,
+          cardFormState: { ...prev.cardFormState, isValid, errors: parsed },
+        }));
+      },
+      onBinDataChange: (binData: PrimerBinData) => {
+        setState((prev) => ({
+          ...prev,
+          cardFormState: { ...prev.cardFormState, binData },
+        }));
+      },
+      onMetadataChange: (metadata: unknown) => {
+        setState((prev) => ({
+          ...prev,
+          cardFormState: { ...prev.cardFormState, metadata },
+        }));
+      },
+    };
+    lastManagerCallbacksRef.current = callbacks;
+
+    (async () => {
+      try {
+        await m.configure({ paymentMethodType: method, ...callbacks });
+        if (cancelled) return;
+        const requiredFields = await m.getRequiredInputElementTypes();
+        if (cancelled) return;
+        setState((prev) => ({
+          ...prev,
+          cardFormState: { ...prev.cardFormState, requiredFields },
+        }));
+      } catch (err) {
+        console.error(`${LOG} manager configure failed ${fmt(err)}`);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      m.cleanUp().catch((err) => console.warn(`${LOG} manager cleanUp failed ${fmt(err)}`));
+      m.removeAllListeners();
+      if (managerRef.current === m) {
+        managerRef.current = null;
+      }
+      lastManagerCallbacksRef.current = null;
+      setState((prev) => ({ ...prev, cardFormState: initialCardFormState }));
+    };
+  }, [state.activeMethod, state.isReady]);
+
+  // -----------------------------------------------------------------------
+  // Actions — stable identities.
+  // -----------------------------------------------------------------------
+  const setActiveMethod = useCallback((method: string | null) => {
+    setState((prev) => (prev.activeMethod === method ? prev : { ...prev, activeMethod: method }));
+  }, []);
+
+  const setRawData = useCallback(async (data: PrimerRawData) => {
+    lastRawDataRef.current = data;
+    const m = managerRef.current;
+    if (!m) {
+      console.warn(`${LOG} setRawData: no manager (activeMethod=${stateRef.current.activeMethod})`);
+      return;
+    }
+    try {
+      await m.setRawData(data);
+    } catch (err) {
+      console.warn(`${LOG} setRawData failed: ${err instanceof PrimerError ? err.errorId : 'unknown'}`);
+      throw err;
+    }
+  }, []);
+
+  const submit = useCallback(async () => {
+    const m = managerRef.current;
+    if (!m) {
+      console.warn(`${LOG} submit: no manager`);
+      return;
+    }
+    await m.submit();
+  }, []);
+
+  const retry = useCallback(async () => {
+    const method = stateRef.current.activeMethod;
+    const m = managerRef.current;
+    if (!method || !m) {
+      console.warn(`${LOG} retry: no active method or manager ${fmt({ method, hasManager: !!m })}`);
+      return;
+    }
+    // TODO(iOS native fix): ios .../RawDataManager.swift:237 nullifies its delegate on
+    // successful tokenization, so any post-tokenize failure would silently drop subsequent
+    // submit() outcomes. Reconfiguring here rebuilds the delegate binding. Harmless on
+    // Android. Remove the reconfigure once the iOS SDK stops nullifying.
+    try {
+      // Re-pass the original callbacks so the JS-wrapper's listeners get re-registered.
+      // Otherwise native would emit onValidation/onBinDataChange/onMetadataChange during
+      // the retry attempt with no JS-side subscribers → RN warns "no listeners registered".
+      const callbacks = lastManagerCallbacksRef.current;
+      await m.configure(callbacks ? { paymentMethodType: method, ...callbacks } : { paymentMethodType: method });
+      if (lastRawDataRef.current) {
+        await m.setRawData(lastRawDataRef.current);
+      }
+      // Clear the previous outcome so the transitioner fires for the new attempt.
+      setState((prev) => (prev.paymentOutcome === null ? prev : { ...prev, paymentOutcome: null }));
+      await m.submit();
+    } catch (err) {
+      console.error(`${LOG} retry failed ${fmt(err)}`);
+      throw err;
+    }
+  }, []);
+
+  const clearPaymentOutcome = useCallback(() => {
+    setState((prev) => (prev.paymentOutcome === null ? prev : { ...prev, paymentOutcome: null }));
+  }, []);
+
+  const contextValue = useMemo<PrimerCheckoutContextValue>(
+    () => ({
+      isReady: state.isReady,
+      error: state.error,
+      clientSession: state.clientSession,
+      availablePaymentMethods: state.availablePaymentMethods,
+      paymentMethodResources: state.paymentMethodResources,
+      isLoadingResources: state.isLoadingResources,
+      resourcesError: state.resourcesError,
+      settings: settingsRef.current,
+      paymentOutcome: state.paymentOutcome,
+      activeMethod: state.activeMethod,
+      cardFormState: state.cardFormState,
+      setActiveMethod,
+      setRawData,
+      submit,
+      retry,
+      clearPaymentOutcome,
+    }),
+    [state, setActiveMethod, setRawData, submit, retry, clearPaymentOutcome]
+  );
+
   return (
     <ThemeContext.Provider value={{ lightTokens, darkTokens }}>
-      <PrimerCheckoutContext.Provider value={state}>{children}</PrimerCheckoutContext.Provider>
+      <PrimerCheckoutContext.Provider value={contextValue}>{children}</PrimerCheckoutContext.Provider>
     </ThemeContext.Provider>
   );
 }

--- a/src/Components/hooks/useCardForm.ts
+++ b/src/Components/hooks/useCardForm.ts
@@ -1,0 +1,234 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { usePrimerCheckout } from './usePrimerCheckout';
+import { debounce, type DebouncedFunction } from '../../utils/debounce';
+import { fmt } from '../internal/debug';
+import { PrimerError } from '../../models/PrimerError';
+import type { CardFormField, CardFormErrors, UseCardFormOptions, UseCardFormReturn } from '../types/CardFormTypes';
+
+const LOG = '[useCardForm]';
+const DEBOUNCE_MS = 150;
+const PAYMENT_METHOD_TYPE = 'PAYMENT_CARD';
+
+function formatCardNumber(value: string): string {
+  const digits = value.replace(/\D/g, '').slice(0, 16);
+  return digits.replace(/(\d{4})(?=\d)/g, '$1 ');
+}
+
+function formatExpiryDate(value: string, previous: string): string {
+  const digits = value.replace(/\D/g, '').slice(0, 4);
+  if (value.length < previous.length) {
+    return digits;
+  }
+  if (digits.length >= 2) {
+    return digits.slice(0, 2) + '/' + digits.slice(2);
+  }
+  return digits;
+}
+
+function formatCVV(value: string): string {
+  return value.replace(/\D/g, '').slice(0, 4);
+}
+
+function stripCardNumberForNative(formatted: string): string {
+  return formatted.replace(/\s/g, '');
+}
+
+// Display is MM/YY but Android's validator requires MM/YYYY; iOS accepts both.
+// Expand only once the year is fully typed (4-char "MM/YY"); partial edits
+// pass through unchanged so native can keep reporting "cannot be blank".
+function expandExpiryYearForNative(formatted: string): string {
+  const match = /^(\d{2})\/(\d{2})$/.exec(formatted);
+  return match ? `${match[1]}/20${match[2]}` : formatted;
+}
+
+/**
+ * Card form adapter hook. Reads validation state from the session-owned raw-data
+ * manager on the provider; forwards field updates to it; surfaces a stable
+ * submit() that the form renders behind its button.
+ *
+ * The native manager lifecycle lives on PrimerCheckoutProvider and is keyed by
+ * `activeMethod`, which the method-selection screen sets when the user picks
+ * a payment method. This hook deliberately does NOT touch `activeMethod`, so the
+ * manager survives the card-form view's mount/unmount across nav transitions.
+ */
+export function useCardForm(options: UseCardFormOptions = {}): UseCardFormReturn {
+  const { onValidationChange, onMetadataChange, onBinDataChange } = options;
+  const {
+    isReady,
+    activeMethod,
+    cardFormState,
+    setRawData: providerSetRawData,
+    submit: providerSubmit,
+  } = usePrimerCheckout();
+
+  const [cardNumber, setCardNumber] = useState('');
+  const [expiryDate, setExpiryDate] = useState('');
+  const [cvv, setCVV] = useState('');
+  const [cardholderName, setCardholderName] = useState('');
+
+  const [touched, setTouched] = useState<Record<CardFormField, boolean>>({
+    cardNumber: false,
+    expiryDate: false,
+    cvv: false,
+    cardholderName: false,
+  });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const onValidationChangeRef = useRef(onValidationChange);
+  onValidationChangeRef.current = onValidationChange;
+  const onBinDataChangeRef = useRef(onBinDataChange);
+  onBinDataChangeRef.current = onBinDataChange;
+  const onMetadataChangeRef = useRef(onMetadataChange);
+  onMetadataChangeRef.current = onMetadataChange;
+
+  useEffect(() => {
+    onValidationChangeRef.current?.(cardFormState.isValid, cardFormState.errors);
+  }, [cardFormState.isValid, cardFormState.errors]);
+  useEffect(() => {
+    if (cardFormState.binData) {
+      onBinDataChangeRef.current?.(cardFormState.binData);
+    }
+  }, [cardFormState.binData]);
+  useEffect(() => {
+    if (cardFormState.metadata) {
+      onMetadataChangeRef.current?.(cardFormState.metadata);
+    }
+  }, [cardFormState.metadata]);
+
+  const fieldsRef = useRef({ cardNumber: '', expiryDate: '', cvv: '', cardholderName: '' });
+  const debouncedRef = useRef<DebouncedFunction<
+    (data: { cardNumber: string; expiryDate: string; cvv: string; cardholderName: string }) => void
+  > | null>(null);
+
+  useEffect(() => {
+    debouncedRef.current = debounce(
+      (data: { cardNumber: string; expiryDate: string; cvv: string; cardholderName: string }) => {
+        providerSetRawData(data).catch(() => {
+          // Provider already logs (sanitized); swallow to prevent unhandled rejection.
+        });
+      },
+      DEBOUNCE_MS
+    );
+    return () => debouncedRef.current?.cancel();
+  }, [providerSetRawData]);
+
+  // Always include cardholderName in the payload — the native SDK's required-fields set
+  // varies by client session; sending the field unconditionally keeps validation honest
+  // regardless of whether the merchant has required it server-side.
+  const syncToNative = useCallback(() => {
+    const fields = fieldsRef.current;
+    const data = {
+      cardNumber: stripCardNumberForNative(fields.cardNumber),
+      expiryDate: expandExpiryYearForNative(fields.expiryDate),
+      cvv: fields.cvv,
+      cardholderName: fields.cardholderName,
+    };
+    debouncedRef.current?.(data);
+  }, []);
+
+  const updateCardNumber = useCallback(
+    (value: string) => {
+      const formatted = formatCardNumber(value);
+      setCardNumber(formatted);
+      fieldsRef.current.cardNumber = formatted;
+      syncToNative();
+    },
+    [syncToNative]
+  );
+
+  const updateExpiryDate = useCallback(
+    (value: string) => {
+      const formatted = formatExpiryDate(value, fieldsRef.current.expiryDate);
+      setExpiryDate(formatted);
+      fieldsRef.current.expiryDate = formatted;
+      syncToNative();
+    },
+    [syncToNative]
+  );
+
+  const updateCVV = useCallback(
+    (value: string) => {
+      const formatted = formatCVV(value);
+      setCVV(formatted);
+      fieldsRef.current.cvv = formatted;
+      syncToNative();
+    },
+    [syncToNative]
+  );
+
+  const updateCardholderName = useCallback(
+    (value: string) => {
+      setCardholderName(value);
+      fieldsRef.current.cardholderName = value;
+      syncToNative();
+    },
+    [syncToNative]
+  );
+
+  const markFieldTouched = useCallback((field: CardFormField) => {
+    setTouched((prev) => (prev[field] ? prev : { ...prev, [field]: true }));
+  }, []);
+
+  const errors = useMemo(() => {
+    const visible: CardFormErrors = {};
+    for (const field of Object.keys(cardFormState.errors) as CardFormField[]) {
+      if (touched[field]) {
+        visible[field] = cardFormState.errors[field];
+      }
+    }
+    return visible;
+  }, [cardFormState.errors, touched]);
+
+  const isSubmittingRef = useRef(false);
+  const submit = useCallback(async () => {
+    if (!isReady || activeMethod !== PAYMENT_METHOD_TYPE) {
+      console.warn(`${LOG} submit: not ready ${fmt({ isReady, activeMethod })}`);
+      return;
+    }
+    if (isSubmittingRef.current) return;
+    debouncedRef.current?.flush();
+    if (!cardFormState.isValid) return;
+    isSubmittingRef.current = true;
+    setIsSubmitting(true);
+    try {
+      await providerSubmit();
+    } catch (err) {
+      console.error(`${LOG} submit failed: ${err instanceof PrimerError ? err.errorId : 'unknown'}`);
+    } finally {
+      isSubmittingRef.current = false;
+      setIsSubmitting(false);
+    }
+  }, [isReady, activeMethod, cardFormState.isValid, providerSubmit]);
+
+  const reset = useCallback(() => {
+    setCardNumber('');
+    setExpiryDate('');
+    setCVV('');
+    setCardholderName('');
+    setTouched({ cardNumber: false, expiryDate: false, cvv: false, cardholderName: false });
+    setIsSubmitting(false);
+    isSubmittingRef.current = false;
+    fieldsRef.current = { cardNumber: '', expiryDate: '', cvv: '', cardholderName: '' };
+    debouncedRef.current?.cancel();
+    providerSetRawData({ cardNumber: '', expiryDate: '', cvv: '', cardholderName: '' }).catch(() => {});
+  }, [providerSetRawData]);
+
+  return {
+    cardNumber,
+    expiryDate,
+    cvv,
+    cardholderName,
+    updateCardNumber,
+    updateExpiryDate,
+    updateCVV,
+    updateCardholderName,
+    isValid: cardFormState.isValid,
+    errors,
+    markFieldTouched,
+    submit,
+    isSubmitting,
+    requiredFields: cardFormState.requiredFields,
+    binData: cardFormState.binData,
+    reset,
+  };
+}

--- a/src/Components/index.ts
+++ b/src/Components/index.ts
@@ -2,7 +2,12 @@ export { PrimerCheckoutProvider } from './PrimerCheckoutProvider';
 export { usePrimerCheckout } from './hooks/usePrimerCheckout';
 export { useLocalization } from './internal/localization';
 export { usePaymentMethods } from './hooks/usePaymentMethods';
-export type { PrimerCheckoutProviderProps, PrimerCheckoutContextValue } from './types/PrimerCheckoutProviderTypes';
+export type {
+  PrimerCheckoutProviderProps,
+  PrimerCheckoutContextValue,
+  PaymentOutcome,
+  CardFormState,
+} from './types/PrimerCheckoutProviderTypes';
 export type { TranslationParams } from './internal/localization';
 export type {
   PaymentMethodItem,
@@ -10,6 +15,8 @@ export type {
   UsePaymentMethodsOptions,
   UsePaymentMethodsReturn,
 } from './types/PaymentMethodTypes';
+export { useCardForm } from './hooks/useCardForm';
+export type { UseCardFormOptions, UseCardFormReturn, CardFormErrors, CardFormField } from './types/CardFormTypes';
 export { PrimerPaymentMethodList } from './PrimerPaymentMethodList';
 export type { PrimerPaymentMethodListProps } from './types/PrimerPaymentMethodListTypes';
 export { PrimerCheckoutSheet } from './PrimerCheckoutSheet';

--- a/src/Components/internal/debug.ts
+++ b/src/Components/internal/debug.ts
@@ -1,0 +1,12 @@
+/** Single-line formatter for console logs. Handles Error stacks and JSON circular refs. */
+export function fmt(value: unknown): string {
+  if (value instanceof Error) {
+    return value.stack ? `${value.message}\n${value.stack}` : value.message;
+  }
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/src/Components/types/CardFormTypes.ts
+++ b/src/Components/types/CardFormTypes.ts
@@ -1,0 +1,51 @@
+import type { PrimerBinData } from '../../models/PrimerBinData';
+import type { PrimerInputElementType } from '../../models/PrimerInputElementType';
+
+export type CardFormField = 'cardNumber' | 'expiryDate' | 'cvv' | 'cardholderName';
+
+export type CardFormErrors = Partial<Record<CardFormField, string>>;
+
+export interface UseCardFormOptions {
+  /** Called when validation state changes */
+  onValidationChange?: (isValid: boolean, errors: CardFormErrors) => void;
+  /** Called when card metadata changes (e.g., network detection) */
+  onMetadataChange?: (metadata: any) => void;
+  /** Called when BIN data changes */
+  onBinDataChange?: (binData: PrimerBinData) => void;
+}
+
+export interface UseCardFormReturn {
+  /** Formatted card number (with spaces). */
+  cardNumber: string;
+  /** Formatted expiry as MM/YY. */
+  expiryDate: string;
+  cvv: string;
+  cardholderName: string;
+
+  /** Auto-formats with spaces. */
+  updateCardNumber: (value: string) => void;
+  /** Auto-formats as MM/YY. */
+  updateExpiryDate: (value: string) => void;
+  updateCVV: (value: string) => void;
+  updateCardholderName: (value: string) => void;
+
+  /** Overall form validity as reported by the native SDK. */
+  isValid: boolean;
+  /** Per-field errors, surfaced only for touched fields. */
+  errors: CardFormErrors;
+  /** Marks a field as touched so its error can appear on blur. */
+  markFieldTouched: (field: CardFormField) => void;
+
+  /** Trigger tokenization. No-op if invalid or already submitting. */
+  submit: () => Promise<void>;
+  isSubmitting: boolean;
+
+  /** Fields the active client session requires. */
+  requiredFields: PrimerInputElementType[];
+
+  /** BIN / card network data from the native SDK. */
+  binData: PrimerBinData | null;
+
+  /** Clear all fields and reset local state. */
+  reset: () => void;
+}

--- a/src/Components/types/PrimerCheckoutProviderTypes.ts
+++ b/src/Components/types/PrimerCheckoutProviderTypes.ts
@@ -5,6 +5,9 @@ import type { PrimerClientSession } from '../../models/PrimerClientSession';
 import type { PrimerCheckoutData } from '../../models/PrimerCheckoutData';
 import type { PrimerCheckoutPaymentMethodData } from '../../models/PrimerCheckoutPaymentMethodData';
 import type { PrimerPaymentMethodTokenData } from '../../models/PrimerPaymentMethodTokenData';
+import type { PrimerRawData } from '../../models/PrimerRawData';
+import type { PrimerBinData } from '../../models/PrimerBinData';
+import type { PrimerInputElementType } from '../../models/PrimerInputElementType';
 import type {
   PrimerHeadlessUniversalCheckoutResumeHandler,
   PrimerPaymentCreationHandler,
@@ -12,6 +15,7 @@ import type {
 import type { IPrimerHeadlessUniversalCheckoutPaymentMethod } from '../../models/PrimerHeadlessUniversalCheckoutPaymentMethod';
 import type { PrimerPaymentMethodAsset, PrimerPaymentMethodNativeView } from '../../models/PrimerPaymentMethodResource';
 import type { PrimerThemeOverride } from '../internal/theme/types';
+import type { CardFormErrors } from './CardFormTypes';
 
 export interface PrimerCheckoutProviderProps {
   clientToken: string;
@@ -30,12 +34,55 @@ export interface PrimerCheckoutProviderProps {
   children?: ReactNode;
 }
 
+/** Outcome of the most recent payment attempt within a checkout session. */
+export type PaymentOutcome =
+  | { status: 'success'; data: PrimerCheckoutData }
+  | { status: 'error'; error: PrimerError; data: PrimerCheckoutData | null };
+
+/** Validation + metadata state surfaced by the active raw-data manager. */
+export interface CardFormState {
+  isValid: boolean;
+  errors: CardFormErrors;
+  binData: PrimerBinData | null;
+  metadata: unknown;
+  requiredFields: PrimerInputElementType[];
+}
+
 export interface PrimerCheckoutContextValue {
+  // --- Session state ---
   isReady: boolean;
+  /** Init-time errors only (before `isReady`). Payment-time errors land in `paymentOutcome`. */
   error: PrimerError | null;
   clientSession: PrimerClientSession | null;
   availablePaymentMethods: IPrimerHeadlessUniversalCheckoutPaymentMethod[];
   paymentMethodResources: Array<PrimerPaymentMethodAsset | PrimerPaymentMethodNativeView>;
   isLoadingResources: boolean;
   resourcesError: Error | null;
+  /** Settings the merchant passed to the provider. Needed for UI-option toggles. */
+  settings: PrimerSettings | undefined;
+
+  // --- Active payment attempt ---
+  /** Outcome of the most recent payment attempt; `null` before any submit. */
+  paymentOutcome: PaymentOutcome | null;
+  /** The payment method whose raw-data manager is currently active. */
+  activeMethod: string | null;
+  /** Validation + metadata state from the active raw-data manager. */
+  cardFormState: CardFormState;
+
+  // --- Actions ---
+  /** Register/deregister the active payment method. Pass `null` to tear down. */
+  setActiveMethod: (method: string | null) => void;
+  /** Forward raw data to the active native manager. */
+  setRawData: (data: PrimerRawData) => Promise<void>;
+  /** Fire the active manager's submit. First-attempt path. */
+  submit: () => Promise<void>;
+  /**
+   * Retry the last submit. Reconfigures the manager, re-sends the last raw data, then submits.
+   * The reconfigure is defensive for iOS: `RawDataManager.swift:237` nullifies the delegate on
+   * successful tokenization, so any post-tokenize failure would otherwise have no delegate
+   * to surface a retry's outcome. Reconfigure rebuilds the delegate binding. Harmless on Android.
+   */
+  retry: () => Promise<void>;
+  /** Clear the last payment outcome (e.g., when leaving the error screen). */
+  clearPaymentOutcome: () => void;
 }

--- a/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/RawDataManager.ts
+++ b/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/RawDataManager.ts
@@ -52,6 +52,14 @@ class PrimerHeadlessUniversalCheckoutRawDataManager {
   }
 
   async configureListeners(): Promise<void> {
+    // Drop previous subscriptions so calling configure() multiple times (e.g. the
+    // reconfigure-on-retry pattern in Checkout Components) doesn't stack duplicate
+    // event handlers on the shared module emitter.
+    for (const sub of this.subscriptions) {
+      sub.remove();
+    }
+    this.subscriptions = [];
+
     //@ts-ignore
     if (this.options?.onMetadataChange) {
       const sub = await this.addListener('onMetadataChange', (data) => {

--- a/src/__tests__/components/PrimerCheckoutProvider.test.tsx
+++ b/src/__tests__/components/PrimerCheckoutProvider.test.tsx
@@ -88,12 +88,10 @@ describe('PrimerCheckoutProvider', () => {
       await flushPromises();
     });
 
-    // First render: not ready
     expect(captures[0]!.isReady).toBe(false);
     expect(captures[0]!.error).toBeNull();
     expect(captures[0]!.availablePaymentMethods).toEqual([]);
 
-    // After init: ready with payment methods
     const last = captures[captures.length - 1]!;
     expect(last.isReady).toBe(true);
     expect(last.availablePaymentMethods).toHaveLength(1);
@@ -199,7 +197,6 @@ describe('PrimerCheckoutProvider', () => {
       await flushPromises();
     });
 
-    // Should still be 1 — callbacks are ref-stable
     expect(nativeModule.startWithClientToken).toHaveBeenCalledTimes(1);
   });
 
@@ -365,7 +362,13 @@ describe('PrimerCheckoutProvider native event callbacks', () => {
     });
 
     expect(onError).toHaveBeenCalled();
-    expect(captured!.error).toBeTruthy();
+    // Post-init errors land in paymentOutcome; `error` is reserved for init failures.
+    expect(captured!.paymentOutcome).toEqual({
+      status: 'error',
+      error: expect.objectContaining({ errorId: 'err-1' }),
+      data: null,
+    });
+    expect(captured!.error).toBeNull();
   });
 
   it('updates clientSession in context on onClientSessionUpdate', async () => {
@@ -452,7 +455,6 @@ describe('PrimerCheckoutProvider native event callbacks', () => {
       await flushPromises();
     });
 
-    // Update callback prop without changing clientToken
     await act(async () => {
       root!.update(
         createElement(PrimerCheckoutProvider, { clientToken: 'token-1', onCheckoutComplete: onCheckoutComplete2 }, null)
@@ -460,10 +462,8 @@ describe('PrimerCheckoutProvider native event callbacks', () => {
       await flushPromises();
     });
 
-    // Still only 1 init call
     expect(nativeModule.startWithClientToken).toHaveBeenCalledTimes(1);
 
-    // Fire the event — should use the latest callback
     const listener = findListener('onCheckoutComplete');
     const checkoutData = { payment: { id: 'pay_456' } };
 
@@ -478,7 +478,6 @@ describe('PrimerCheckoutProvider native event callbacks', () => {
 
 describe('usePrimerCheckout', () => {
   it('throws when called outside React render cycle', () => {
-    // Calling a hook outside a component throws React's own invalid hook error
     expect(() => usePrimerCheckout()).toThrow();
   });
 });

--- a/src/__tests__/components/usePaymentMethods.test.ts
+++ b/src/__tests__/components/usePaymentMethods.test.ts
@@ -87,6 +87,21 @@ const readyContext: PrimerCheckoutContextValue = {
   ],
   isLoadingResources: false,
   resourcesError: null,
+  settings: undefined,
+  paymentOutcome: null,
+  activeMethod: null,
+  cardFormState: {
+    isValid: false,
+    errors: {},
+    binData: null,
+    metadata: null,
+    requiredFields: [],
+  },
+  setActiveMethod: () => {},
+  setRawData: async () => {},
+  submit: async () => {},
+  retry: async () => {},
+  clearPaymentOutcome: () => {},
 };
 
 describe('usePaymentMethods', () => {
@@ -158,7 +173,7 @@ describe('usePaymentMethods', () => {
   it('handles methods without matching resources', () => {
     const ctx: PrimerCheckoutContextValue = {
       ...readyContext,
-      paymentMethodResources: [], // no resources
+      paymentMethodResources: [],
     };
     const { result } = renderHook(() => usePaymentMethods(), contextWrapper(ctx));
     expect(result.current.paymentMethods).toHaveLength(3);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -140,6 +140,8 @@ export type {
   UsePaymentMethodsOptions,
   UsePaymentMethodsReturn,
 } from './Components';
+export { useCardForm } from './Components';
+export type { UseCardFormOptions, UseCardFormReturn, CardFormErrors, CardFormField } from './Components';
 export { PrimerPaymentMethodList } from './Components';
 export type { PrimerPaymentMethodListProps } from './Components';
 export { PrimerCheckoutSheet } from './Components';

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,33 @@
+export type DebouncedFunction<T extends (...args: any[]) => any> = ((...args: Parameters<T>) => void) & {
+  cancel: () => void;
+  flush: () => void;
+};
+
+export function debounce<T extends (...args: any[]) => any>(fn: T, delay: number): DebouncedFunction<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let lastArgs: Parameters<T> | null = null;
+  const debounced = (...args: Parameters<T>) => {
+    lastArgs = args;
+    if (timer != null) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => {
+      timer = null;
+      fn(...args);
+    }, delay);
+  };
+  debounced.cancel = () => {
+    if (timer != null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+  debounced.flush = () => {
+    if (timer != null) {
+      clearTimeout(timer);
+      timer = null;
+      fn(...lastArgs!);
+    }
+  };
+  return debounced;
+}


### PR DESCRIPTION
## Summary

- Add `useCardForm()` hook that wraps RawDataManager to provide managed card form state, auto-formatting, touch-based validation, debounced native sync, BIN detection, and guarded submit for tokenization/3DS
- Add `useRawDataManagerBridge` internal hook managing RawDataManager lifecycle, event subscription, and cleanup
- Add `CardFormTypes` with `UseCardFormOptions`, `UseCardFormReturn`, `CardFormErrors`, `CardFormField`
- Add `debounce` utility in `src/utils/debounce.ts`
- Export `useCardForm` and types from package root

## Jira

[ACC-6925](https://primerapi.atlassian.net/browse/ACC-6925)

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 32/32 tests pass
- [x] `npx tsc --noEmit` — no TypeScript errors
- [ ] Manual: verify hook initializes RawDataManager when SDK is ready
- [ ] Manual: verify card number auto-formats with spaces
- [ ] Manual: verify expiry auto-formats as MM/YY
- [ ] Manual: verify validation errors surface only for touched fields
- [ ] Manual: verify submit is no-op when form is invalid

[ACC-6925]: https://primerapi.atlassian.net/browse/ACC-6925