### PR TITLE
feat: pay from vault for Checkout Components (ACC-6509)

### DIFF
--- a/ios/Sources/Headless Universal Checkout/Managers/Assets Manager/RNTAssetsManager.swift
+++ b/ios/Sources/Headless Universal Checkout/Managers/Assets Manager/RNTAssetsManager.swift
@@ -29,18 +29,14 @@ class RNTPrimerHeadlessUniversalCheckoutAssetsManager: RCTEventEmitter {
         rejecter: RCTPromiseRejectBlock
     ) {
         do {
-
-            guard let cardNetwork = CardNetwork(rawValue: cardNetworkStr) else {
-                let err = RNTNativeError(
-                    errorId: "native-ios",
-                    errorDescription: "Failed to find asset of \(cardNetworkStr).",
-                    recoverySuggestion: nil)
-                throw err
-            }
-
+            // Use the non-deprecated getCardNetworkAsset API. The deprecated
+            // getCardNetworkImage(for:) concatenates rawValue uppercase with a lowercase
+            // bundle filename (e.g. "VISA-logo-colored" vs "visa-logo-colored.imageset"),
+            // which always misses on iOS's case-sensitive asset lookup.
             guard
-                let cardNetworkImage = try PrimerSDK.PrimerHeadlessUniversalCheckout.AssetsManager
-                    .getCardNetworkImage(for: cardNetwork)
+                let cardNetworkAsset = PrimerSDK.PrimerHeadlessUniversalCheckout.AssetsManager
+                    .getCardNetworkAsset(cardNetworkString: cardNetworkStr),
+                let cardNetworkImage = cardNetworkAsset.cardImage
             else {
                 let err = RNTNativeError(
                     errorId: "native-ios",
@@ -49,7 +45,7 @@ class RNTPrimerHeadlessUniversalCheckoutAssetsManager: RCTEventEmitter {
                 throw err
             }
 
-            let localUrl = try cardNetworkImage.store(withName: cardNetwork.rawValue)
+            let localUrl = try cardNetworkImage.store(withName: cardNetworkAsset.cardNetwork.rawValue)
             resolver(["cardNetworkImageURL": localUrl.absoluteString])
 
         } catch {

--- a/src/Components/PrimerCheckoutProvider.tsx
+++ b/src/Components/PrimerCheckoutProvider.tsx
@@ -6,11 +6,13 @@ import { mergeTokens } from './internal/theme/merge';
 import { PrimerHeadlessUniversalCheckout } from '../HeadlessUniversalCheckout/PrimerHeadlessUniversalCheckout';
 import PrimerHeadlessUniversalCheckoutAssetsManager from '../HeadlessUniversalCheckout/Managers/AssetsManager';
 import PrimerHeadlessUniversalCheckoutRawDataManager from '../HeadlessUniversalCheckout/Managers/PaymentMethodManagers/RawDataManager';
+import PrimerHeadlessUniversalCheckoutVaultManager from '../HeadlessUniversalCheckout/Managers/VaultManager';
 import type { PrimerSettings } from '../models/PrimerSettings';
 import { PrimerError } from '../models/PrimerError';
 import type { PrimerCheckoutData } from '../models/PrimerCheckoutData';
 import type { PrimerRawData } from '../models/PrimerRawData';
 import type { PrimerBinData } from '../models/PrimerBinData';
+import type { PrimerVaultedPaymentMethod } from '../models/PrimerVaultedPaymentMethod';
 import type {
   PrimerCheckoutProviderProps,
   PrimerCheckoutContextValue,
@@ -44,6 +46,10 @@ interface InternalState {
   paymentOutcome: PaymentOutcome | null;
   activeMethod: string | null;
   cardFormState: CardFormState;
+  vaultedMethods: PrimerVaultedPaymentMethod[];
+  vaultedIconUrisById: Record<string, string | undefined>;
+  isLoadingVaulted: boolean;
+  vaultedError: Error | null;
 }
 
 const initialState: InternalState = {
@@ -57,6 +63,10 @@ const initialState: InternalState = {
   paymentOutcome: null,
   activeMethod: null,
   cardFormState: initialCardFormState,
+  vaultedMethods: [],
+  vaultedIconUrisById: {},
+  isLoadingVaulted: false,
+  vaultedError: null,
 };
 
 /**
@@ -131,6 +141,9 @@ export function PrimerCheckoutProvider({
   // Native manager. Lifecycle is driven by `state.activeMethod` — the method the user
   // picked on the selection screen — so it survives the card-form view mount/unmount.
   const managerRef = useRef<PrimerHeadlessUniversalCheckoutRawDataManager | null>(null);
+  // Vault manager is lazy — created on first vault fetch, reused across client-session updates,
+  // cleared on session teardown alongside `PrimerHeadlessUniversalCheckout.cleanUp()`.
+  const vaultManagerRef = useRef<PrimerHeadlessUniversalCheckoutVaultManager | null>(null);
   // Stashed so `retry()` can re-submit without needing the view to re-enter the form.
   // Compensates for an iOS native bug (see TODO in `retry`), not a JS-side concern.
   const lastRawDataRef = useRef<PrimerRawData | null>(null);
@@ -285,6 +298,8 @@ export function PrimerCheckoutProvider({
 
     return () => {
       cancelled = true;
+      // Vault manager is tied to the native session — let the next session recreate it.
+      vaultManagerRef.current = null;
       PrimerHeadlessUniversalCheckout.cleanUp();
     };
   }, [clientToken]);
@@ -342,6 +357,77 @@ export function PrimerCheckoutProvider({
       cancelled = true;
     };
   }, [state.isReady, methodTypesSignature]);
+
+  // -----------------------------------------------------------------------
+  // Vaulted payment methods — lazy-configured after `isReady`, re-fetched on
+  // every client-session update. Brand-icon URIs are resolved at fetch time so
+  // the row can render synchronously.
+  // -----------------------------------------------------------------------
+  useEffect(() => {
+    // Key on `isReady` only. Native's `onClientSessionUpdate` only fires on session
+    // *mutation*, not on initial load, so waiting for `clientSession` would hang forever
+    // in the common case.
+    if (!state.isReady) return;
+
+    let cancelled = false;
+    setState((prev) =>
+      prev.isLoadingVaulted && prev.vaultedError === null
+        ? prev
+        : { ...prev, isLoadingVaulted: true, vaultedError: null }
+    );
+
+    (async () => {
+      try {
+        if (!vaultManagerRef.current) {
+          const vm = new PrimerHeadlessUniversalCheckoutVaultManager();
+          await vm.configure();
+          if (cancelled) return;
+          vaultManagerRef.current = vm;
+        }
+        const methods = await vaultManagerRef.current.fetchVaultedPaymentMethods();
+        if (cancelled) return;
+        console.log(`${LOG} vault fetched ${methods.length} method(s)`);
+
+        const iconEntries = await Promise.all(
+          methods.map(async (m) => {
+            const network = m.paymentInstrumentData?.network;
+            if (!network) return [m.id, undefined] as const;
+            try {
+              const uri = await assetsManager.getCardNetworkImageURL(network);
+              return [m.id, uri] as const;
+            } catch (iconErr) {
+              console.warn(`${LOG} vault icon resolve failed for ${network} ${fmt(iconErr)}`);
+              return [m.id, undefined] as const;
+            }
+          })
+        );
+        if (cancelled) return;
+
+        const iconMap: Record<string, string | undefined> = {};
+        for (const [id, uri] of iconEntries) iconMap[id] = uri;
+
+        setState((prev) => ({
+          ...prev,
+          vaultedMethods: methods,
+          vaultedIconUrisById: iconMap,
+          isLoadingVaulted: false,
+        }));
+      } catch (err) {
+        console.warn(`${LOG} vault fetch failed ${fmt(err)}`);
+        if (!cancelled) {
+          setState((prev) => ({
+            ...prev,
+            isLoadingVaulted: false,
+            vaultedError: toError(err),
+          }));
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [state.isReady, state.clientSession]);
 
   // -----------------------------------------------------------------------
   // Raw-data manager lifecycle.
@@ -501,6 +587,29 @@ export function PrimerCheckoutProvider({
     setState((prev) => (prev.paymentOutcome === null ? prev : { ...prev, paymentOutcome: null }));
   }, []);
 
+  const payFromVault = useCallback(async (vaultedPaymentMethodId: string) => {
+    const vm = vaultManagerRef.current;
+    if (!vm) {
+      console.warn(`${LOG} payFromVault: vault manager not configured`);
+      return;
+    }
+    console.log(`${LOG} payFromVault id=${vaultedPaymentMethodId}`);
+    // Clear any stale outcome so PaymentOutcomeTransitioner re-fires for this attempt.
+    setState((prev) => (prev.paymentOutcome === null ? prev : { ...prev, paymentOutcome: null }));
+    try {
+      await vm.startPaymentFlow(vaultedPaymentMethodId);
+      // Outcome arrives through the shared onCheckoutComplete/onError callbacks.
+    } catch (err) {
+      console.error(`${LOG} payFromVault failed ${fmt(err)}`);
+      // Surface as an error outcome so the transitioner routes to the error screen.
+      const primerError = err as PrimerError;
+      setState((prev) => ({
+        ...prev,
+        paymentOutcome: { status: 'error', error: primerError, data: null },
+      }));
+    }
+  }, []);
+
   const contextValue = useMemo<PrimerCheckoutContextValue>(
     () => ({
       isReady: state.isReady,
@@ -514,13 +623,18 @@ export function PrimerCheckoutProvider({
       paymentOutcome: state.paymentOutcome,
       activeMethod: state.activeMethod,
       cardFormState: state.cardFormState,
+      vaultedMethods: state.vaultedMethods,
+      vaultedIconUrisById: state.vaultedIconUrisById,
+      isLoadingVaulted: state.isLoadingVaulted,
+      vaultedError: state.vaultedError,
       setActiveMethod,
       setRawData,
       submit,
       retry,
       clearPaymentOutcome,
+      payFromVault,
     }),
-    [state, setActiveMethod, setRawData, submit, retry, clearPaymentOutcome]
+    [state, setActiveMethod, setRawData, submit, retry, clearPaymentOutcome, payFromVault]
   );
 
   return (

--- a/src/Components/PrimerVaultedPaymentMethod.tsx
+++ b/src/Components/PrimerVaultedPaymentMethod.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useMemo } from 'react';
+import { Image, StyleSheet, Text, View } from 'react-native';
+import type { TextStyle } from 'react-native';
+
+import { useTheme } from './internal/theme';
+import type { PrimerTokens } from './internal/theme';
+import { useLocalization } from './internal/localization';
+import { CheckoutRoute } from './internal/navigation/types';
+import { useNavigation } from './internal/navigation/useNavigation';
+import { CheckoutButton } from './internal/ui';
+import { useVaultedPaymentMethods } from './hooks/useVaultedPaymentMethods';
+import type { PrimerVaultedPaymentMethodProps, VaultedPaymentMethodItem } from './types/VaultedPaymentMethodTypes';
+
+export const VAULTED_PAYMENT_METHOD_ROW_HEIGHT = 68;
+
+export function PrimerVaultedPaymentMethod({ data, onPay, style }: PrimerVaultedPaymentMethodProps) {
+  const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+  const { t } = useLocalization();
+
+  const hook = useVaultedPaymentMethods();
+  const { replace } = useNavigation();
+  const method = data !== undefined ? data : hook.primaryMethod;
+
+  const handlePress = useCallback(() => {
+    if (!method) return;
+    if (onPay) {
+      onPay(method);
+      return;
+    }
+    // Jump to processing on Pay so the user doesn't stare at a stale form during tokenization.
+    // Matches the CardFormScreen submit pattern.
+    replace(CheckoutRoute.processing);
+    void hook.pay();
+  }, [method, onPay, hook, replace]);
+
+  if (!method) return null;
+
+  const maskedNumber = method.last4 != null ? t('primer_vault_format_masked', { last4: method.last4 }) : null;
+  const expiryText =
+    method.expiryMonth != null && method.expiryYear != null
+      ? t('primer_vault_format_expires', { month: method.expiryMonth, year: method.expiryYear })
+      : null;
+
+  return (
+    <View style={[styles.outer, style]}>
+      <View style={styles.tile}>
+        <View style={styles.row}>
+          <View style={styles.leftCol}>
+            {method.cardholderName != null && (
+              <Text style={styles.primaryText} numberOfLines={1}>
+                {method.cardholderName}
+              </Text>
+            )}
+            <View style={styles.brandRow}>
+              {method.brandIconUri != null && (
+                <Image source={{ uri: method.brandIconUri }} style={styles.brandIcon} resizeMode="contain" />
+              )}
+              {method.brandName != null && (
+                <Text style={styles.secondaryText} numberOfLines={1}>
+                  {method.brandName}
+                </Text>
+              )}
+            </View>
+          </View>
+          <View style={styles.rightCol}>
+            {maskedNumber != null && <Text style={styles.mediumText}>{maskedNumber}</Text>}
+            {expiryText != null && <Text style={styles.secondaryText}>{expiryText}</Text>}
+          </View>
+        </View>
+      </View>
+      <CheckoutButton title={t('primer_common_button_pay')} variant="primary" onPress={handlePress} />
+    </View>
+  );
+}
+
+function createStyles(tokens: PrimerTokens) {
+  const { colors, spacing, radii, borders, typography } = tokens;
+
+  /* eslint-disable react-native/no-unused-styles */
+  return StyleSheet.create({
+    brandIcon: {
+      height: 16,
+      width: 22.4,
+    },
+    brandRow: {
+      alignItems: 'center',
+      flexDirection: 'row',
+      gap: spacing.xsmall,
+    },
+    leftCol: {
+      flex: 1,
+      gap: spacing.xsmall,
+      justifyContent: 'center',
+    },
+    mediumText: {
+      color: colors.textPrimary,
+      fontFamily: typography.bodyMedium.fontFamily,
+      fontSize: typography.bodyMedium.fontSize,
+      fontWeight: typography.bodyMedium.fontWeight as TextStyle['fontWeight'],
+      letterSpacing: typography.bodyMedium.letterSpacing,
+      lineHeight: typography.bodyMedium.lineHeight,
+      textAlign: 'right',
+    },
+    outer: {
+      backgroundColor: colors.surface,
+      borderRadius: radii.large,
+      gap: spacing.small,
+      padding: spacing.small,
+      width: '100%',
+    },
+    primaryText: {
+      color: colors.textPrimary,
+      fontFamily: typography.bodyLarge.fontFamily,
+      fontSize: typography.bodyLarge.fontSize,
+      fontWeight: typography.bodyLarge.fontWeight as TextStyle['fontWeight'],
+      letterSpacing: typography.bodyLarge.letterSpacing,
+      lineHeight: typography.bodyLarge.lineHeight,
+    },
+    rightCol: {
+      alignItems: 'flex-end',
+      gap: spacing.xsmall,
+    },
+    row: {
+      alignItems: 'center',
+      flexDirection: 'row',
+      gap: spacing.medium,
+    },
+    secondaryText: {
+      color: colors.textSecondary,
+      fontFamily: typography.bodySmall.fontFamily,
+      fontSize: typography.bodySmall.fontSize,
+      fontWeight: typography.bodySmall.fontWeight as TextStyle['fontWeight'],
+      letterSpacing: typography.bodySmall.letterSpacing,
+      lineHeight: typography.bodySmall.lineHeight,
+    },
+    tile: {
+      backgroundColor: colors.background,
+      borderColor: colors.primary,
+      borderRadius: radii.medium,
+      borderWidth: borders.strong,
+      padding: spacing.medium,
+    },
+  });
+  /* eslint-enable react-native/no-unused-styles */
+}
+
+export type { VaultedPaymentMethodItem };

--- a/src/Components/hooks/useVaultedPaymentMethods.ts
+++ b/src/Components/hooks/useVaultedPaymentMethods.ts
@@ -1,0 +1,79 @@
+import { useCallback, useMemo } from 'react';
+import { usePrimerCheckout } from './usePrimerCheckout';
+import type { UseVaultedPaymentMethodsReturn, VaultedPaymentMethodItem } from '../types/VaultedPaymentMethodTypes';
+import type { PrimerVaultedPaymentMethod } from '../../models/PrimerVaultedPaymentMethod';
+
+const CARD_PAYMENT_METHOD_TYPE = 'PAYMENT_CARD';
+
+function titleCase(value: string): string {
+  const lower = value.toLowerCase();
+  return lower.charAt(0).toUpperCase() + lower.slice(1);
+}
+
+function pad2(value: number | undefined): string | undefined {
+  if (value == null) return undefined;
+  return value < 10 ? `0${value}` : String(value);
+}
+
+function toVaultedItem(method: PrimerVaultedPaymentMethod, iconUri: string | undefined): VaultedPaymentMethodItem {
+  const isCard = method.paymentMethodType === CARD_PAYMENT_METHOD_TYPE;
+  const instrument = method.paymentInstrumentData;
+
+  const last4Raw = instrument?.last4Digits ?? instrument?.accountNumberLast4Digits;
+  const last4 = last4Raw != null ? String(last4Raw) : undefined;
+
+  const yearRaw = instrument?.expirationYear;
+  // Year field is typed as `number` (e.g. 2026) — display the last two digits for the card row.
+  const expiryYear = yearRaw != null ? String(yearRaw).slice(-2) : undefined;
+
+  return {
+    id: method.id,
+    paymentMethodType: method.paymentMethodType,
+    paymentInstrumentType: method.paymentInstrumentType,
+    cardholderName: isCard ? instrument?.cardholderName : undefined,
+    last4,
+    expiryMonth: isCard ? pad2(instrument?.expirationMonth) : undefined,
+    expiryYear: isCard ? expiryYear : undefined,
+    brandName: isCard && instrument?.network ? titleCase(instrument.network) : undefined,
+    brandIconUri: iconUri,
+    rawMethod: method,
+  };
+}
+
+export function useVaultedPaymentMethods(): UseVaultedPaymentMethodsReturn {
+  const {
+    vaultedMethods: rawMethods,
+    vaultedIconUrisById,
+    isLoadingVaulted,
+    vaultedError,
+    payFromVault,
+  } = usePrimerCheckout();
+
+  const vaultedMethods = useMemo<VaultedPaymentMethodItem[]>(
+    () => rawMethods.map((m) => toVaultedItem(m, vaultedIconUrisById[m.id])),
+    [rawMethods, vaultedIconUrisById]
+  );
+
+  const primaryMethod = vaultedMethods[0] ?? null;
+
+  const pay = useCallback(async () => {
+    if (!primaryMethod) return;
+    await payFromVault(primaryMethod.id);
+  }, [primaryMethod, payFromVault]);
+
+  const payById = useCallback(
+    async (id: string) => {
+      await payFromVault(id);
+    },
+    [payFromVault]
+  );
+
+  return {
+    vaultedMethods,
+    primaryMethod,
+    isLoading: isLoadingVaulted,
+    error: vaultedError,
+    pay,
+    payById,
+  };
+}

--- a/src/Components/index.ts
+++ b/src/Components/index.ts
@@ -19,6 +19,13 @@ export { useCardForm } from './hooks/useCardForm';
 export type { UseCardFormOptions, UseCardFormReturn, CardFormErrors, CardFormField } from './types/CardFormTypes';
 export { PrimerPaymentMethodList } from './PrimerPaymentMethodList';
 export type { PrimerPaymentMethodListProps } from './types/PrimerPaymentMethodListTypes';
+export { PrimerVaultedPaymentMethod } from './PrimerVaultedPaymentMethod';
+export { useVaultedPaymentMethods } from './hooks/useVaultedPaymentMethods';
+export type {
+  VaultedPaymentMethodItem,
+  UseVaultedPaymentMethodsReturn,
+  PrimerVaultedPaymentMethodProps,
+} from './types/VaultedPaymentMethodTypes';
 export { PrimerCheckoutSheet } from './PrimerCheckoutSheet';
 export type { PrimerCheckoutSheetProps } from './PrimerCheckoutSheet';
 export { PrimerCardForm } from './PrimerCardForm';

--- a/src/Components/internal/screens/MethodSelectionScreen.tsx
+++ b/src/Components/internal/screens/MethodSelectionScreen.tsx
@@ -3,7 +3,9 @@ import { StyleSheet, Text, View } from 'react-native';
 
 import { usePaymentMethods } from '../../hooks/usePaymentMethods';
 import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
+import { useVaultedPaymentMethods } from '../../hooks/useVaultedPaymentMethods';
 import { PrimerPaymentMethodList } from '../../PrimerPaymentMethodList';
+import { PrimerVaultedPaymentMethod } from '../../PrimerVaultedPaymentMethod';
 import { useCheckoutFlow } from '../checkout-flow/CheckoutFlowContext';
 import { useLocalization } from '../localization';
 import { NavigationHeader } from '../navigation/NavigationHeader';
@@ -20,6 +22,10 @@ import type { PaymentMethodItem } from '../../types/PaymentMethodTypes';
 
 const LOG = '[MethodSelectionScreen]';
 
+// Inner vault tile content height (cardholder line + brand row + inner gap).
+// Outer grey padding + tile padding are added into sheetHeight separately below.
+const VAULT_TILE_CONTENT_HEIGHT = 44;
+
 export function MethodSelectionScreen() {
   const tokens = useTheme();
   const styles = useMemo(() => createStyles(tokens), [tokens]);
@@ -28,6 +34,7 @@ export function MethodSelectionScreen() {
   const { paymentMethods } = usePaymentMethods();
   const { push } = useNavigation();
   const { setActiveMethod } = usePrimerCheckout();
+  const { primaryMethod: primaryVaultedMethod } = useVaultedPaymentMethods();
 
   const methodCount = paymentMethods.length;
   const buttonGap = tokens.spacing.small;
@@ -39,10 +46,25 @@ export function MethodSelectionScreen() {
   //   + spacing.xlarge for the sheet's drag-handle area (not part of screen content).
   const headerArea = tokens.spacing.xxsmall * 2 + tokens.typography.titleXLarge.lineHeight;
   const titleArea = tokens.typography.titleLarge.lineHeight;
+  // Vault section = section title + content gap + outer padding*2 + tile padding*2 + tile content
+  //   + tile-to-button gap + Pay button (CheckoutButton: padding.medium*2 + titleLarge lineHeight)
+  //   + section-to-APM gap.
+  const vaultSectionHeight =
+    primaryVaultedMethod != null
+      ? titleArea +
+        tokens.spacing.medium +
+        tokens.spacing.small * 2 +
+        tokens.spacing.medium * 2 +
+        VAULT_TILE_CONTENT_HEIGHT +
+        tokens.spacing.small +
+        (tokens.spacing.medium * 2 + tokens.typography.titleLarge.lineHeight) +
+        tokens.spacing.medium
+      : 0;
   const sheetHeight =
     tokens.spacing.large +
     headerArea +
     tokens.spacing.xxlarge +
+    vaultSectionHeight +
     titleArea +
     tokens.spacing.medium +
     listHeight +
@@ -66,8 +88,16 @@ export function MethodSelectionScreen() {
         rightAction={{ label: t('primer_common_button_cancel'), onPress: onCancel }}
       />
       <View style={styles.content}>
-        <Text style={styles.sectionTitle}>{t('primer_payment_selection_header')}</Text>
-        <PrimerPaymentMethodList data={paymentMethods} onSelect={handleSelect} />
+        {primaryVaultedMethod != null && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>{t('primer_vault_section_title')}</Text>
+            <PrimerVaultedPaymentMethod />
+          </View>
+        )}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>{t('primer_payment_selection_header')}</Text>
+          <PrimerPaymentMethodList data={paymentMethods} onSelect={handleSelect} />
+        </View>
       </View>
     </View>
   );
@@ -86,6 +116,9 @@ function createStyles(tokens: PrimerTokens) {
       gap: spacing.medium,
       paddingHorizontal: spacing.large,
       paddingTop: spacing.xxlarge,
+    },
+    section: {
+      gap: spacing.medium,
     },
     sectionTitle: {
       color: colors.textPrimary,

--- a/src/Components/types/PrimerCheckoutProviderTypes.ts
+++ b/src/Components/types/PrimerCheckoutProviderTypes.ts
@@ -14,6 +14,7 @@ import type {
 } from '../../models/PrimerHandlers';
 import type { IPrimerHeadlessUniversalCheckoutPaymentMethod } from '../../models/PrimerHeadlessUniversalCheckoutPaymentMethod';
 import type { PrimerPaymentMethodAsset, PrimerPaymentMethodNativeView } from '../../models/PrimerPaymentMethodResource';
+import type { PrimerVaultedPaymentMethod } from '../../models/PrimerVaultedPaymentMethod';
 import type { PrimerThemeOverride } from '../internal/theme/types';
 import type { CardFormErrors } from './CardFormTypes';
 
@@ -69,6 +70,13 @@ export interface PrimerCheckoutContextValue {
   /** Validation + metadata state from the active raw-data manager. */
   cardFormState: CardFormState;
 
+  // --- Vaulted payment methods ---
+  vaultedMethods: PrimerVaultedPaymentMethod[];
+  /** Brand-icon URIs keyed by vaulted-method id, resolved via AssetsManager at fetch time. */
+  vaultedIconUrisById: Record<string, string | undefined>;
+  isLoadingVaulted: boolean;
+  vaultedError: Error | null;
+
   // --- Actions ---
   /** Register/deregister the active payment method. Pass `null` to tear down. */
   setActiveMethod: (method: string | null) => void;
@@ -85,4 +93,6 @@ export interface PrimerCheckoutContextValue {
   retry: () => Promise<void>;
   /** Clear the last payment outcome (e.g., when leaving the error screen). */
   clearPaymentOutcome: () => void;
+  /** Start the payment flow for a vaulted payment method by id. */
+  payFromVault: (vaultedPaymentMethodId: string) => Promise<void>;
 }

--- a/src/Components/types/VaultedPaymentMethodTypes.ts
+++ b/src/Components/types/VaultedPaymentMethodTypes.ts
@@ -1,0 +1,43 @@
+import type { StyleProp, ViewStyle } from 'react-native';
+import type { PrimerVaultedPaymentMethod } from '../../models/PrimerVaultedPaymentMethod';
+
+/** View-model for a single vaulted payment method, with derived display fields. */
+export interface VaultedPaymentMethodItem {
+  id: string;
+  paymentMethodType: string;
+  paymentInstrumentType: string;
+  /** Human-readable cardholder name (card vaults only). */
+  cardholderName?: string;
+  /** Last 4 digits as a string, masked-format ready. Card / bank-account vaults only. */
+  last4?: string;
+  /** Two-digit zero-padded expiry month. Card vaults only. */
+  expiryMonth?: string;
+  /** Two-digit expiry year (e.g. "26"). Card vaults only. */
+  expiryYear?: string;
+  /** Title-cased brand name for display (e.g. "Mastercard"). Card vaults only. */
+  brandName?: string;
+  /** Local file URI for the brand icon, resolved via AssetsManager. Card vaults only. */
+  brandIconUri?: string;
+  /** The underlying native method, preserved for consumers that need raw fields. */
+  rawMethod: PrimerVaultedPaymentMethod;
+}
+
+export interface UseVaultedPaymentMethodsReturn {
+  vaultedMethods: VaultedPaymentMethodItem[];
+  /** The method that should be displayed when only one row is rendered. `null` when none exist. */
+  primaryMethod: VaultedPaymentMethodItem | null;
+  isLoading: boolean;
+  error: Error | null;
+  /** Start payment for `primaryMethod`. No-op when none is available. */
+  pay: () => Promise<void>;
+  /** Start payment for a specific vaulted method id. */
+  payById: (id: string) => Promise<void>;
+}
+
+export interface PrimerVaultedPaymentMethodProps {
+  /** Optional override for the row data. Defaults to `useVaultedPaymentMethods().primaryMethod`. */
+  data?: VaultedPaymentMethodItem | null;
+  /** Optional override for the Pay handler. Defaults to the hook's `pay`. */
+  onPay?: (method: VaultedPaymentMethodItem) => void;
+  style?: StyleProp<ViewStyle>;
+}

--- a/src/__tests__/components/usePaymentMethods.test.ts
+++ b/src/__tests__/components/usePaymentMethods.test.ts
@@ -97,11 +97,16 @@ const readyContext: PrimerCheckoutContextValue = {
     metadata: null,
     requiredFields: [],
   },
+  vaultedMethods: [],
+  vaultedIconUrisById: {},
+  isLoadingVaulted: false,
+  vaultedError: null,
   setActiveMethod: () => {},
   setRawData: async () => {},
   submit: async () => {},
   retry: async () => {},
   clearPaymentOutcome: () => {},
+  payFromVault: async () => {},
 };
 
 describe('usePaymentMethods', () => {

--- a/src/__tests__/components/useVaultedPaymentMethods.test.ts
+++ b/src/__tests__/components/useVaultedPaymentMethods.test.ts
@@ -1,0 +1,172 @@
+import { createElement, type ReactNode } from 'react';
+// @ts-expect-error -- react-test-renderer has no types for React 19
+import { act, create } from 'react-test-renderer';
+import { PrimerCheckoutContext } from '../../Components/internal/PrimerCheckoutContext';
+import { useVaultedPaymentMethods } from '../../Components/hooks/useVaultedPaymentMethods';
+import type { PrimerCheckoutContextValue } from '../../Components/types/PrimerCheckoutProviderTypes';
+import type { PrimerVaultedPaymentMethod } from '../../models/PrimerVaultedPaymentMethod';
+
+// @ts-expect-error -- React 19 concurrent act environment
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('react-native', () => ({ useColorScheme: () => 'light' }), { virtual: true });
+
+function renderHook<T>(hook: () => T, Wrapper?: (props: { children: ReactNode }) => ReactNode | null) {
+  const result = { current: null as unknown as T };
+
+  function HookComponent() {
+    result.current = hook();
+    return null;
+  }
+
+  act(() => {
+    create(Wrapper ? createElement(Wrapper, { children: createElement(HookComponent) }) : createElement(HookComponent));
+  });
+
+  return { result };
+}
+
+function contextWrapper(value: PrimerCheckoutContextValue) {
+  return ({ children }: { children: ReactNode }) => createElement(PrimerCheckoutContext.Provider, { value }, children);
+}
+
+function makeCardVault(overrides: Partial<PrimerVaultedPaymentMethod> = {}): PrimerVaultedPaymentMethod {
+  return {
+    id: 'vault-1',
+    analyticsId: 'a1',
+    paymentInstrumentType: 'PAYMENT_CARD',
+    paymentMethodType: 'PAYMENT_CARD',
+    paymentInstrumentData: {
+      cardholderName: 'John Appleseed',
+      network: 'MASTERCARD',
+      last4Digits: 1234,
+      expirationMonth: 5,
+      expirationYear: 2026,
+    },
+    ...overrides,
+  };
+}
+
+const payFromVault = jest.fn().mockResolvedValue(undefined);
+
+const baseContext: PrimerCheckoutContextValue = {
+  isReady: true,
+  error: null,
+  clientSession: null,
+  availablePaymentMethods: [],
+  paymentMethodResources: [],
+  isLoadingResources: false,
+  resourcesError: null,
+  settings: undefined,
+  paymentOutcome: null,
+  activeMethod: null,
+  cardFormState: { isValid: false, errors: {}, binData: null, metadata: null, requiredFields: [] },
+  vaultedMethods: [],
+  vaultedIconUrisById: {},
+  isLoadingVaulted: false,
+  vaultedError: null,
+  setActiveMethod: () => {},
+  setRawData: async () => {},
+  submit: async () => {},
+  retry: async () => {},
+  clearPaymentOutcome: () => {},
+  payFromVault,
+};
+
+beforeEach(() => {
+  payFromVault.mockClear();
+});
+
+describe('useVaultedPaymentMethods', () => {
+  it('returns empty list and null primary when there are no vaulted methods', () => {
+    const { result } = renderHook(() => useVaultedPaymentMethods(), contextWrapper(baseContext));
+    expect(result.current.vaultedMethods).toEqual([]);
+    expect(result.current.primaryMethod).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('derives card-vault display fields (last4, expiry, brand)', () => {
+    const vault = makeCardVault();
+    const ctx: PrimerCheckoutContextValue = {
+      ...baseContext,
+      vaultedMethods: [vault],
+      vaultedIconUrisById: { 'vault-1': 'file:///tmp/mastercard.png' },
+    };
+    const { result } = renderHook(() => useVaultedPaymentMethods(), contextWrapper(ctx));
+    const item = result.current.primaryMethod;
+    expect(item).not.toBeNull();
+    expect(item?.id).toBe('vault-1');
+    expect(item?.cardholderName).toBe('John Appleseed');
+    expect(item?.last4).toBe('1234');
+    expect(item?.expiryMonth).toBe('05');
+    expect(item?.expiryYear).toBe('26');
+    expect(item?.brandName).toBe('Mastercard');
+    expect(item?.brandIconUri).toBe('file:///tmp/mastercard.png');
+  });
+
+  it('falls back to accountNumberLast4Digits when last4Digits is missing', () => {
+    const vault = makeCardVault({
+      paymentInstrumentData: { last4Digits: undefined, accountNumberLast4Digits: 7890 },
+    });
+    const ctx: PrimerCheckoutContextValue = { ...baseContext, vaultedMethods: [vault] };
+    const { result } = renderHook(() => useVaultedPaymentMethods(), contextWrapper(ctx));
+    expect(result.current.primaryMethod?.last4).toBe('7890');
+  });
+
+  it('picks the first method as primary', () => {
+    const first = makeCardVault({ id: 'first' });
+    const second = makeCardVault({ id: 'second' });
+    const ctx: PrimerCheckoutContextValue = { ...baseContext, vaultedMethods: [first, second] };
+    const { result } = renderHook(() => useVaultedPaymentMethods(), contextWrapper(ctx));
+    expect(result.current.primaryMethod?.id).toBe('first');
+    expect(result.current.vaultedMethods).toHaveLength(2);
+  });
+
+  it('pay() is a no-op when no primary method exists', async () => {
+    const { result } = renderHook(() => useVaultedPaymentMethods(), contextWrapper(baseContext));
+    await result.current.pay();
+    expect(payFromVault).not.toHaveBeenCalled();
+  });
+
+  it('pay() delegates to payFromVault with primary method id', async () => {
+    const vault = makeCardVault();
+    const ctx: PrimerCheckoutContextValue = { ...baseContext, vaultedMethods: [vault] };
+    const { result } = renderHook(() => useVaultedPaymentMethods(), contextWrapper(ctx));
+    await result.current.pay();
+    expect(payFromVault).toHaveBeenCalledWith('vault-1');
+  });
+
+  it('payById() delegates to payFromVault with the passed id', async () => {
+    const { result } = renderHook(() => useVaultedPaymentMethods(), contextWrapper(baseContext));
+    await result.current.payById('explicit-id');
+    expect(payFromVault).toHaveBeenCalledWith('explicit-id');
+  });
+
+  it('surfaces isLoading / error from context', () => {
+    const err = new Error('boom');
+    const ctx: PrimerCheckoutContextValue = {
+      ...baseContext,
+      isLoadingVaulted: true,
+      vaultedError: err,
+    };
+    const { result } = renderHook(() => useVaultedPaymentMethods(), contextWrapper(ctx));
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.error).toBe(err);
+  });
+
+  it('leaves card fields undefined for non-card vaults (e.g. PayPal)', () => {
+    const paypal: PrimerVaultedPaymentMethod = {
+      id: 'pp-1',
+      analyticsId: 'a',
+      paymentInstrumentType: 'PAYPAL',
+      paymentMethodType: 'PAYPAL',
+      paymentInstrumentData: { externalPayerInfo: { email: 'a@b.c' } },
+    };
+    const ctx: PrimerCheckoutContextValue = { ...baseContext, vaultedMethods: [paypal] };
+    const { result } = renderHook(() => useVaultedPaymentMethods(), contextWrapper(ctx));
+    const item = result.current.primaryMethod;
+    expect(item?.cardholderName).toBeUndefined();
+    expect(item?.expiryMonth).toBeUndefined();
+    expect(item?.brandName).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `<PrimerVaultedPaymentMethod />` — drop-in row showing the primary vaulted card with cardholder, brand, last 4, and expiry, plus a Pay button. Defaults to `useVaultedPaymentMethods().primaryMethod`; merchants can override with `data` / `onPay`.
- Add `useVaultedPaymentMethods()` hook deriving display fields (masked last 4, zero-padded `MM` / two-digit `YY`, title-cased brand, resolved brand-icon URI) from raw `PrimerVaultedPaymentMethod`s. Exposes `pay()` for the primary method and `payById(id)` for explicit selection.
- Extend `PrimerCheckoutProvider` with a vault manager that's lazy-configured after `isReady` and re-fetched on every `clientSession` update. Brand-icon URIs are resolved via `AssetsManager` at fetch time so the row renders synchronously. Adds `payFromVault(id)` to the context — clears any stale `paymentOutcome`, kicks off `vaultManager.startPaymentFlow`, and surfaces failures as an error outcome routed to the error screen.
- Wire the vault tile into `MethodSelectionScreen` above the APM list under a "Saved" section, gated on a primary vaulted method existing. Sheet-height math accounts for the new section.
- Fix iOS brand-icon resolution: switch `RNTAssetsManager.getCardNetworkImageURL` from the deprecated `getCardNetworkImage(for:)` to `getCardNetworkAsset(cardNetworkString:)`. The deprecated path concatenated the uppercase rawValue with the lowercase imageset filename (e.g. `VISA-logo-colored` vs `visa-logo-colored.imageset`) and always missed on iOS's case-sensitive lookup.

## Jira

[ACC-6509]

## Test plan

- [x] \`yarn typecheck\` — clean
- [x] \`yarn lint\` — clean
- [x] \`yarn test\` — passing (9 new in \`useVaultedPaymentMethods.test.ts\`)
- [ ] Manual iOS: method-selection screen shows the saved-card section above the APM list with the correct brand icon
- [ ] Manual iOS: Pay → processing → success on a vaulted Mastercard
- [ ] Manual Android: method-selection screen shows the saved-card section above the APM list with the correct brand icon
- [ ] Manual Android: Pay → processing → success on a vaulted Mastercard
- [ ] Manual: client-session update refreshes the saved-card row without flicker

[ACC-6509]: https://primerapi.atlassian.net/browse/ACC-6509