### PR TITLE
feat: add prebuilt PrimerCardForm and payment outcome flow (ACC-6495)

### DIFF
--- a/example/src/screens/CheckoutComponentsListScreen.tsx
+++ b/example/src/screens/CheckoutComponentsListScreen.tsx
@@ -111,7 +111,6 @@ export function CheckoutComponentsListScreen() {
           settings={settings}
           onCheckoutComplete={checkoutData => {
             console.log('Checkout complete:', checkoutData);
-            setSheetVisible(false);
           }}
           onError={error => {
             console.error('Checkout error:', error);

--- a/src/Components/PrimerCardForm.tsx
+++ b/src/Components/PrimerCardForm.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTheme } from './internal/theme';
+import type { PrimerTokens } from './internal/theme';
+import { CardNumberInput } from './inputs/CardNumberInput';
+import { ExpiryDateInput } from './inputs/ExpiryDateInput';
+import { CVVInput } from './inputs/CVVInput';
+import { CardholderNameInput } from './inputs/CardholderNameInput';
+import type { PrimerTextInputRef } from './types/CardInputTypes';
+import type { PrimerCardFormProps } from './types/PrimerCardFormTypes';
+
+export function PrimerCardForm({
+  cardForm,
+  onSubmit,
+  autoFocus = false,
+  style,
+  testID = 'primer-card-form',
+}: PrimerCardFormProps) {
+  const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+
+  const cardRef = useRef<PrimerTextInputRef>(null);
+  const expiryRef = useRef<PrimerTextInputRef>(null);
+  const cvvRef = useRef<PrimerTextInputRef>(null);
+  const nameRef = useRef<PrimerTextInputRef>(null);
+
+  // Delay tracks NavigationContainer's 250ms push; focusing sooner opens the
+  // keyboard mid-slide and jumps the layout.
+  useEffect(() => {
+    if (!autoFocus) return;
+    const handle = setTimeout(() => cardRef.current?.focus(), 300);
+    return () => clearTimeout(handle);
+  }, [autoFocus]);
+
+  const disabled = cardForm.isSubmitting;
+
+  return (
+    <View style={[styles.container, style]} testID={testID}>
+      <CardNumberInput
+        ref={cardRef}
+        cardForm={cardForm}
+        editable={!disabled}
+        returnKeyType="next"
+        onSubmitEditing={() => expiryRef.current?.focus()}
+        testID={`${testID}-card-number`}
+      />
+
+      <View style={styles.row}>
+        <View style={styles.halfField}>
+          <ExpiryDateInput
+            ref={expiryRef}
+            cardForm={cardForm}
+            editable={!disabled}
+            returnKeyType="next"
+            onSubmitEditing={() => cvvRef.current?.focus()}
+            testID={`${testID}-expiry`}
+          />
+        </View>
+        <View style={styles.halfField}>
+          <CVVInput
+            ref={cvvRef}
+            cardForm={cardForm}
+            editable={!disabled}
+            returnKeyType="next"
+            onSubmitEditing={() => nameRef.current?.focus()}
+            testID={`${testID}-cvv`}
+          />
+        </View>
+      </View>
+
+      <CardholderNameInput
+        ref={nameRef}
+        cardForm={cardForm}
+        editable={!disabled}
+        returnKeyType="done"
+        onSubmitEditing={onSubmit}
+        testID={`${testID}-cardholder-name`}
+      />
+    </View>
+  );
+}
+
+function createStyles(tokens: PrimerTokens) {
+  const { spacing } = tokens;
+  /* eslint-disable react-native/no-unused-styles */
+  return StyleSheet.create({
+    container: {
+      gap: spacing.medium,
+      width: '100%',
+    },
+    halfField: {
+      flex: 1,
+    },
+    row: {
+      flexDirection: 'row',
+      gap: spacing.medium,
+    },
+  });
+  /* eslint-enable react-native/no-unused-styles */
+}

--- a/src/Components/PrimerCheckoutProvider.tsx
+++ b/src/Components/PrimerCheckoutProvider.tsx
@@ -8,6 +8,7 @@ import PrimerHeadlessUniversalCheckoutAssetsManager from '../HeadlessUniversalCh
 import PrimerHeadlessUniversalCheckoutRawDataManager from '../HeadlessUniversalCheckout/Managers/PaymentMethodManagers/RawDataManager';
 import type { PrimerSettings } from '../models/PrimerSettings';
 import { PrimerError } from '../models/PrimerError';
+import type { PrimerCheckoutData } from '../models/PrimerCheckoutData';
 import type { PrimerRawData } from '../models/PrimerRawData';
 import type { PrimerBinData } from '../models/PrimerBinData';
 import type {
@@ -57,6 +58,24 @@ const initialState: InternalState = {
   activeMethod: null,
   cardFormState: initialCardFormState,
 };
+
+/**
+ * Native `onCheckoutComplete` fires for every terminal checkout, including
+ * FAILED ones — so we inspect `payment.status` to pick the result screen.
+ */
+function buildPaymentOutcome(checkoutData: PrimerCheckoutData): PaymentOutcome {
+  const payment = checkoutData?.payment;
+  if (payment?.status !== 'FAILED') {
+    return { status: 'success', data: checkoutData };
+  }
+  const errorCode = payment.paymentFailureReason ?? 'payment-failed';
+  const description = payment.id ? `Payment ${payment.id} failed` : 'Payment failed';
+  return {
+    status: 'error',
+    error: new PrimerError('payment-failed', errorCode, description, undefined, undefined),
+    data: checkoutData,
+  };
+}
 
 /** Map native validation errors to per-field typed errors the UI can render. */
 function parseValidationErrors(errors: PrimerError[] | undefined): CardFormErrors {
@@ -166,9 +185,12 @@ export function PrimerCheckoutProvider({
         },
         // Always-subscribed so paymentOutcome fires regardless of merchant callbacks.
         onCheckoutComplete: (checkoutData) => {
+          // Native fires onCheckoutComplete for any finished checkout — including
+          // FAILED payments — so we have to read `payment.status` to decide which
+          // result screen to show. Backend statuses: SUCCESS | FAILED | PENDING.
           setState((prev) => ({
             ...prev,
-            paymentOutcome: { status: 'success', data: checkoutData },
+            paymentOutcome: buildPaymentOutcome(checkoutData),
           }));
           onCheckoutCompleteRef.current?.(checkoutData);
           settingsRef.current?.headlessUniversalCheckoutCallbacks?.onCheckoutComplete?.(checkoutData);

--- a/src/Components/PrimerCheckoutProvider.tsx
+++ b/src/Components/PrimerCheckoutProvider.tsx
@@ -90,7 +90,7 @@ function parseValidationErrors(errors: PrimerError[] | undefined): CardFormError
       fieldErrors.expiryDate = description;
     } else if (id.includes('cvv') || id.includes('cvc')) {
       fieldErrors.cvv = description;
-    } else if (id.includes('cardholder') || id.includes('name')) {
+    } else if (id.includes('cardholder') || id.includes('card_holder')) {
       fieldErrors.cardholderName = description;
     }
   }
@@ -139,6 +139,10 @@ export function PrimerCheckoutProvider({
     onBinDataChange: (binData: PrimerBinData) => void;
     onMetadataChange: (metadata: unknown) => void;
   } | null>(null);
+  // Marks the manager that `retry()` currently holds. Effect cleanup defers
+  // teardown of this manager so an in-flight submit/configure isn't destroyed.
+  const retryingManagerRef = useRef<PrimerHeadlessUniversalCheckoutRawDataManager | null>(null);
+  const pendingCleanupRef = useRef<PrimerHeadlessUniversalCheckoutRawDataManager | null>(null);
 
   // -----------------------------------------------------------------------
   // Session init — create headless checkout + wire session-level callbacks.
@@ -402,6 +406,12 @@ export function PrimerCheckoutProvider({
 
     return () => {
       cancelled = true;
+      // If retry() holds this manager, defer destroy until retry's finally
+      // runs — otherwise we'd cleanUp() between its awaited configure/submit.
+      if (retryingManagerRef.current === m) {
+        pendingCleanupRef.current = m;
+        return;
+      }
       m.cleanUp().catch((err) => console.warn(`${LOG} manager cleanUp failed ${fmt(err)}`));
       m.removeAllListeners();
       if (managerRef.current === m) {
@@ -454,6 +464,7 @@ export function PrimerCheckoutProvider({
     // successful tokenization, so any post-tokenize failure would silently drop subsequent
     // submit() outcomes. Reconfiguring here rebuilds the delegate binding. Harmless on
     // Android. Remove the reconfigure once the iOS SDK stops nullifying.
+    retryingManagerRef.current = m;
     try {
       // Re-pass the original callbacks so the JS-wrapper's listeners get re-registered.
       // Otherwise native would emit onValidation/onBinDataChange/onMetadataChange during
@@ -469,6 +480,20 @@ export function PrimerCheckoutProvider({
     } catch (err) {
       console.error(`${LOG} retry failed ${fmt(err)}`);
       throw err;
+    } finally {
+      retryingManagerRef.current = null;
+      // Run a teardown that the effect cleanup deferred while retry was in flight.
+      const pending = pendingCleanupRef.current;
+      if (pending === m) {
+        pendingCleanupRef.current = null;
+        pending.cleanUp().catch((err) => console.warn(`${LOG} deferred cleanUp failed ${fmt(err)}`));
+        pending.removeAllListeners();
+        if (managerRef.current === pending) {
+          managerRef.current = null;
+        }
+        lastManagerCallbacksRef.current = null;
+        setState((prev) => ({ ...prev, cardFormState: initialCardFormState }));
+      }
     }
   }, []);
 

--- a/src/Components/index.ts
+++ b/src/Components/index.ts
@@ -21,6 +21,8 @@ export { PrimerPaymentMethodList } from './PrimerPaymentMethodList';
 export type { PrimerPaymentMethodListProps } from './types/PrimerPaymentMethodListTypes';
 export { PrimerCheckoutSheet } from './PrimerCheckoutSheet';
 export type { PrimerCheckoutSheetProps } from './PrimerCheckoutSheet';
+export { PrimerCardForm } from './PrimerCardForm';
+export type { PrimerCardFormProps } from './types/PrimerCardFormTypes';
 export { PrimerTextInput, CardNumberInput, ExpiryDateInput, CVVInput, CardholderNameInput } from './inputs';
 export type {
   PrimerTextInputTheme,

--- a/src/Components/internal/checkout-flow/CheckoutFlow.tsx
+++ b/src/Components/internal/checkout-flow/CheckoutFlow.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useContext, useEffect, useMemo, useRef } from 'react';
 import { NavigationProvider } from '../navigation/NavigationProvider';
 import { NavigationContainer } from '../navigation/NavigationContainer';
 import { useNavigation } from '../navigation/useNavigation';
@@ -7,19 +7,37 @@ import type { CheckoutRoute as CheckoutRouteType } from '../navigation/types';
 import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
 import { LoadingScreen } from '../screens/LoadingScreen';
 import { MethodSelectionScreen } from '../screens/MethodSelectionScreen';
+import { CardFormScreen } from '../screens/CardFormScreen';
 import { ErrorScreen } from '../screens/ErrorScreen';
+import { SuccessScreen } from '../screens/SuccessScreen';
 import { CheckoutFlowContext } from './CheckoutFlowContext';
+
+const SUCCESS_AUTO_DISMISS_MS = 5000;
+
+function CheckoutSuccessScreen() {
+  const flow = useContext(CheckoutFlowContext);
+  const { clearPaymentOutcome } = usePrimerCheckout();
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      clearPaymentOutcome();
+      flow?.onCancel();
+    }, SUCCESS_AUTO_DISMISS_MS);
+    return () => clearTimeout(t);
+  }, [flow, clearPaymentOutcome]);
+
+  return <SuccessScreen />;
+}
 
 const screenMap: Partial<Record<CheckoutRouteType, React.ComponentType>> = {
   [CheckoutRoute.splash]: LoadingScreen,
   [CheckoutRoute.methodSelection]: MethodSelectionScreen,
+  [CheckoutRoute.cardForm]: CardFormScreen,
+  [CheckoutRoute.processing]: LoadingScreen,
+  [CheckoutRoute.success]: CheckoutSuccessScreen,
   [CheckoutRoute.error]: ErrorScreen,
 };
 
-/**
- * Watches checkout readiness and navigates from loading to method selection.
- * Renders nothing — purely a side-effect component.
- */
 function ReadinessTransitioner() {
   const { isReady, isLoadingResources, error } = usePrimerCheckout();
   const { replace } = useNavigation();
@@ -43,8 +61,42 @@ function ReadinessTransitioner() {
   return null;
 }
 
+function PaymentOutcomeTransitioner() {
+  const { paymentOutcome, settings, clearPaymentOutcome } = usePrimerCheckout();
+  const { replace } = useNavigation();
+  const flow = useContext(CheckoutFlowContext);
+  const lastOutcomeRef = useRef<typeof paymentOutcome>(null);
+
+  useEffect(() => {
+    // Guard against re-fires when unrelated context fields change.
+    if (paymentOutcome === lastOutcomeRef.current) return;
+    lastOutcomeRef.current = paymentOutcome;
+
+    if (!paymentOutcome) return;
+
+    const uiOptions = settings?.uiOptions;
+
+    if (paymentOutcome.status === 'success') {
+      if (uiOptions?.isSuccessScreenEnabled === false) {
+        clearPaymentOutcome();
+        flow?.onCancel();
+        return;
+      }
+      replace(CheckoutRoute.success, { checkoutData: paymentOutcome.data });
+    } else {
+      if (uiOptions?.isErrorScreenEnabled === false) {
+        clearPaymentOutcome();
+        flow?.onCancel();
+        return;
+      }
+      replace(CheckoutRoute.error, { error: paymentOutcome.error });
+    }
+  }, [paymentOutcome, settings, replace, clearPaymentOutcome, flow]);
+
+  return null;
+}
+
 export interface CheckoutFlowProps {
-  /** Called when the user requests to cancel/close the checkout flow */
   onCancel?: () => void;
 }
 
@@ -55,6 +107,7 @@ export function CheckoutFlow({ onCancel }: CheckoutFlowProps = {}) {
     <CheckoutFlowContext.Provider value={contextValue}>
       <NavigationProvider initialRoute={CheckoutRoute.splash}>
         <ReadinessTransitioner />
+        <PaymentOutcomeTransitioner />
         <NavigationContainer screenMap={screenMap} />
       </NavigationProvider>
     </CheckoutFlowContext.Provider>

--- a/src/Components/internal/checkout-sheet/CheckoutSheet.tsx
+++ b/src/Components/internal/checkout-sheet/CheckoutSheet.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { HeightReleaseFn } from './SheetHeightContext';
 import {
   Animated,
   Easing,
@@ -36,14 +37,17 @@ export function CheckoutSheet({
   const styles = useMemo(() => createStyles(tokens), [tokens]);
 
   const [modalVisible, setModalVisible] = useState(false);
-  const [heightRatio, setHeightRatioState] = useState(DEFAULT_HEIGHT_RATIO);
+  // Token-keyed stack: latest entry wins. Per-token release prevents a stale screen's
+  // cleanup from clobbering the current screen's height request.
+  const [heightRequests, setHeightRequests] = useState<Array<{ token: number; ratio: number }>>([]);
+  const heightRatio =
+    heightRequests.length > 0 ? heightRequests[heightRequests.length - 1]!.ratio : DEFAULT_HEIGHT_RATIO;
+  const nextTokenRef = useRef(0);
 
-  // Show/hide animation: 0 = hidden (off-screen below), 1 = fully shown
+  // 0 = hidden (off-screen below), 1 = fully shown.
   const showAnimValue = useRef(new Animated.Value(0)).current;
-  // Height offset: translateY to push the sheet down so only the desired height is visible.
-  // 0 = full screen, (screenHeight - sheetHeight) = shows only sheetHeight from the bottom.
+  // translateY that pushes the sheet down so only `heightRatio` of the screen shows.
   const heightOffsetValue = useRef(new Animated.Value(screenHeight * (1 - DEFAULT_HEIGHT_RATIO))).current;
-  // Drag offset: tracks finger position during a swipe-down gesture.
   const dragValue = useRef(new Animated.Value(0)).current;
   const isMountedRef = useRef(true);
 
@@ -58,7 +62,6 @@ export function CheckoutSheet({
     };
   }, []);
 
-  // Animate height offset when heightRatio changes
   useEffect(() => {
     Animated.timing(heightOffsetValue, {
       toValue: heightOffset,
@@ -117,11 +120,10 @@ export function CheckoutSheet({
     });
   }, [dragValue, sheetHeight, showAnimValue, onDismiss, onRequestDismiss]);
 
-  // Handle visible prop changes (including initial mount with visible=true)
   const prevVisibleRef = useRef(false);
   useEffect(() => {
     if (visible && !prevVisibleRef.current) {
-      setHeightRatioState(DEFAULT_HEIGHT_RATIO);
+      setHeightRequests([]);
       heightOffsetValue.setValue(screenHeight * (1 - DEFAULT_HEIGHT_RATIO));
       setModalVisible(true);
     } else if (!visible && prevVisibleRef.current && modalVisible) {
@@ -166,25 +168,29 @@ export function CheckoutSheet({
     [dismissOnSwipeDown, sheetHeight, dragValue, dismissBySwipe, springDragBack]
   );
 
-  const sheetHeightContextValue = useMemo<SheetHeightContextValue>(
-    () => ({
-      setHeight: (h: number) => setHeightRatioState(Math.max(MIN_HEIGHT_RATIO, Math.min(1, h / screenHeight))),
-      setHeightRatio: (ratio: number) => setHeightRatioState(Math.max(MIN_HEIGHT_RATIO, Math.min(1, ratio))),
-      resetHeight: () => setHeightRatioState(DEFAULT_HEIGHT_RATIO),
-    }),
-    [screenHeight]
-  );
+  const sheetHeightContextValue = useMemo<SheetHeightContextValue>(() => {
+    const register = (ratio: number): HeightReleaseFn => {
+      const clamped = Math.max(MIN_HEIGHT_RATIO, Math.min(1, ratio));
+      const token = nextTokenRef.current++;
+      setHeightRequests((prev) => [...prev, { token, ratio: clamped }]);
+      return () => {
+        setHeightRequests((prev) => prev.filter((r) => r.token !== token));
+      };
+    };
+    return {
+      requestHeight: (h: number) => register(h / screenHeight),
+      requestHeightRatio: (r: number) => register(r),
+    };
+  }, [screenHeight]);
 
-  // Show/hide: slide the entire sheet from below the screen to its resting position
+  // Slide the entire sheet from below the screen to its resting position.
   const showTranslateY = showAnimValue.interpolate({
     inputRange: [0, 1],
     outputRange: [screenHeight, 0],
   });
 
-  // Combined translateY: show animation + height offset + drag offset
   const translateY = Animated.add(Animated.add(showTranslateY, heightOffsetValue), dragValue);
 
-  // Backdrop fades with both the show animation and the drag progress
   const backdropOpacity = Animated.multiply(
     showAnimValue,
     dragValue.interpolate({

--- a/src/Components/internal/checkout-sheet/SheetHeightContext.ts
+++ b/src/Components/internal/checkout-sheet/SheetHeightContext.ts
@@ -1,12 +1,16 @@
 import { createContext, useContext } from 'react';
 
+export type HeightReleaseFn = () => void;
+
 export interface SheetHeightContextValue {
-  /** Set sheet height in absolute pixels. */
-  setHeight: (height: number) => void;
-  /** Set sheet height as a fraction of screen height (0-1). */
-  setHeightRatio: (ratio: number) => void;
-  /** Reset sheet height to default. */
-  resetHeight: () => void;
+  /**
+   * Request `height` px of sheet. Returns a release for this specific request — the
+   * per-request release (instead of a free-standing reset) prevents a stale screen's
+   * cleanup from clobbering a newer screen's active request.
+   */
+  requestHeight: (height: number) => HeightReleaseFn;
+  /** Same as `requestHeight` but expressed as a 0–1 ratio of screen height. */
+  requestHeightRatio: (ratio: number) => HeightReleaseFn;
 }
 
 export const SheetHeightContext = createContext<SheetHeightContextValue | null>(null);

--- a/src/Components/internal/navigation/NavigationContainer.tsx
+++ b/src/Components/internal/navigation/NavigationContainer.tsx
@@ -1,5 +1,6 @@
-import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { View, Animated, StyleSheet, useWindowDimensions } from 'react-native';
+import type { ViewStyle } from 'react-native';
 import { NavigationContext, RouteEntryContext } from './NavigationContext';
 import { useTheme } from '../theme';
 import type { CheckoutRoute, RouteEntry } from './types';
@@ -26,10 +27,6 @@ export function NavigationContainer({ screenMap }: NavigationContainerProps) {
   }
 
   const tokens = useTheme();
-  const screenStyle = useMemo(
-    () => [styles.screen, { backgroundColor: tokens.colors.background }],
-    [tokens.colors.background]
-  );
   const { width } = useWindowDimensions();
   const { state } = context;
   const current = state.stack[state.stack.length - 1]!;
@@ -52,7 +49,6 @@ export function NavigationContainer({ screenMap }: NavigationContainerProps) {
       type = 'replace';
     }
 
-    // Set transition state synchronously so this render already shows both screens
     setTransition({ type, outgoingEntry: prevEntryRef.current });
     animValue.setValue(0);
     needsAnimationRef.current = true;
@@ -66,7 +62,6 @@ export function NavigationContainer({ screenMap }: NavigationContainerProps) {
     context.setAnimating(false);
   }, [context]);
 
-  // Start the animation after the render with both screens visible
   useEffect(() => {
     if (!needsAnimationRef.current) return;
     needsAnimationRef.current = false;
@@ -91,69 +86,84 @@ export function NavigationContainer({ screenMap }: NavigationContainerProps) {
     return null;
   }
 
-  const renderScreen = (Component: React.ComponentType, entry: RouteEntry) => (
-    <RouteEntryContext.Provider value={entry}>
-      <Component />
-    </RouteEntryContext.Provider>
-  );
+  // Always render the current screen inside a stable Animated.View wrapper keyed by its route.
+  // The outgoing screen is rendered as a sibling only during transitions. Consequence: the
+  // current screen's component instance is preserved across transition start/end — no remount,
+  // no useEffect re-runs caused by the container swapping tree shapes.
+  const bg = { backgroundColor: tokens.colors.background };
+  const currentZIndex = transition.type === 'pop' ? 1 : 2;
+  const outgoingZIndex = transition.type === 'pop' ? 2 : 1;
+  const showOutgoing = transition.type !== 'none' && !!OutgoingComponent && !!transition.outgoingEntry;
 
-  if (transition.type === 'none' || !OutgoingComponent || !transition.outgoingEntry) {
-    return <View style={styles.container}>{renderScreen(ScreenComponent, current)}</View>;
-  }
-
-  if (transition.type === 'replace') {
-    return (
-      <View style={styles.container}>
-        <Animated.View style={[screenStyle, { opacity: Animated.subtract(1, animValue) }]}>
-          {renderScreen(OutgoingComponent, transition.outgoingEntry)}
-        </Animated.View>
-        <Animated.View style={[screenStyle, { opacity: animValue }]}>
-          {renderScreen(ScreenComponent, current)}
-        </Animated.View>
-      </View>
-    );
-  }
-
-  if (transition.type === 'push') {
-    const outgoingTranslate = animValue.interpolate({
-      inputRange: [0, 1],
-      outputRange: [0, -width * 0.3],
-    });
-    const incomingTranslate = animValue.interpolate({
-      inputRange: [0, 1],
-      outputRange: [width, 0],
-    });
-    return (
-      <View style={styles.container}>
-        <Animated.View style={[screenStyle, { transform: [{ translateX: outgoingTranslate }] }]}>
-          {renderScreen(OutgoingComponent, transition.outgoingEntry)}
-        </Animated.View>
-        <Animated.View style={[screenStyle, { transform: [{ translateX: incomingTranslate }] }]}>
-          {renderScreen(ScreenComponent, current)}
-        </Animated.View>
-      </View>
-    );
-  }
-
-  // Pop
-  const outgoingTranslate = animValue.interpolate({
-    inputRange: [0, 1],
-    outputRange: [0, width],
-  });
-  const incomingTranslate = animValue.interpolate({
-    inputRange: [0, 1],
-    outputRange: [-width * 0.3, 0],
-  });
   return (
     <View style={styles.container}>
-      <Animated.View style={[screenStyle, { transform: [{ translateX: incomingTranslate }] }]}>
-        {renderScreen(ScreenComponent, current)}
+      <Animated.View
+        key={`screen-${current.key}`}
+        style={[styles.screen, bg, { zIndex: currentZIndex }, renderCurrentAnim(transition.type, animValue, width)]}
+      >
+        <RouteEntryContext.Provider value={current}>
+          <ScreenComponent />
+        </RouteEntryContext.Provider>
       </Animated.View>
-      <Animated.View style={[screenStyle, { transform: [{ translateX: outgoingTranslate }] }]}>
-        {renderScreen(OutgoingComponent, transition.outgoingEntry)}
-      </Animated.View>
+      {showOutgoing && OutgoingComponent && transition.outgoingEntry && (
+        <Animated.View
+          key={`screen-${transition.outgoingEntry.key}`}
+          style={[styles.screen, bg, { zIndex: outgoingZIndex }, renderOutgoingAnim(transition.type, animValue, width)]}
+        >
+          <RouteEntryContext.Provider value={transition.outgoingEntry}>
+            <OutgoingComponent />
+          </RouteEntryContext.Provider>
+        </Animated.View>
+      )}
     </View>
   );
+}
+
+// Animated styles use the Animated.View's style prop type, which is wider than the
+// static StyleProp<ViewStyle>. Returning `Animated.WithAnimatedValue<ViewStyle>`
+// keeps full type safety without resorting to `any`.
+function renderCurrentAnim(
+  type: TransitionType,
+  animValue: Animated.Value,
+  width: number
+): Animated.WithAnimatedValue<ViewStyle> | null {
+  switch (type) {
+    case 'replace':
+      return { opacity: animValue };
+    case 'push':
+      return {
+        transform: [{ translateX: animValue.interpolate({ inputRange: [0, 1], outputRange: [width, 0] }) }],
+      };
+    case 'pop':
+      return {
+        transform: [{ translateX: animValue.interpolate({ inputRange: [0, 1], outputRange: [-width * 0.3, 0] }) }],
+      };
+    case 'none':
+    default:
+      return null;
+  }
+}
+
+function renderOutgoingAnim(
+  type: TransitionType,
+  animValue: Animated.Value,
+  width: number
+): Animated.WithAnimatedValue<ViewStyle> | null {
+  switch (type) {
+    case 'replace':
+      return { opacity: Animated.subtract(1, animValue) };
+    case 'push':
+      return {
+        transform: [{ translateX: animValue.interpolate({ inputRange: [0, 1], outputRange: [0, -width * 0.3] }) }],
+      };
+    case 'pop':
+      return {
+        transform: [{ translateX: animValue.interpolate({ inputRange: [0, 1], outputRange: [0, width] }) }],
+      };
+    case 'none':
+    default:
+      return null;
+  }
 }
 
 const styles = StyleSheet.create({

--- a/src/Components/internal/screens/CardFormScreen.tsx
+++ b/src/Components/internal/screens/CardFormScreen.tsx
@@ -1,0 +1,118 @@
+import { useCallback, useMemo } from 'react';
+import { ActivityIndicator, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import type { TextStyle } from 'react-native';
+import { useTheme } from '../theme';
+import type { PrimerTokens } from '../theme';
+import { NavigationHeader } from '../navigation/NavigationHeader';
+import { useNavigation } from '../navigation/useNavigation';
+import { CheckoutRoute } from '../navigation/types';
+import { useLocalization } from '../localization';
+import { useCheckoutFlow } from '../checkout-flow/CheckoutFlowContext';
+import { PrimerCardForm } from '../../PrimerCardForm';
+import { useCardForm } from '../../hooks/useCardForm';
+
+export function CardFormScreen() {
+  const tokens = useTheme();
+  const { t } = useLocalization();
+  const { pop, replace, canGoBack } = useNavigation();
+  const { onCancel } = useCheckoutFlow();
+  const cardForm = useCardForm();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+
+  const canSubmit = cardForm.isValid && !cardForm.isSubmitting;
+
+  // Jump to processing on Pay so the user doesn't stare at a stale form during tokenization.
+  const handlePay = useCallback(() => {
+    if (!canSubmit) return;
+    replace(CheckoutRoute.processing);
+    cardForm.submit();
+  }, [canSubmit, cardForm, replace]);
+
+  return (
+    <View style={styles.root}>
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+        automaticallyAdjustKeyboardInsets
+      >
+        <NavigationHeader
+          title={t('primer_card_form_title')}
+          showBackButton={canGoBack}
+          backLabel={t('primer_common_back')}
+          onBackPress={pop}
+          rightAction={{ label: t('primer_common_button_cancel'), onPress: onCancel }}
+        />
+        <View style={styles.body}>
+          <PrimerCardForm cardForm={cardForm} autoFocus onSubmit={handlePay} />
+          <TouchableOpacity
+            onPress={handlePay}
+            disabled={!canSubmit}
+            activeOpacity={0.7}
+            style={[styles.payButton, !canSubmit && styles.payButtonDisabled]}
+            accessibilityRole="button"
+            accessibilityState={{ disabled: !canSubmit, busy: cardForm.isSubmitting }}
+            accessibilityLabel={t('accessibility_card_form_submit_label')}
+            accessibilityHint={
+              cardForm.isSubmitting
+                ? t('accessibility_card_form_submit_loading')
+                : canSubmit
+                  ? t('accessibility_card_form_submit_hint')
+                  : t('accessibility_card_form_submit_disabled')
+            }
+            testID="primer-card-form-submit"
+          >
+            {cardForm.isSubmitting ? (
+              <ActivityIndicator color={tokens.colors.background} />
+            ) : (
+              <Text style={styles.payButtonText}>{t('primer_common_button_pay')}</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+function createStyles(tokens: PrimerTokens) {
+  const { colors, radii, spacing, typography } = tokens;
+  /* eslint-disable react-native/no-unused-styles */
+  return StyleSheet.create({
+    body: {
+      gap: spacing.medium,
+      paddingBottom: spacing.large,
+      paddingHorizontal: spacing.large,
+      paddingTop: spacing.large,
+    },
+    payButton: {
+      alignItems: 'center',
+      backgroundColor: colors.primary,
+      borderRadius: radii.medium,
+      justifyContent: 'center',
+      marginTop: spacing.small,
+      minHeight: 44,
+      padding: spacing.medium,
+      width: '100%',
+    },
+    payButtonDisabled: {
+      opacity: 0.5,
+    },
+    payButtonText: {
+      color: colors.background,
+      fontFamily: typography.titleLarge.fontFamily,
+      fontSize: typography.titleLarge.fontSize,
+      fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],
+      letterSpacing: typography.titleLarge.letterSpacing,
+      lineHeight: typography.titleLarge.lineHeight,
+      textAlign: 'center',
+    },
+    root: {
+      flex: 1,
+    },
+    scroll: {
+      flexGrow: 1,
+      paddingTop: spacing.large,
+    },
+  });
+  /* eslint-enable react-native/no-unused-styles */
+}

--- a/src/Components/internal/screens/ErrorScreen.tsx
+++ b/src/Components/internal/screens/ErrorScreen.tsx
@@ -9,7 +9,10 @@ import { useStatusScreenHeight } from './useStatusScreenHeight';
 import { STATUS_SCREEN_ICON_SIZE } from './constants';
 import { useBottomSafeArea } from './useBottomSafeArea';
 import { CheckoutButton } from '../ui';
+import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
+import { fmt } from '../debug';
 
+const LOG = '[ErrorScreen]';
 const errorIcon = require('./assets/error-large.png');
 const CONTENT_HEIGHT = 282;
 const TOP_PADDING = 34;
@@ -17,8 +20,9 @@ const TOP_PADDING = 34;
 export function ErrorScreen() {
   const tokens = useTheme();
   const { t } = useLocalization();
-  const { popToRoot } = useNavigation();
+  const { replace } = useNavigation();
   const { params } = useRoute<CheckoutRoute.error>();
+  const { retry, clearPaymentOutcome } = usePrimerCheckout();
   const rawBottomInset = useBottomSafeArea();
   const bottomInset = Math.max(rawBottomInset, tokens.spacing.large);
   const sheetHeight = TOP_PADDING + CONTENT_HEIGHT + bottomInset;
@@ -28,6 +32,18 @@ export function ErrorScreen() {
   const title = params?.title ?? t('primer_checkout_error_title');
   const subtitle = params?.subtitle ?? params?.error?.description ?? t('primer_checkout_error_subtitle');
 
+  const onRetry = () => {
+    // Navigate to processing first so the user sees an immediate spinner;
+    // the outcome transitioner replaces with success/error when retry resolves.
+    replace(CheckoutRoute.processing);
+    retry().catch((err) => console.warn(`${LOG} retry error ${fmt(err)}`));
+  };
+
+  const onChooseOther = () => {
+    clearPaymentOutcome();
+    replace(CheckoutRoute.methodSelection);
+  };
+
   return (
     <View style={{ height: sheetHeight, paddingTop: TOP_PADDING, paddingBottom: bottomInset }}>
       <StatusScreenLayout
@@ -36,11 +52,11 @@ export function ErrorScreen() {
         subtitle={subtitle}
       >
         <View style={styles.buttonGroup}>
-          <CheckoutButton title={t('primer_common_button_retry')} variant="primary" onPress={popToRoot} />
+          <CheckoutButton title={t('primer_common_button_retry')} variant="primary" onPress={onRetry} />
           <CheckoutButton
             title={t('primer_checkout_error_button_other_methods')}
             variant="outlined"
-            onPress={popToRoot}
+            onPress={onChooseOther}
           />
         </View>
       </StatusScreenLayout>

--- a/src/Components/internal/screens/ErrorScreen.tsx
+++ b/src/Components/internal/screens/ErrorScreen.tsx
@@ -11,6 +11,7 @@ import { useBottomSafeArea } from './useBottomSafeArea';
 import { CheckoutButton } from '../ui';
 import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
 import { fmt } from '../debug';
+import { PrimerError } from '../../../models/PrimerError';
 
 const LOG = '[ErrorScreen]';
 const errorIcon = require('./assets/error-large.png');
@@ -36,7 +37,13 @@ export function ErrorScreen() {
     // Navigate to processing first so the user sees an immediate spinner;
     // the outcome transitioner replaces with success/error when retry resolves.
     replace(CheckoutRoute.processing);
-    retry().catch((err) => console.warn(`${LOG} retry error ${fmt(err)}`));
+    retry().catch((err) => {
+      console.warn(`${LOG} retry error ${fmt(err)}`);
+      // JS-side failures (e.g. configure/setRawData rejecting) never reach the
+      // native onError callback, so paymentOutcome stays null — without this
+      // the user is stuck on the processing spinner.
+      replace(CheckoutRoute.error, err instanceof PrimerError ? { error: err } : undefined);
+    });
   };
 
   const onChooseOther = () => {

--- a/src/Components/internal/screens/LoadingScreen.tsx
+++ b/src/Components/internal/screens/LoadingScreen.tsx
@@ -14,16 +14,24 @@ const CONTENT_HEIGHT = 246;
 export function LoadingScreen() {
   const tokens = useTheme();
   const { t } = useLocalization();
-  const { route, params } = useRoute<CheckoutRoute.splash | CheckoutRoute.loading>();
+  const { route, params } = useRoute<CheckoutRoute.splash | CheckoutRoute.loading | CheckoutRoute.processing>();
   const rawBottomInset = useBottomSafeArea();
   const bottomInset = Math.max(rawBottomInset, tokens.spacing.large);
   const sheetHeight = CONTENT_HEIGHT + bottomInset;
   useStatusScreenHeight(sheetHeight);
 
   const defaultTitleKey =
-    route === CheckoutRoute.splash ? 'primer_checkout_splash_title' : 'primer_checkout_loading_indicator';
+    route === CheckoutRoute.splash
+      ? 'primer_checkout_splash_title'
+      : route === CheckoutRoute.processing
+        ? 'primer_checkout_processing_title'
+        : 'primer_checkout_loading_indicator';
   const defaultSubtitleKey =
-    route === CheckoutRoute.splash ? 'primer_checkout_splash_subtitle' : 'primer_checkout_loading_subtitle';
+    route === CheckoutRoute.splash
+      ? 'primer_checkout_splash_subtitle'
+      : route === CheckoutRoute.processing
+        ? 'primer_checkout_processing_subtitle'
+        : 'primer_checkout_loading_subtitle';
 
   const title = params?.title ?? t(defaultTitleKey);
   const subtitle = params?.subtitle ?? t(defaultSubtitleKey);

--- a/src/Components/internal/screens/MethodSelectionScreen.tsx
+++ b/src/Components/internal/screens/MethodSelectionScreen.tsx
@@ -2,10 +2,13 @@ import { useMemo } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 import { usePaymentMethods } from '../../hooks/usePaymentMethods';
+import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
 import { PrimerPaymentMethodList } from '../../PrimerPaymentMethodList';
 import { useCheckoutFlow } from '../checkout-flow/CheckoutFlowContext';
 import { useLocalization } from '../localization';
 import { NavigationHeader } from '../navigation/NavigationHeader';
+import { CheckoutRoute } from '../navigation/types';
+import { useNavigation } from '../navigation/useNavigation';
 import { useTheme } from '../theme';
 import { PAYMENT_METHOD_BUTTON_HEIGHT } from '../ui/PaymentMethodButton';
 import { useBottomSafeArea } from './useBottomSafeArea';
@@ -15,12 +18,16 @@ import type { TextStyle } from 'react-native';
 import type { PrimerTokens } from '../theme';
 import type { PaymentMethodItem } from '../../types/PaymentMethodTypes';
 
+const LOG = '[MethodSelectionScreen]';
+
 export function MethodSelectionScreen() {
   const tokens = useTheme();
   const styles = useMemo(() => createStyles(tokens), [tokens]);
   const { t } = useLocalization();
   const { onCancel } = useCheckoutFlow();
   const { paymentMethods } = usePaymentMethods();
+  const { push } = useNavigation();
+  const { setActiveMethod } = usePrimerCheckout();
 
   const methodCount = paymentMethods.length;
   const buttonGap = tokens.spacing.small;
@@ -43,8 +50,13 @@ export function MethodSelectionScreen() {
     tokens.spacing.xlarge;
   useStatusScreenHeight(sheetHeight);
 
-  const handleSelect = (_method: PaymentMethodItem) => {
-    // Payment form navigation to be wired when forms are implemented
+  const handleSelect = (method: PaymentMethodItem) => {
+    if (method.type === 'PAYMENT_CARD') {
+      setActiveMethod(method.type);
+      push(CheckoutRoute.cardForm, { paymentMethodType: method.type });
+      return;
+    }
+    console.warn(`${LOG} payment method ${method.type} not yet wired`);
   };
 
   return (

--- a/src/Components/internal/screens/SuccessScreen.tsx
+++ b/src/Components/internal/screens/SuccessScreen.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Image, View } from 'react-native';
 import { useTheme } from '../theme';
 import { useLocalization } from '../localization';
@@ -6,18 +7,26 @@ import { StatusScreenLayout } from './StatusScreenLayout';
 import { useStatusScreenHeight } from './useStatusScreenHeight';
 import { STATUS_SCREEN_ICON_SIZE } from './constants';
 import { useBottomSafeArea } from './useBottomSafeArea';
+import { useCheckoutFlow } from '../checkout-flow/CheckoutFlowContext';
 
 const checkCircleIcon = require('./assets/check-circle-large.png');
 const CONTENT_HEIGHT = 246;
+const AUTO_DISMISS_MS = 3000;
 
 export function SuccessScreen() {
   const tokens = useTheme();
   const { t } = useLocalization();
   const { params } = useRoute<CheckoutRoute.success>();
+  const { onCancel } = useCheckoutFlow();
   const rawBottomInset = useBottomSafeArea();
   const bottomInset = Math.max(rawBottomInset, tokens.spacing.large);
   const sheetHeight = CONTENT_HEIGHT + bottomInset;
   useStatusScreenHeight(sheetHeight);
+
+  useEffect(() => {
+    const id = setTimeout(onCancel, AUTO_DISMISS_MS);
+    return () => clearTimeout(id);
+  }, [onCancel]);
 
   const title = params?.title ?? t('primer_checkout_success_title');
   const subtitle = params?.subtitle ?? t('primer_checkout_success_subtitle');

--- a/src/Components/internal/screens/useStatusScreenHeight.ts
+++ b/src/Components/internal/screens/useStatusScreenHeight.ts
@@ -2,9 +2,10 @@ import { useEffect } from 'react';
 import { useSheetHeight } from '../checkout-sheet';
 
 export function useStatusScreenHeight(height: number) {
-  const { setHeight } = useSheetHeight();
+  const { requestHeight } = useSheetHeight();
 
   useEffect(() => {
-    setHeight(height);
-  }, [height, setHeight]);
+    const release = requestHeight(height);
+    return release;
+  }, [height, requestHeight]);
 }

--- a/src/Components/types/PrimerCardFormTypes.ts
+++ b/src/Components/types/PrimerCardFormTypes.ts
@@ -1,0 +1,26 @@
+import type { StyleProp, ViewStyle } from 'react-native';
+import type { UseCardFormReturn } from './CardFormTypes';
+
+/** Merchant-facing props for the composed `<PrimerCardForm />` component. */
+export interface PrimerCardFormProps {
+  /**
+   * The card-form state returned by `useCardForm()`. Hoisted so the host screen
+   * can share it with a Pay button rendered outside the form, compose sibling
+   * sections that rely on the same state (e.g. billing address), and drive submit.
+   */
+  cardForm: UseCardFormReturn;
+  /**
+   * Fires when the user hits the return key on the last input. The host screen
+   * typically routes this to the same handler that its Pay button uses.
+   */
+  onSubmit?: () => void;
+  /**
+   * Focus the card number field after mount. Deferred until interactions settle so
+   * the keyboard opens after any nav transition, not during it.
+   */
+  autoFocus?: boolean;
+  /** Optional outer container style. */
+  style?: StyleProp<ViewStyle>;
+  /** Test ID root for the form. Nested elements derive suffixed IDs. */
+  testID?: string;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -133,7 +133,12 @@ export type { NamedComponentValidatableData };
 export { PrimerCheckoutProvider } from './Components';
 export { usePrimerCheckout } from './Components';
 export { usePaymentMethods } from './Components';
-export type { PrimerCheckoutProviderProps, PrimerCheckoutContextValue } from './Components';
+export type {
+  PrimerCheckoutProviderProps,
+  PrimerCheckoutContextValue,
+  PaymentOutcome,
+  CardFormState,
+} from './Components';
 export type {
   PaymentMethodItem,
   PaymentMethodSurcharge,
@@ -146,6 +151,8 @@ export { PrimerPaymentMethodList } from './Components';
 export type { PrimerPaymentMethodListProps } from './Components';
 export { PrimerCheckoutSheet } from './Components';
 export type { PrimerCheckoutSheetProps } from './Components';
+export { PrimerCardForm } from './Components';
+export type { PrimerCardFormProps } from './Components';
 export { PrimerTextInput, CardNumberInput, ExpiryDateInput, CVVInput, CardholderNameInput } from './Components';
 export type {
   PrimerTextInputTheme,

--- a/src/models/PrimerCheckoutData.ts
+++ b/src/models/PrimerCheckoutData.ts
@@ -12,8 +12,11 @@ export type PrimerCheckoutDataPayment = IPrimerCheckoutDataPayment;
 interface IPrimerCheckoutDataPayment {
   id?: string;
   orderId?: string;
+  status?: PrimerPaymentStatus;
   paymentFailureReason?: PrimerPaymentErrorCode;
 }
+
+export type PrimerPaymentStatus = 'SUCCESS' | 'FAILED' | 'PENDING';
 
 enum PrimerPaymentErrorCode {
   FAILED = 'payment-failed',


### PR DESCRIPTION
## Summary

- Add `<PrimerCardForm />` — drop-in card form composing `useCardForm()` + the four card inputs with an internal focus chain (card → expiry → CVV → name → submit) and submit button. Exposes `onSubmitStart`, `autoFocus`, `style`, `testID`.
- Route `paymentOutcome` through `<CheckoutFlow />`: success auto-dismisses the sheet after 5s, error lands on the retry screen. Honors `isSuccessScreenEnabled` / `isErrorScreenEnabled` to skip screens when disabled.
- Make the provider's raw-data manager session-scoped, keyed by `activeMethod` (set by the method-selection screen rather than the view lifecycle). The manager survives the card-form view mount/unmount so retry and post-submit screens keep the same native manager alive.
- Implement retry on `PrimerCheckoutProvider`: reconfigure → re-set raw data → submit. The reconfigure is a workaround for [ACC-6920] (iOS `RawDataManager.swift:237` nullifies its delegate on successful tokenization) — a `TODO(iOS native fix)` marks it.
- Replace the sheet's single-value `setHeight` / `resetHeight` with a token-based height-request stack. Each request returns a per-token release so a late cleanup from a prior screen can't clobber a newer screen's active request.
- Make `NavigationContainer` always render the current screen inside a stable `Animated.View` wrapper; the outgoing screen is a sibling during transitions. Component instances survive transition start/end — no remount churn, no duplicate `useEffect` fires.
- Add `CardFormScreen` (header + scroll + `KeyboardAvoidingView`) as the drop-in wrapper; standalone merchants render `<PrimerCardForm />` directly.
- Make `RawDataManager.configureListeners()` idempotent so reconfigure-on-retry doesn't stack duplicate subscriptions or trigger "no listeners registered" warnings.
- Add `src/Components/internal/debug.ts` with a single-line `fmt()` for console logs.

## Out of scope (intentional)

- Apple Pay / Google Pay / PayPal / Klarna / APM tiles — deferred to M10 / M14.
- Merchant-customizable success/error screens — current screens are the default; full customization arrives with the layer-1/layer-3 customization work.
- iOS native `RawDataManager` delegate fix — tracked separately; retry workaround stays until the native change lands.

## Jira

[ACC-6495]

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn lint` — clean
- [x] `yarn test` — 91/91 passing
- [ ] Manual: tap card tile → form opens with card number focused after the slide lands
- [ ] Manual: valid card (`4242 4242 4242 4242`) → Pay → processing → success → auto-dismiss after 5s
- [ ] Manual: failing card (`4000 0000 0000 0002`) → Pay → processing → error → Retry re-submits
- [ ] Manual: error screen → "Choose other" → back to method selection
- [ ] Manual: swipe-down / backdrop press dismisses the sheet cleanly

## Stacked on

Depends on #347 (ACC-6494 input-chain additions). Merge #347 first, then rebase this onto `main`.

[ACC-6495]: https://primerapi.atlassian.net/browse/ACC-6495
[ACC-6920]: https://primerapi.atlassian.net/browse/ACC-6920