### PR TITLE
feat: bridge setBillingAddress to RN RawDataManager (ACC-6916)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -135,6 +135,7 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3"
   implementation 'io.primer:android:2.49.0'
   implementation 'io.primer:components-analytics:3.0.0-beta.2'
+  implementation 'io.primer:components-bridge:3.0.0-beta.2'
   testImplementation 'io.mockk:mockk:1.14.2'
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'

--- a/android/src/main/java/com/primerioreactnative/components/datamodels/manager/raw/billingAddress/PrimerRNAddress.kt
+++ b/android/src/main/java/com/primerioreactnative/components/datamodels/manager/raw/billingAddress/PrimerRNAddress.kt
@@ -1,0 +1,29 @@
+package com.primerioreactnative.components.datamodels.manager.raw.billingAddress
+
+import io.primer.android.configuration.data.model.CountryCode
+import io.primer.android.domain.action.models.PrimerAddress
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class PrimerRNAddress(
+    val firstName: String? = null,
+    val lastName: String? = null,
+    val addressLine1: String? = null,
+    val addressLine2: String? = null,
+    val postalCode: String? = null,
+    val city: String? = null,
+    val state: String? = null,
+    val countryCode: String? = null,
+) {
+    fun toPrimerAddress(): PrimerAddress =
+        PrimerAddress(
+            firstName = firstName,
+            lastName = lastName,
+            addressLine1 = addressLine1,
+            addressLine2 = addressLine2,
+            postalCode = postalCode,
+            city = city,
+            state = state,
+            countryCode = countryCode?.let { CountryCode.valueOf(it) },
+        )
+}

--- a/android/src/main/java/com/primerioreactnative/components/manager/raw/PrimerRNHeadlessUniversalCheckoutRawManager.kt
+++ b/android/src/main/java/com/primerioreactnative/components/manager/raw/PrimerRNHeadlessUniversalCheckoutRawManager.kt
@@ -10,6 +10,7 @@ import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.primerioreactnative.Keys
 import com.primerioreactnative.components.datamodels.core.PrimerRawPaymentMethodType
+import com.primerioreactnative.components.datamodels.manager.raw.billingAddress.PrimerRNAddress
 import com.primerioreactnative.components.datamodels.manager.raw.card.PrimerRNCardData
 import com.primerioreactnative.components.datamodels.manager.raw.cardRedirect.PrimerRNBancontactCardData
 import com.primerioreactnative.components.datamodels.manager.raw.phoneNumber.PrimerRNPhoneNumberData
