### PR TITLE
ci: skip jobs on draft PRs

### DIFF
--- a/.github/workflows/android-build-and-distribute.yml
+++ b/.github/workflows/android-build-and-distribute.yml
@@ -1,7 +1,8 @@
 name: Android
 
 on:
-  pull_request
+  pull_request:
+    types: [opened, ready_for_review, synchronize, reopened]
 
 permissions:
   contents: read
@@ -10,6 +11,7 @@ permissions:
 
 jobs:
   android-distribute-to-appetize:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     name: "Build and upload app to Appetize 🚀"
     steps:

--- a/.github/workflows/danger-js.yml
+++ b/.github/workflows/danger-js.yml
@@ -6,6 +6,8 @@ on:
       - opened
       - edited
       - synchronize
+      - ready_for_review
+      - reopened
 
 concurrency:
   group: ${{ github.ref }}-danger-js
@@ -17,6 +19,7 @@ permissions:
 
 jobs:
   danger-js:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     name: "Run Danger JS"
     steps:

--- a/.github/workflows/danger-kotlin.yml
+++ b/.github/workflows/danger-kotlin.yml
@@ -6,6 +6,8 @@ on:
       - opened
       - edited
       - synchronize
+      - ready_for_review
+      - reopened
 
 concurrency:
   group: ${{ github.ref }}-danger-kotlin
@@ -17,6 +19,7 @@ permissions:
 
 jobs:
   danger-kotlin:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     name: "Run Danger Kotlin"
     steps:

--- a/.github/workflows/danger-swift.yml
+++ b/.github/workflows/danger-swift.yml
@@ -6,6 +6,8 @@ on:
       - opened
       - edited
       - synchronize
+      - ready_for_review
+      - reopened
 
 concurrency:
   group: ${{ github.ref }}-danger-swift
@@ -17,6 +19,7 @@ permissions:
 
 jobs:
   danger-swift:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     name: "Run Danger"
     steps:

--- a/.github/workflows/ios-build-and-distribute.yml
+++ b/.github/workflows/ios-build-and-distribute.yml
@@ -1,7 +1,8 @@
 ---
 name: iOS
 on:
-  pull_request
+  pull_request:
+    types: [opened, ready_for_review, synchronize, reopened]
 
 permissions:
   contents: read
@@ -11,6 +12,7 @@ permissions:
 jobs:
 
   build-and-upload-to-appetize:
+    if: github.event.pull_request.draft == false
     runs-on: macos-26-xlarge
     timeout-minutes: 30
     name: Build and upload app to Appetize 🚀

--- a/.github/workflows/rn-version-compat.yml
+++ b/.github/workflows/rn-version-compat.yml
@@ -2,6 +2,7 @@ name: RN Compat Build
 
 on:
   pull_request:
+    types: [opened, ready_for_review, synchronize, reopened]
 
 permissions:
   contents: read
@@ -9,6 +10,7 @@ permissions:
 
 jobs:
   rn-compat-build-ios:
+    if: github.event.pull_request.draft == false
     runs-on: macos-26-xlarge
     timeout-minutes: 30
     strategy:
@@ -75,6 +77,7 @@ jobs:
             CODE_SIGNING_ALLOWED=NO
 
   rn-compat-build-android:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/unit-tests-and-code-quality.yml
+++ b/.github/workflows/unit-tests-and-code-quality.yml
@@ -1,11 +1,17 @@
 name: Unit Tests and Code Quality
-on: push
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize, reopened]
+  push:
+    branches:
+      - master
 
 permissions:
   contents: read
 
 jobs:
   run-unit-tests:
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     name: Run RN unit tests
     runs-on: ubuntu-latest
     steps:
@@ -31,6 +37,7 @@ jobs:
           path: coverage
 
   run-unit-tests-android:
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     name: Run Android unit tests
     runs-on: ubuntu-latest
     steps:
@@ -86,6 +93,7 @@ jobs:
           path: android/build/reports
 
   run-unit-tests-ios:
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     name: Run iOS unit tests
     runs-on: macos-26-xlarge
     timeout-minutes: 35
@@ -145,6 +153,7 @@ jobs:
           path: sonar-coverage.xml
 
   sonarcloud:
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     needs:
       - run-unit-tests
       - run-unit-tests-android

--- a/.github/workflows/validate-sdk.yml
+++ b/.github/workflows/validate-sdk.yml
@@ -1,6 +1,8 @@
 ---
 name: Validate SDK
-on: pull_request
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize, reopened]
 
 permissions:
   contents: read
@@ -9,6 +11,7 @@ permissions:
 jobs:
 
   validate:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     name: Validate SDK
     steps:


### PR DESCRIPTION
## What changed

Skip CI jobs when a PR is in draft state. Also narrows `unit-tests-and-code-quality` so it no longer runs on every push to every branch.

## Workflows affected

| Workflow | Trigger | Skips drafts? |
|---|---|---|
| `ios-build-and-distribute` | `pull_request` (opened, ready_for_review, synchronize, reopened) | ✅ |
| `android-build-and-distribute` | same | ✅ |
| `rn-version-compat` (5× iOS + 3× Android matrix) | same | ✅ |
| `validate-sdk` | same | ✅ |
| `danger-js` / `danger-kotlin` / `danger-swift` | `pull_request` (+ ready_for_review, reopened) | ✅ |
| `unit-tests-and-code-quality` | **changed**: was `on: push` (all branches) → now `pull_request` + `push: branches: [master]` | ✅ on PR; master push runs |

## Scenarios

| When | What runs |
|---|---|
| Open PR as **draft** | Workflows trigger but jobs show as `skipped` (gray). No runners spin up. |
| Push while draft | Same — skipped. |
| Mark PR **ready-for-review** | Full pipeline runs. |
| Push while ready | Full pipeline runs. |
| Flip ready → draft | Nothing re-triggers. Next push is skipped. |
| Merge PR → master | Only `unit-tests-and-code-quality` runs (tests + Sonar). |
| Push directly to master | Only `unit-tests-and-code-quality` runs. |
| Push to feature branch with no PR open | Nothing runs (was: unit tests fired before). |

## Test plan

- [ ] This PR opened as draft → confirm jobs show `skipped`
- [ ] Mark ready-for-review → confirm full pipeline kicks in
- [ ] Push a follow-up commit while ready → confirm re-run
- [ ] After merge, check master run shows only `unit-tests-and-code-quality`