### PR TITLE
feat: card network detection with icons and abbreviation fallback (ACC-6915)

### DIFF
--- a/android/src/main/java/com/primerioreactnative/components/manager/asset/PrimerRNHeadlessUniversalCheckoutAssetManager.kt
+++ b/android/src/main/java/com/primerioreactnative/components/manager/asset/PrimerRNHeadlessUniversalCheckoutAssetManager.kt
@@ -1,6 +1,7 @@
 package com.primerioreactnative.components.manager.asset
 
 import androidx.core.content.ContextCompat
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
@@ -36,6 +37,34 @@ internal class PrimerRNHeadlessUniversalCheckoutAssetManager(
     private val reactContext: ReactApplicationContext,
 ) : ReactContextBaseJavaModule(reactContext) {
     override fun getName() = "RNTPrimerHeadlessUniversalCheckoutAssetsManager"
+
+    @ReactMethod
+    fun getCardNetworkTraits(
+        cardNetworkStr: String,
+        promise: Promise,
+    ) {
+        // Android always returns a Descriptor (Type.OTHER fallback for unknown strings).
+        // JS normalises cardNetwork == "OTHER" to DEFAULT_DESCRIPTOR, matching iOS nil semantics.
+        val descriptor = CardNetwork.lookupByCardNetwork(cardNetworkStr)
+        val panLengthsArray =
+            Arguments.createArray().apply {
+                descriptor.lengths.forEach { pushInt(it) }
+            }
+        val gapPatternArray =
+            Arguments.createArray().apply {
+                descriptor.gaps.forEach { pushInt(it) }
+            }
+        val result =
+            Arguments.createMap().apply {
+                putString("cardNetwork", descriptor.type.name)
+                putString("displayName", descriptor.type.displayName)
+                putArray("panLengths", panLengthsArray)
+                putArray("gapPattern", gapPatternArray)
+                putInt("cvvLength", descriptor.cvvLength)
+                putString("cvvLabel", descriptor.cvvLabel)
+            }
+        promise.resolve(result)
+    }
 
     @ReactMethod
     fun getCardNetworkImage(

--- a/ios/Sources/Headless Universal Checkout/Managers/Assets Manager/RNTAssetsManager.m
+++ b/ios/Sources/Headless Universal Checkout/Managers/Assets Manager/RNTAssetsManager.m
@@ -10,6 +10,10 @@
 
 @interface RCT_EXTERN_MODULE(RNTPrimerHeadlessUniversalCheckoutAssetsManager, RCTEventEmitter)
 
+RCT_EXTERN_METHOD(getCardNetworkTraits:(NSString *)cardNetworkStr
+                      resolver:(RCTPromiseResolveBlock)resolver
+                      rejecter:(RCTPromiseRejectBlock)rejecter)
+
 RCT_EXTERN_METHOD(getCardNetworkImage:(NSString *)cardNetworkStr
                       resolver:(RCTPromiseResolveBlock)resolver
                       rejecter:(RCTPromiseRejectBlock)rejecter)

--- a/ios/Sources/Headless Universal Checkout/Managers/Assets Manager/RNTAssetsManager.swift
+++ b/ios/Sources/Headless Universal Checkout/Managers/Assets Manager/RNTAssetsManager.swift
@@ -23,6 +23,27 @@ class RNTPrimerHeadlessUniversalCheckoutAssetsManager: RCTEventEmitter {
     }
 
     @objc
+    func getCardNetworkTraits(
+        _ cardNetworkStr: String,
+        resolver: RCTPromiseResolveBlock,
+        rejecter: RCTPromiseRejectBlock
+    ) {
+        guard let traits = PrimerSDK.PrimerHeadlessUniversalCheckout.AssetsManager
+            .getCardNetworkTraits(cardNetworkString: cardNetworkStr) else {
+            resolver(nil)
+            return
+        }
+        resolver([
+            "cardNetwork": traits.cardNetwork.rawValue,
+            "displayName": traits.displayName,
+            "panLengths": traits.panLengths,
+            "gapPattern": traits.gapPattern,
+            "cvvLength": traits.cvvLength,
+            "cvvLabel": traits.cvvLabel
+        ])
+    }
+
+    @objc
     func getCardNetworkImage(
         _ cardNetworkStr: String,
         resolver: RCTPromiseResolveBlock,

--- a/src/Components/hooks/useCardNetwork.ts
+++ b/src/Components/hooks/useCardNetwork.ts
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react';
+import { usePrimerCheckout } from './usePrimerCheckout';
+import PrimerHeadlessUniversalCheckoutAssetsManager from '../../HeadlessUniversalCheckout/Managers/AssetsManager';
+import { DEFAULT_DESCRIPTOR, fetchCardNetworkDescriptor } from '../internal/cardNetwork';
+import type { CardNetworkDescriptor, CardNetworkIconSource } from '../internal/cardNetwork';
+
+const LOG = '[useCardNetwork]';
+
+const assetsManager = new PrimerHeadlessUniversalCheckoutAssetsManager();
+
+// Promise cache dedupes in-flight icon requests and persists resolved URLs across hook
+// instances. Keyed on the upper-cased network id.
+const iconUrlCache = new Map<string, Promise<string>>();
+
+function getCardNetworkIconURL(network: string): Promise<string> {
+  const existing = iconUrlCache.get(network);
+  if (existing) return existing;
+  const promise = assetsManager.getCardNetworkImageURL(network).catch((err) => {
+    iconUrlCache.delete(network);
+    throw err;
+  });
+  iconUrlCache.set(network, promise);
+  return promise;
+}
+
+export interface UseCardNetworkReturn {
+  /** Raw network identifier as reported by native (`"VISA"`, `"AMEX"`, ...), or `null` before BIN detection. */
+  network: string | null;
+  /**
+   * Traits for the detected network, resolved asynchronously from the native SDK.
+   * Starts as `DEFAULT_DESCRIPTOR` on mount / network-change and upgrades when the
+   * native call returns. Stays as `DEFAULT_DESCRIPTOR` for unknown networks or when
+   * the native call fails.
+   */
+  descriptor: CardNetworkDescriptor;
+  /** `{ uri }` source for `<Image />`, or `null` while loading or when unknown. */
+  iconSource: CardNetworkIconSource;
+}
+
+/**
+ * Reads the detected card network from the provider's BIN data and resolves the
+ * matching traits + icon from the native SDK. Traits drive per-network input
+ * formatting (gaps), max length, and the CVV label; icon is a separate fetch.
+ */
+export function useCardNetwork(): UseCardNetworkReturn {
+  const { cardFormState } = usePrimerCheckout();
+  const network = cardFormState.binData?.preferred?.network ?? null;
+
+  const [descriptor, setDescriptor] = useState<CardNetworkDescriptor>(DEFAULT_DESCRIPTOR);
+  const [iconUri, setIconUri] = useState<string | null>(null);
+
+  useEffect(() => {
+    console.log(`${LOG} network change ${JSON.stringify({ network })}`);
+    if (!network) {
+      setDescriptor(DEFAULT_DESCRIPTOR);
+      return;
+    }
+    let cancelled = false;
+    fetchCardNetworkDescriptor(network).then((d) => {
+      if (cancelled) return;
+      console.log(`${LOG} descriptor resolved ${JSON.stringify({ network, id: d.id })}`);
+      setDescriptor(d);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [network]);
+
+  useEffect(() => {
+    // Guard on the raw network string, not descriptor.id. Networks like Cartes Bancaires,
+    // Bancontact, and EFTPOS have icons but no validation traits on iOS — their descriptor
+    // collapses to DEFAULT (id: 'OTHER'), but the raw network string is still the real
+    // network name and the icon asset exists.
+    if (!network || network.toUpperCase() === 'OTHER') {
+      setIconUri(null);
+      return;
+    }
+    let cancelled = false;
+    getCardNetworkIconURL(network)
+      .then((uri) => {
+        console.log(`${LOG} icon resolved ${JSON.stringify({ network, uri })}`);
+        if (!cancelled) setIconUri(uri);
+      })
+      .catch((err) => {
+        console.warn(`${LOG} icon fetch failed ${network}: ${String(err)}`);
+        if (!cancelled) setIconUri(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [network]);
+
+  const iconSource: CardNetworkIconSource = iconUri ? { uri: iconUri } : null;
+  return { network, descriptor, iconSource };
+}

--- a/src/Components/hooks/useCardNetwork.ts
+++ b/src/Components/hooks/useCardNetwork.ts
@@ -13,13 +13,14 @@ const assetsManager = new PrimerHeadlessUniversalCheckoutAssetsManager();
 const iconUrlCache = new Map<string, Promise<string>>();
 
 function getCardNetworkIconURL(network: string): Promise<string> {
-  const existing = iconUrlCache.get(network);
+  const key = network.toUpperCase();
+  const existing = iconUrlCache.get(key);
   if (existing) return existing;
-  const promise = assetsManager.getCardNetworkImageURL(network).catch((err) => {
-    iconUrlCache.delete(network);
+  const promise = assetsManager.getCardNetworkImageURL(key).catch((err) => {
+    iconUrlCache.delete(key);
     throw err;
   });
-  iconUrlCache.set(network, promise);
+  iconUrlCache.set(key, promise);
   return promise;
 }
 
@@ -51,10 +52,8 @@ export function useCardNetwork(): UseCardNetworkReturn {
 
   useEffect(() => {
     console.log(`${LOG} network change ${JSON.stringify({ network })}`);
-    if (!network) {
-      setDescriptor(DEFAULT_DESCRIPTOR);
-      return;
-    }
+    setDescriptor(DEFAULT_DESCRIPTOR);
+    if (!network) return;
     let cancelled = false;
     fetchCardNetworkDescriptor(network).then((d) => {
       if (cancelled) return;
@@ -71,10 +70,8 @@ export function useCardNetwork(): UseCardNetworkReturn {
     // Bancontact, and EFTPOS have icons but no validation traits on iOS — their descriptor
     // collapses to DEFAULT (id: 'OTHER'), but the raw network string is still the real
     // network name and the icon asset exists.
-    if (!network || network.toUpperCase() === 'OTHER') {
-      setIconUri(null);
-      return;
-    }
+    setIconUri(null);
+    if (!network || network.toUpperCase() === 'OTHER') return;
     let cancelled = false;
     getCardNetworkIconURL(network)
       .then((uri) => {

--- a/src/Components/index.ts
+++ b/src/Components/index.ts
@@ -17,6 +17,9 @@ export type {
 } from './types/PaymentMethodTypes';
 export { useCardForm } from './hooks/useCardForm';
 export type { UseCardFormOptions, UseCardFormReturn, CardFormErrors, CardFormField } from './types/CardFormTypes';
+export { useCardNetwork } from './hooks/useCardNetwork';
+export type { UseCardNetworkReturn } from './hooks/useCardNetwork';
+export type { CardNetworkDescriptor, CardNetworkId, CardNetworkIconSource, CvvLabel } from './internal/cardNetwork';
 export { PrimerPaymentMethodList } from './PrimerPaymentMethodList';
 export type { PrimerPaymentMethodListProps } from './types/PrimerPaymentMethodListTypes';
 export { PrimerVaultedPaymentMethod } from './PrimerVaultedPaymentMethod';

--- a/src/Components/inputs/CardNumberInput.tsx
+++ b/src/Components/inputs/CardNumberInput.tsx
@@ -1,9 +1,12 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
-import { Image, StyleSheet, type TextInputProps } from 'react-native';
+import { Image, StyleSheet, Text, View, type TextInputProps } from 'react-native';
 import { PrimerTextInput } from './PrimerTextInput';
 import { caretFromDigitIndex, countDigits, countDigitsBefore, targetDigitIndex } from './caret';
 import { PLACEHOLDER_ICON_HEIGHT, PLACEHOLDER_ICON_WIDTH, TRAILING_ICON_MARGIN } from './dimensions';
 import { useLocalization } from '../internal/localization';
+import { useTheme } from '../internal/theme';
+import { useCardNetwork } from '../hooks/useCardNetwork';
+import { getNetworkAbbreviation } from '../internal/cardNetwork';
 import type { CardNumberInputProps, PrimerTextInputRef } from '../types/CardInputTypes';
 
 type SelectionChangeHandler = NonNullable<TextInputProps['onSelectionChange']>;
@@ -17,6 +20,9 @@ export const CardNumberInput = forwardRef<PrimerTextInputRef, CardNumberInputPro
   const { t } = useLocalization();
   const resolvedLabel = label ?? t('primer_card_form_label_number');
   const resolvedPlaceholder = placeholder ?? t('primer_card_form_placeholder_number');
+  const { network, iconSource } = useCardNetwork();
+  const tokens = useTheme();
+  const abbreviation = iconSource == null && network ? getNetworkAbbreviation(network) : '';
 
   const innerRef = useRef<PrimerTextInputRef>(null);
   const lastSelectionRef = useRef({ start: 0, end: 0 });
@@ -80,12 +86,36 @@ export const CardNumberInput = forwardRef<PrimerTextInputRef, CardNumberInputPro
       error={cardForm.errors.cardNumber}
       onSelectionChange={handleSelectionChange}
       trailingContent={
-        <Image
-          source={placeholderSource}
-          style={styles.placeholder}
-          resizeMode="contain"
-          testID={rest.testID ? `${rest.testID}-placeholder-icon` : undefined}
-        />
+        abbreviation ? (
+          <View
+            style={[
+              styles.abbreviationChip,
+              {
+                borderColor: tokens.colors.border,
+                borderRadius: tokens.radii.small,
+                borderWidth: tokens.borders.input,
+              },
+            ]}
+            testID={rest.testID ? `${rest.testID}-network-abbreviation` : undefined}
+          >
+            <Text
+              style={{
+                color: tokens.colors.textPrimary,
+                fontFamily: tokens.typography.fontFamily,
+                fontSize: tokens.typography.bodySmall.fontSize,
+              }}
+            >
+              {abbreviation}
+            </Text>
+          </View>
+        ) : (
+          <Image
+            source={iconSource ?? placeholderSource}
+            style={styles.placeholder}
+            resizeMode="contain"
+            testID={rest.testID ? `${rest.testID}-network-icon` : undefined}
+          />
+        )
       }
       {...rest}
     />
@@ -93,6 +123,13 @@ export const CardNumberInput = forwardRef<PrimerTextInputRef, CardNumberInputPro
 });
 
 const styles = StyleSheet.create({
+  abbreviationChip: {
+    alignItems: 'center',
+    height: PLACEHOLDER_ICON_HEIGHT,
+    justifyContent: 'center',
+    marginLeft: TRAILING_ICON_MARGIN,
+    width: PLACEHOLDER_ICON_WIDTH,
+  },
   placeholder: {
     height: PLACEHOLDER_ICON_HEIGHT,
     marginLeft: TRAILING_ICON_MARGIN,

--- a/src/Components/internal/cardNetwork.ts
+++ b/src/Components/internal/cardNetwork.ts
@@ -1,0 +1,128 @@
+/**
+ * Card-network descriptor: PAN lengths, gap pattern, CVV length, CVV label.
+ *
+ * Traits are fetched asynchronously from the native SDK via `fetchCardNetworkDescriptor`
+ * and cached per network id for the session. `DEFAULT_DESCRIPTOR` is the safe fallback
+ * for unknown/loading networks and the networks native reports without validation data.
+ *
+ * Source of truth:
+ *   - iOS: `PrimerHeadlessUniversalCheckout.AssetsManager.getCardNetworkTraits(cardNetworkString:)`
+ *   - Android: `CardNetwork.lookupByCardNetwork(cardNetwork)` via the RN asset bridge
+ */
+import type { ImageSourcePropType } from 'react-native';
+import PrimerHeadlessUniversalCheckoutAssetsManager from '../../HeadlessUniversalCheckout/Managers/AssetsManager';
+
+/** Upper-cased network identifier; matches `binData.preferred.network` from native. */
+export type CardNetworkId =
+  | 'VISA'
+  | 'MASTERCARD'
+  | 'AMEX'
+  | 'DINERS_CLUB'
+  | 'DISCOVER'
+  | 'JCB'
+  | 'UNIONPAY'
+  | 'MAESTRO'
+  | 'ELO'
+  | 'MIR'
+  | 'HIPER'
+  | 'HIPERCARD'
+  | 'DANKORT'
+  | 'BANCONTACT'
+  | 'CARTES_BANCAIRES'
+  | 'EFTPOS'
+  | 'OTHER';
+
+/** CVV label variants emitted by native (iOS: per-network; Android: per-network after ACC-7168). */
+export type CvvLabel = 'CVV' | 'CVC' | 'CID' | 'CVN' | 'CVE' | 'CVP2';
+
+export interface CardNetworkDescriptor {
+  /** Upper-cased network identifier. */
+  id: CardNetworkId;
+  /** Human-readable name for UI (e.g. "American Express"). */
+  displayName: string;
+  /** Allowed PAN digit counts (unformatted, no spaces). */
+  panLengths: readonly number[];
+  /**
+   * Zero-indexed digit positions *before which* a space is inserted when formatting.
+   * Example: `[4, 8, 12]` → `4242 4242 4242 4242`; `[4, 10]` → `3782 822463 10005`.
+   */
+  gapPattern: readonly number[];
+  /** CVV digit count. */
+  cvvLength: 3 | 4;
+  /** Label shown next to the CVV field (iOS-style: matches the physical card). */
+  cvvLabel: CvvLabel;
+}
+
+/** Used when the network is `null`, `OTHER`, or the native bridge hasn't resolved traits yet. */
+export const DEFAULT_DESCRIPTOR: CardNetworkDescriptor = {
+  id: 'OTHER',
+  displayName: 'Card',
+  panLengths: [16, 17, 18, 19],
+  gapPattern: [4, 8, 12],
+  cvvLength: 3,
+  cvvLabel: 'CVV',
+};
+
+const assetsManager = new PrimerHeadlessUniversalCheckoutAssetsManager();
+
+// Promise cache keyed by upper-cased network id. Dedupes in-flight calls and persists
+// resolved descriptors across hook instances so switching back to a previously seen
+// network is instantaneous — mirrors the icon-cache pattern in useCardNetwork.
+const descriptorCache = new Map<string, Promise<CardNetworkDescriptor>>();
+
+/**
+ * Fetch the descriptor for a network from the native SDK. Falls back to DEFAULT_DESCRIPTOR
+ * when native reports null (iOS: bancontact/cartesBancaires/eftpos/unknown) or OTHER
+ * (Android's fallback for unrecognised names). Bridge errors also resolve to defaults
+ * so the UI never gets stuck on a rejected promise.
+ */
+export function fetchCardNetworkDescriptor(network: string): Promise<CardNetworkDescriptor> {
+  const key = network.toUpperCase();
+  const existing = descriptorCache.get(key);
+  if (existing) return existing;
+  const promise = assetsManager
+    .getCardNetworkTraits(key)
+    .then((traits): CardNetworkDescriptor => {
+      if (!traits || traits.cardNetwork === 'OTHER') return DEFAULT_DESCRIPTOR;
+      return {
+        id: traits.cardNetwork as CardNetworkId,
+        displayName: traits.displayName,
+        panLengths: traits.panLengths,
+        gapPattern: traits.gapPattern,
+        cvvLength: traits.cvvLength as 3 | 4,
+        cvvLabel: traits.cvvLabel as CvvLabel,
+      };
+    })
+    .catch((err) => {
+      descriptorCache.delete(key);
+      console.warn(`[cardNetwork] fetchCardNetworkDescriptor failed for ${key}: ${String(err)}`);
+      return DEFAULT_DESCRIPTOR;
+    });
+  descriptorCache.set(key, promise);
+  return promise;
+}
+
+/** Narrow `ImageSourcePropType | null` when a hook consumer wants to render the network icon. */
+export type CardNetworkIconSource = ImageSourcePropType | null;
+
+/**
+ * Two-letter abbreviation for the bordered fallback chip when a network has no icon
+ * asset (Bancontact, Cartes Bancaires, EFTPOS) or the asset fetch failed.
+ *
+ * Accepts the raw network string from native (`useCardNetwork().network`) since natives
+ * can report ids outside the known union. Underscored ids → first letter of each word;
+ * single-word ids → first two letters. `OTHER` and empty input return empty string —
+ * callers should render nothing in that case.
+ */
+export function getNetworkAbbreviation(network: string): string {
+  const id = network.toUpperCase();
+  if (!id || id === 'OTHER') return '';
+  if (id.includes('_')) {
+    return id
+      .split('_')
+      .map((word) => word.charAt(0))
+      .join('')
+      .slice(0, 2);
+  }
+  return id.slice(0, 2);
+}

--- a/src/HeadlessUniversalCheckout/Managers/AssetsManager.ts
+++ b/src/HeadlessUniversalCheckout/Managers/AssetsManager.ts
@@ -7,6 +7,20 @@ import type {
 
 type Resource = PrimerPaymentMethodAsset | PrimerPaymentMethodNativeView;
 
+/**
+ * Raw bridge shape emitted by native `getCardNetworkTraits`.
+ * iOS resolves `null` for networks without validation (bancontact, cartesBancaires, eftpos, unknown);
+ * Android always resolves a dict (Type.OTHER fallback) — consumers coalesce both to a default descriptor.
+ */
+export interface CardNetworkTraits {
+  cardNetwork: string;
+  displayName: string;
+  panLengths: number[];
+  gapPattern: number[];
+  cvvLength: number;
+  cvvLabel: string;
+}
+
 const { RNTPrimerHeadlessUniversalCheckoutAssetsManager } = NativeModules;
 
 class PrimerHeadlessUniversalCheckoutAssetsManager {
@@ -24,6 +38,18 @@ class PrimerHeadlessUniversalCheckoutAssetsManager {
       try {
         const data = await RNTPrimerHeadlessUniversalCheckoutAssetsManager.getCardNetworkImage(cardNetwork);
         resolve(data.cardNetworkImageURL);
+      } catch (err) {
+        console.error(err);
+        reject(err);
+      }
+    });
+  }
+
+  async getCardNetworkTraits(cardNetwork: string): Promise<CardNetworkTraits | null> {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const data = await RNTPrimerHeadlessUniversalCheckoutAssetsManager.getCardNetworkTraits(cardNetwork);
+        resolve(data ?? null);
       } catch (err) {
         console.error(err);
         reject(err);


### PR DESCRIPTION
## Summary

- `getCardNetworkTraits` native bridge — iOS (`RNTAssetsManager.swift` + `.m`), Android (`PrimerRNHeadlessUniversalCheckoutAssetManager.kt`), and TS `AssetsManager.getCardNetworkTraits`
- `useCardNetwork()` returns `{ network, descriptor, iconSource }`; resolves descriptors asynchronously and caches results across hook instances
- `cardNetwork.ts` defines `CardNetworkId` (16 networks), `CvvLabel`, `CardNetworkDescriptor`, `DEFAULT_DESCRIPTOR`, and `getNetworkAbbreviation`
- Module-level `descriptorCache` and `iconUrlCache` replace the POC's per-render `new AssetsManager()`
- `CardNumberInput` renders a bordered chip with the two-letter abbreviation when a network has no icon asset or the asset fetch fails (`BANCONTACT → "BA"`, `CARTES_BANCAIRES → "CB"`, `DINERS_CLUB → "DC"`)

## Out of scope

Form-side consumption of the descriptor — `gapPattern` / `cardNumberMaxLength` / `cvvLength` / `cvvLabel` wiring, reformat-on-network-flip, and `markSubmitAttempted` / `hasBeenFocused` — lives in [ACC-6932] / #360.

## Depends on

- iOS: `bn/feature/checkout-components` (exposes `PrimerCardNetworkTraits`)
- Android: `v3` (adds `cvvLabel` to `Descriptor`)

## Jira

[ACC-6915]

## Test plan

- [x] \`yarn typecheck\` — clean
- [x] \`yarn lint\` — clean
- [x] \`yarn test\` — 127/127 passing
- [x] iOS manual: Visa / Mastercard / Amex → real logos
- [x] Android manual: Visa / Mastercard / Amex → real logos
- [ ] Manual: force-trigger asset fetch failure → 2-letter chip with border (path is dead in normal flow)

[ACC-6915]: https://primerapi.atlassian.net/browse/ACC-6915
[ACC-6932]: https://primerapi.atlassian.net/browse/ACC-6932