@@ -26,6 +27,11 @@ import io.primer.android.components.domain.exception.UnsupportedPaymentMethodMan
 import io.primer.android.components.manager.raw.PrimerHeadlessUniversalCheckoutRawDataManager
 import io.primer.android.components.manager.raw.PrimerHeadlessUniversalCheckoutRawDataManagerInterface
 import io.primer.android.core.ExperimentalPrimerApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -42,6 +48,7 @@ internal class PrimerRNHeadlessUniversalCheckoutRawManager(
     private val listener = PrimerRNHeadlessUniversalCheckoutRawManagerListener()
     private lateinit var rawManager: PrimerHeadlessUniversalCheckoutRawDataManagerInterface
     private var paymentMethodTypeStr: String? = null
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     init {
         listener.sendEvent = { eventName, paramsJson -> sendEvent(eventName, paramsJson) }
@@ -175,6 +182,53 @@ internal class PrimerRNHeadlessUniversalCheckoutRawManager(
     }
 
     @ReactMethod
+    fun setBillingAddress(
+        billingAddressStr: String,
+        promise: Promise,
+    ) {
+        if (::rawManager.isInitialized.not()) {
+            val exception =
+                ErrorTypeRN.NativeBridgeFailed errorTo UNINITIALIZED_ERROR
+            promise.reject(exception.errorId, exception.description)
+            return
+        }
+
+        val rnAddress =
+            try {
+                json.decodeFromString<PrimerRNAddress>(billingAddressStr)
+            } catch (e: Exception) {
+                val exception =
+                    ErrorTypeRN.NativeBridgeFailed errorTo
+                        "Failed to decode billing address $billingAddressStr on Android. " +
+                        "Make sure you're providing a valid billing address object."
+                promise.reject(exception.errorId, exception.description, e)
+                return
+            }
+
+        val address =
+            try {
+                rnAddress.toPrimerAddress()
+            } catch (e: IllegalArgumentException) {
+                val exception = ErrorTypeRN.InvalidRawData errorTo (e.message ?: "Invalid billing address.")
+                promise.reject(exception.errorId, exception.description, e)
+                return
+            }
+
+        scope.launch {
+            try {
+                rawManager.setBillingAddress(address)
+                promise.resolve(null)
+            } catch (e: IllegalArgumentException) {
+                val exception = ErrorTypeRN.InvalidRawData errorTo (e.message ?: "Invalid billing address.")
+                promise.reject(exception.errorId, exception.description, e)
+            } catch (e: Exception) {
+                val exception = ErrorTypeRN.NativeBridgeFailed errorTo e.message.orEmpty()
+                promise.reject(exception.errorId, exception.description, e)
+            }
+        }
+    }
+
+    @ReactMethod
     fun cleanUp(promise: Promise) {
         if (::rawManager.isInitialized.not()) {
             val exception =
@@ -182,6 +236,7 @@ internal class PrimerRNHeadlessUniversalCheckoutRawManager(
             promise.reject(exception.errorId, exception.description)
         } else {
             rawManager.cleanup()
+            // `scope` is module-scoped; keep it alive across configure/cleanup cycles.
             promise.resolve(null)
         }
     }

--- a/android/src/main/java/com/primerioreactnative/components/manager/raw/PrimerRNHeadlessUniversalCheckoutRawManager.kt
+++ b/android/src/main/java/com/primerioreactnative/components/manager/raw/PrimerRNHeadlessUniversalCheckoutRawManager.kt
@@ -24,6 +24,7 @@ import com.primerioreactnative.utils.toWritableMap
 import io.primer.android.RetailOutletsList
 import io.primer.android.components.SdkUninitializedException
 import io.primer.android.components.domain.exception.UnsupportedPaymentMethodManagerException
+import io.primer.android.components.bridge.billingaddress.ComponentsBillingAddressBridge
 import io.primer.android.components.manager.raw.PrimerHeadlessUniversalCheckoutRawDataManager
 import io.primer.android.components.manager.raw.PrimerHeadlessUniversalCheckoutRawDataManagerInterface
 import io.primer.android.core.ExperimentalPrimerApi
@@ -216,7 +217,7 @@ internal class PrimerRNHeadlessUniversalCheckoutRawManager(
 
         scope.launch {
             try {
-                rawManager.setBillingAddress(address)
+                ComponentsBillingAddressBridge.create().setBillingAddress(address)
                 promise.resolve(null)
             } catch (e: IllegalArgumentException) {
                 val exception = ErrorTypeRN.InvalidRawData errorTo (e.message ?: "Invalid billing address.")

--- a/android/src/main/java/com/primerioreactnative/datamodels/PrimerErrorRN.kt
+++ b/android/src/main/java/com/primerioreactnative/datamodels/PrimerErrorRN.kt
@@ -19,6 +19,7 @@ enum class ErrorTypeRN(val errorId: String) {
     UnsupportedPaymentIntent("unsupported-session-intent"),
     VaultManagerDeleteFailed("vaulted-manager-delete-failed"),
     InvalidVaultedPaymentMethodId("invalid-vaulted-payment-method-id"),
+    InvalidRawData("invalid-raw-data"),
 }
 
 @Serializable

--- a/ios/Sources/DataModels/PrimerAddress+Extension.swift
+++ b/ios/Sources/DataModels/PrimerAddress+Extension.swift
@@ -1,0 +1,35 @@
+//
+//  PrimerAddress+Extension.swift
+//  primer-io-react-native
+//
+
+import Foundation
+import PrimerSDK
+
+extension PrimerAddress {
+
+    convenience init?(billingAddressStr: String) {
+        guard
+            let data = billingAddressStr.data(using: .utf8),
+            let json = try? JSONSerialization.jsonObject(with: data),
+            let dict = json as? [String: Any]
+        else {
+            return nil
+        }
+
+        let stringValue: (String) -> String? = { key in
+            dict[key] as? String
+        }
+
+        self.init(
+            firstName: stringValue("firstName"),
+            lastName: stringValue("lastName"),
+            addressLine1: stringValue("addressLine1"),
+            addressLine2: stringValue("addressLine2"),
+            postalCode: stringValue("postalCode"),
+            city: stringValue("city"),
+            state: stringValue("state"),
+            countryCode: stringValue("countryCode")
+        )
+    }
+}

--- a/ios/Sources/Headless Universal Checkout/Managers/Payment Method Managers/RNTRawDataManager.m
+++ b/ios/Sources/Headless Universal Checkout/Managers/Payment Method Managers/RNTRawDataManager.m
@@ -18,6 +18,8 @@ RCT_EXTERN_METHOD(setRawData:(NSString *)rawDataStr resolver:(RCTPromiseResolveB
 
 RCT_EXTERN_METHOD(submit:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(setBillingAddress:(NSString *)billingAddressStr resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(cleanUp:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 
 @end

--- a/ios/Sources/Headless Universal Checkout/Managers/Payment Method Managers/RNTRawDataManager.swift
+++ b/ios/Sources/Headless Universal Checkout/Managers/Payment Method Managers/RNTRawDataManager.swift
@@ -166,11 +166,45 @@ class RNTPrimerHeadlessUniversalCheckoutRawDataManager: RCTEventEmitter {
   }
 
   @objc
+  public func setBillingAddress(
+    _ billingAddressStr: String,
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let rawDataManager = rawDataManager else {
+      let err = RNTNativeError(
+        errorId: "native-ios",
+        errorDescription: "The RawDataManager has not been initialized",
+        recoverySuggestion: "Make sure you have called initialized the `RawDataManager' first.")
+      rejecter(err.rnError["errorId"]!, err.rnError["description"], err)
+      return
+    }
+
+    guard let billingAddress = PrimerAddress(billingAddressStr: billingAddressStr) else {
+      let err = RNTNativeError(
+        errorId: "native-ios",
+        errorDescription: "Failed to decode billing address JSON.",
+        recoverySuggestion: "Make sure you're providing a valid billing address object.")
+      rejecter(err.rnError["errorId"]!, err.rnError["description"], err)
+      return
+    }
+
+    Task {
+      do {
+        try await rawDataManager.setBillingAddress(billingAddress)
+        resolver(nil)
+      } catch {
+        rejecter(error.rnError["errorId"]!, error.rnError["description"], error)
+      }
+    }
+  }
+
+  @objc
   public func cleanUp(
     _ resolver: RCTPromiseResolveBlock,
     rejecter: RCTPromiseRejectBlock
   ) {
-
+    resolver(nil)
   }
 
 }

--- a/ios/Sources/Headless Universal Checkout/Managers/Payment Method Managers/RNTRawDataManager.swift
+++ b/ios/Sources/Headless Universal Checkout/Managers/Payment Method Managers/RNTRawDataManager.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import PrimerSDK
+@_spi(PrimerInternal) import PrimerSDK
 import React
 
 // swiftlint:disable type_name
@@ -171,7 +171,7 @@ class RNTPrimerHeadlessUniversalCheckoutRawDataManager: RCTEventEmitter {
     resolver: @escaping RCTPromiseResolveBlock,
     rejecter: @escaping RCTPromiseRejectBlock
   ) {
-    guard let rawDataManager = rawDataManager else {
+    guard rawDataManager != nil else {
       let err = RNTNativeError(
         errorId: "native-ios",
         errorDescription: "The RawDataManager has not been initialized",
@@ -189,9 +189,18 @@ class RNTPrimerHeadlessUniversalCheckoutRawDataManager: RCTEventEmitter {
       return
     }
 
+    guard #available(iOS 15.0, *) else {
+      let err = RNTNativeError(
+        errorId: "native-ios",
+        errorDescription: "setBillingAddress requires iOS 15.0 or later.",
+        recoverySuggestion: "Update the deployment target or run on iOS 15+.")
+      rejecter(err.rnError["errorId"]!, err.rnError["description"], err)
+      return
+    }
+
     Task {
       do {
-        try await rawDataManager.setBillingAddress(billingAddress)
+        try await ComponentsBillingAddressBridge().setBillingAddress(billingAddress)
         resolver(nil)
       } catch {
         rejecter(error.rnError["errorId"]!, error.rnError["description"], error)

--- a/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/RawDataManager.ts
+++ b/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/RawDataManager.ts
@@ -5,6 +5,7 @@ import type { PrimerInitializationData } from '../../../models/PrimerInitializat
 import { PrimerError } from '../../../models/PrimerError';
 import type { PrimerInputElementType } from '../../../models/PrimerInputElementType';
 import type { PrimerBinData } from '../../../models/PrimerBinData';
+import type { PrimerAddress } from '../../../models/PrimerClientSession';
 
 const { RNTPrimerHeadlessUniversalCheckoutRawDataManager } = NativeModules;
 const eventEmitter = new NativeEventEmitter(RNTPrimerHeadlessUniversalCheckoutRawDataManager);
@@ -139,6 +140,28 @@ class PrimerHeadlessUniversalCheckoutRawDataManager {
       if (this.options?.paymentMethodType) {
         try {
           await RNTPrimerHeadlessUniversalCheckoutRawDataManager.submit();
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      } else {
+        const err = new PrimerError(
+          'manager-not-configured',
+          undefined,
+          'HeadlessUniversalCheckoutRawDataManager has not been configured',
+          'Call HeadlessUniversalCheckoutRawDataManager.configure before calling this function.',
+          undefined
+        );
+        reject(err);
+      }
+    });
+  }
+
+  setBillingAddress(address: PrimerAddress): Promise<void> {
+    return new Promise(async (resolve, reject) => {
+      if (this.options?.paymentMethodType) {
+        try {
+          await RNTPrimerHeadlessUniversalCheckoutRawDataManager.setBillingAddress(JSON.stringify(address));
           resolve();
         } catch (err) {
           reject(err);


### PR DESCRIPTION
## Summary

- Exposes `rawDataManager.setBillingAddress(address)` on the JS API, bridging the new native methods on iOS and Android.
- iOS bridge wraps the SDK's `async throws` call in a `Task` and settles the `RCTPromise`.
- Android bridge wraps the SDK's `suspend` call in a coroutine scope and settles the `Promise`.
- Validation failures reject with `code: 'invalid-raw-data'` on both platforms. Added `ErrorTypeRN.InvalidRawData` on Android to match iOS's existing code.
- iOS `cleanUp` now calls `resolver(nil)` — was a no-op that never settled the `RCTPromise`, causing JS `await cleanUp()` to hang.
- Android `cleanUp` no longer cancels the module-level coroutine scope — that was breaking subsequent `setBillingAddress` calls after a configure/cleanup cycle.

## Depends on

- iOS: primer-io/primer-sdk-ios#1707 (ACC-7169)
- Android: primer-io/primer-sdk-android#1245 (ACC-7170)

`android/build.gradle` and `primer-io-react-native.podspec` pins need bumping to the released versions before merge.

## Jira

[ACC-6916]

## Test plan

- [x] Happy path (both platforms): PATCH dispatched, server echoes the billing address via `onClientSessionUpdate`.
- [x] Invalid `countryCode: "USA"` → rejects with `code: 'invalid-raw-data'` (both platforms).
- [x] Empty `{}` → rejects with `code: 'invalid-raw-data'` (both platforms).
- [x] TypeScript + ESLint clean on touched files.

[ACC-6916]: https://primerapi.atlassian.net/browse/ACC-6916