### PR TITLE
feat: add PrimerBillingAddressForm and form-state providers (ACC-6921)

### DIFF
--- a/android/src/main/java/com/primerioreactnative/PrimerRNHeadlessUniversalCheckoutListener.kt
+++ b/android/src/main/java/com/primerioreactnative/PrimerRNHeadlessUniversalCheckoutListener.kt
@@ -23,9 +23,9 @@ import com.primerioreactnative.utils.errorTo
 import com.primerioreactnative.utils.toWritableMap
 import io.primer.android.completion.PrimerHeadlessUniversalCheckoutResumeDecisionHandler
 import io.primer.android.completion.PrimerPaymentCreationDecisionHandler
-import io.primer.android.components.PrimerHeadlessUniversalCheckout
 import io.primer.android.components.PrimerHeadlessUniversalCheckoutListener
 import io.primer.android.components.PrimerHeadlessUniversalCheckoutUiListener
+import io.primer.android.components.bridge.clientsession.ComponentsClientSessionBridge
 import io.primer.android.components.domain.core.models.PrimerHeadlessUniversalCheckoutPaymentMethod
 import io.primer.android.domain.PrimerCheckoutData
 import io.primer.android.domain.action.models.PrimerClientSession
@@ -79,16 +79,23 @@ class PrimerRNHeadlessUniversalCheckoutListener(
         )
 
         // The native SDK only fires `onClientSessionUpdated` on subsequent updates, never on
-        // initial load. Read the current session via `getClientSession()` and synthesize the
-        // update event so JS receives the initial session at startup.
+        // initial load. Read the current session via `ComponentsClientSessionBridge` and
+        // synthesize the update event so JS receives the initial session at startup.
         if (implementedRNCallbacks?.isOnClientSessionUpdateImplemented == true) {
-            PrimerHeadlessUniversalCheckout.current.getClientSession()?.let { initialClientSession ->
+            val bridge = ComponentsClientSessionBridge.create()
+            bridge.getClientSession()?.let { initialClientSession ->
                 sendEvent?.invoke(
                     PrimerHeadlessUniversalCheckoutEvent.ON_CLIENT_SESSION_UPDATE.eventName,
                     JSONObject().apply {
                         put(
                             "clientSession",
-                            JSONObject(Json.encodeToString(initialClientSession.toPrimerClientSessionRN())),
+                            JSONObject(
+                                Json.encodeToString(
+                                    initialClientSession.toPrimerClientSessionRN(
+                                        bridge.getCheckoutModules(),
+                                    ),
+                                ),
+                            ),
                         )
                     },
                 )
@@ -189,12 +196,20 @@ class PrimerRNHeadlessUniversalCheckoutListener(
 
     override fun onClientSessionUpdated(clientSession: PrimerClientSession) {
         if (implementedRNCallbacks?.isOnClientSessionUpdateImplemented == true) {
+            // The SDK callback delivers `PrimerClientSession` without `checkoutModules`.
+            // Read those separately from the bridge so JS gets the same shape it gets
+            // from the synthesized initial event.
+            val checkoutModules = ComponentsClientSessionBridge.create().getCheckoutModules()
             sendEvent?.invoke(
                 PrimerHeadlessUniversalCheckoutEvent.ON_CLIENT_SESSION_UPDATE.eventName,
                 JSONObject().apply {
                     put(
                         "clientSession",
-                        JSONObject(Json.encodeToString(clientSession.toPrimerClientSessionRN())),
+                        JSONObject(
+                            Json.encodeToString(
+                                clientSession.toPrimerClientSessionRN(checkoutModules),
+                            ),
+                        ),
                     )
                 },
             )

--- a/android/src/main/java/com/primerioreactnative/PrimerRNHeadlessUniversalCheckoutListener.kt
+++ b/android/src/main/java/com/primerioreactnative/PrimerRNHeadlessUniversalCheckoutListener.kt
@@ -23,6 +23,7 @@ import com.primerioreactnative.utils.errorTo
 import com.primerioreactnative.utils.toWritableMap
 import io.primer.android.completion.PrimerHeadlessUniversalCheckoutResumeDecisionHandler
 import io.primer.android.completion.PrimerPaymentCreationDecisionHandler
+import io.primer.android.components.PrimerHeadlessUniversalCheckout
 import io.primer.android.components.PrimerHeadlessUniversalCheckoutListener
 import io.primer.android.components.PrimerHeadlessUniversalCheckoutUiListener
 import io.primer.android.components.domain.core.models.PrimerHeadlessUniversalCheckoutPaymentMethod
@@ -76,6 +77,23 @@ class PrimerRNHeadlessUniversalCheckoutListener(
         successCallback?.resolve(
             availablePaymentMethods.toWritableMap(),
         )
+
+        // The native SDK only fires `onClientSessionUpdated` on subsequent updates, never on
+        // initial load. Read the current session via `getClientSession()` and synthesize the
+        // update event so JS receives the initial session at startup.
+        if (implementedRNCallbacks?.isOnClientSessionUpdateImplemented == true) {
+            PrimerHeadlessUniversalCheckout.current.getClientSession()?.let { initialClientSession ->
+                sendEvent?.invoke(
+                    PrimerHeadlessUniversalCheckoutEvent.ON_CLIENT_SESSION_UPDATE.eventName,
+                    JSONObject().apply {
+                        put(
+                            "clientSession",
+                            JSONObject(Json.encodeToString(initialClientSession.toPrimerClientSessionRN())),
+                        )
+                    },
+                )
+            }
+        }
     }
 
     override fun onPreparationStarted(paymentMethodType: String) {

--- a/android/src/main/java/com/primerioreactnative/datamodels/PrimerClientSessionRN.kt
+++ b/android/src/main/java/com/primerioreactnative/datamodels/PrimerClientSessionRN.kt
@@ -12,6 +12,13 @@ data class PrimerClientSessionRN(
     val lineItems: List<PrimerLineItemRN>?,
     val orderDetails: PrimerOrderRN?,
     val customer: PrimerCustomerRN?,
+    val checkoutModules: List<PrimerCheckoutModuleRN>? = null,
+)
+
+@Serializable
+data class PrimerCheckoutModuleRN(
+    val type: String,
+    val options: Map<String, Boolean>?,
 )
 
 @Serializable

--- a/android/src/main/java/com/primerioreactnative/extensions/PrimerClientSession.kt
+++ b/android/src/main/java/com/primerioreactnative/extensions/PrimerClientSession.kt
@@ -2,16 +2,18 @@ package com.primerioreactnative.extensions
 
 import com.primerioreactnative.datamodels.PrimerCheckoutModuleRN
 import com.primerioreactnative.datamodels.PrimerClientSessionRN
+import io.primer.android.components.bridge.clientsession.ComponentsCheckoutModule
 import io.primer.android.domain.action.models.PrimerClientSession
 
-internal fun PrimerClientSession.toPrimerClientSessionRN() =
-    PrimerClientSessionRN(
-        customerId,
-        orderId,
-        currencyCode,
-        totalAmount,
-        lineItems?.map { it.toPrimerLineItemRN() },
-        orderDetails?.toPrimerOrderRN(),
-        customer?.toPrimerCustomerRN(),
-        checkoutModules?.map { PrimerCheckoutModuleRN(it.type, it.options) },
-    )
+internal fun PrimerClientSession.toPrimerClientSessionRN(
+    checkoutModules: List<ComponentsCheckoutModule>? = null,
+) = PrimerClientSessionRN(
+    customerId,
+    orderId,
+    currencyCode,
+    totalAmount,
+    lineItems?.map { it.toPrimerLineItemRN() },
+    orderDetails?.toPrimerOrderRN(),
+    customer?.toPrimerCustomerRN(),
+    checkoutModules?.map { PrimerCheckoutModuleRN(it.type, it.options) },
+)

--- a/android/src/main/java/com/primerioreactnative/extensions/PrimerClientSession.kt
+++ b/android/src/main/java/com/primerioreactnative/extensions/PrimerClientSession.kt
@@ -1,5 +1,6 @@
 package com.primerioreactnative.extensions
 
+import com.primerioreactnative.datamodels.PrimerCheckoutModuleRN
 import com.primerioreactnative.datamodels.PrimerClientSessionRN
 import io.primer.android.domain.action.models.PrimerClientSession
 
@@ -12,4 +13,5 @@ internal fun PrimerClientSession.toPrimerClientSessionRN() =
         lineItems?.map { it.toPrimerLineItemRN() },
         orderDetails?.toPrimerOrderRN(),
         customer?.toPrimerCustomerRN(),
+        checkoutModules?.map { PrimerCheckoutModuleRN(it.type, it.options) },
     )

--- a/ios/Sources/Headless Universal Checkout/RNTPrimerHeadlessUniversalCheckout.swift
+++ b/ios/Sources/Headless Universal Checkout/RNTPrimerHeadlessUniversalCheckout.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import PrimerSDK
+@_spi(PrimerInternal) import PrimerSDK
 import React
 
 // swiftlint:disable file_length
@@ -268,18 +268,25 @@ extension RNTPrimerHeadlessUniversalCheckout: PrimerHeadlessUniversalCheckoutDel
 
       // The native SDK only fires `primerHeadlessUniversalCheckoutDidUpdateClientSession`
       // on subsequent updates, never on initial load. Read the current session via
-      // `getClientSession()` and synthesize the update event so JS receives the initial
-      // session at startup.
+      // `ComponentsClientSessionBridge` and synthesize the update event so JS receives
+      // the initial session at startup. iOS < 15 has no bridge access; the JS-side
+      // `onClientSessionUpdate` callback then fires only on subsequent updates.
       if self.implementedRNCallbacks?.isOnClientSessionUpdateImplemented == true,
-         let initialClientSession = PrimerHeadlessUniversalCheckout.current.getClientSession() {
-        let updateCallbackName = PrimerHeadlessUniversalCheckoutEvents.onClientSessionUpdate.stringValue
-        do {
-          let json = try initialClientSession.toJsonObject()
-          self.sendEvent(
-            withName: updateCallbackName,
-            body: ["clientSession": json])
-        } catch {
-          self.handleRNBridgeError(error, checkoutData: nil, stopOnDebug: true)
+         #available(iOS 15.0, *) {
+        let bridge = ComponentsClientSessionBridge()
+        if let initialClientSession = bridge.getClientSession() {
+          let updateCallbackName = PrimerHeadlessUniversalCheckoutEvents.onClientSessionUpdate.stringValue
+          do {
+            let payload = try Self.makeClientSessionPayload(
+              clientSession: initialClientSession,
+              checkoutModules: bridge.getCheckoutModules()
+            )
+            self.sendEvent(
+              withName: updateCallbackName,
+              body: ["clientSession": payload])
+          } catch {
+            self.handleRNBridgeError(error, checkoutData: nil, stopOnDebug: true)
+          }
         }
       }
     }
@@ -547,16 +554,48 @@ extension RNTPrimerHeadlessUniversalCheckout: PrimerHeadlessUniversalCheckoutDel
     DispatchQueue.main.async {
       if self.implementedRNCallbacks?.isOnClientSessionUpdateImplemented == true {
         do {
-          let json = try clientSession.toJsonObject()
+          // Augment the SDK-provided `clientSession` with `checkoutModules` from the
+          // bridge — these are not surfaced on the public `PrimerClientSession` type.
+          var checkoutModules: [ComponentsCheckoutModule]?
+          if #available(iOS 15.0, *) {
+            checkoutModules = ComponentsClientSessionBridge().getCheckoutModules()
+          }
+          let payload = try Self.makeClientSessionPayload(
+            clientSession: clientSession,
+            checkoutModules: checkoutModules
+          )
           self.sendEvent(
             withName: rnCallbackName,
-            body: ["clientSession": json])
+            body: ["clientSession": payload])
 
         } catch {
           self.handleRNBridgeError(error, checkoutData: nil, stopOnDebug: true)
         }
       }
     }
+  }
+
+  // Merges a `PrimerClientSession`'s JSON representation with `checkoutModules`
+  // surfaced by `ComponentsClientSessionBridge`. The bridge returns a value-typed
+  // `ComponentsCheckoutModule` parameter under SPI, so the parameter is `Any?` in
+  // the public signature to avoid leaking SPI types into call-site availability.
+  private static func makeClientSessionPayload(
+    clientSession: PrimerClientSession,
+    checkoutModules: Any?
+  ) throws -> [String: Any] {
+    let json = try clientSession.toJsonObject()
+    var dict = (json as? [String: Any]) ?? [:]
+
+    if #available(iOS 15.0, *), let modules = checkoutModules as? [ComponentsCheckoutModule] {
+      dict["checkoutModules"] = modules.map { module -> [String: Any] in
+        var moduleDict: [String: Any] = ["type": module.type]
+        if let options = module.options {
+          moduleDict["options"] = options
+        }
+        return moduleDict
+      }
+    }
+    return dict
   }
 
   // case onBeforePaymentCreate

--- a/ios/Sources/Headless Universal Checkout/RNTPrimerHeadlessUniversalCheckout.swift
+++ b/ios/Sources/Headless Universal Checkout/RNTPrimerHeadlessUniversalCheckout.swift
@@ -265,6 +265,23 @@ extension RNTPrimerHeadlessUniversalCheckout: PrimerHeadlessUniversalCheckoutDel
       self.sendEvent(
         withName: rnCallbackName,
         body: ["availablePaymentMethods": paymentMethods.compactMap({ $0.toJsonObject() })])
+
+      // The native SDK only fires `primerHeadlessUniversalCheckoutDidUpdateClientSession`
+      // on subsequent updates, never on initial load. Read the current session via
+      // `getClientSession()` and synthesize the update event so JS receives the initial
+      // session at startup.
+      if self.implementedRNCallbacks?.isOnClientSessionUpdateImplemented == true,
+         let initialClientSession = PrimerHeadlessUniversalCheckout.current.getClientSession() {
+        let updateCallbackName = PrimerHeadlessUniversalCheckoutEvents.onClientSessionUpdate.stringValue
+        do {
+          let json = try initialClientSession.toJsonObject()
+          self.sendEvent(
+            withName: updateCallbackName,
+            body: ["clientSession": json])
+        } catch {
+          self.handleRNBridgeError(error, checkoutData: nil, stopOnDebug: true)
+        }
+      }
     }
   }
 

--- a/ios/Sources/Headless Universal Checkout/RNTPrimerHeadlessUniversalCheckout.swift
+++ b/ios/Sources/Headless Universal Checkout/RNTPrimerHeadlessUniversalCheckout.swift
@@ -283,7 +283,7 @@ extension RNTPrimerHeadlessUniversalCheckout: PrimerHeadlessUniversalCheckoutDel
             )
             self.sendEvent(
               withName: updateCallbackName,
-              body: ["clientSession": payload])
+              body: [Self.clientSessionPayloadKey: payload])
           } catch {
             self.handleRNBridgeError(error, checkoutData: nil, stopOnDebug: true)
           }
@@ -566,7 +566,7 @@ extension RNTPrimerHeadlessUniversalCheckout: PrimerHeadlessUniversalCheckoutDel
           )
           self.sendEvent(
             withName: rnCallbackName,
-            body: ["clientSession": payload])
+            body: [Self.clientSessionPayloadKey: payload])
 
         } catch {
           self.handleRNBridgeError(error, checkoutData: nil, stopOnDebug: true)
@@ -574,6 +574,8 @@ extension RNTPrimerHeadlessUniversalCheckout: PrimerHeadlessUniversalCheckoutDel
       }
     }
   }
+
+  private static let clientSessionPayloadKey = "clientSession"
 
   // Merges a `PrimerClientSession`'s JSON representation with `checkoutModules`
   // surfaced by `ComponentsClientSessionBridge`. The bridge returns a value-typed

--- a/src/Components/PrimerBillingAddressForm.tsx
+++ b/src/Components/PrimerBillingAddressForm.tsx
@@ -1,0 +1,180 @@
+import { useCallback, useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTheme } from './internal/theme';
+import type { PrimerTokens } from './internal/theme';
+import { useLocalization } from './internal/localization';
+import { useNavigation } from './internal/navigation/useNavigation';
+import { CheckoutRoute } from './internal/navigation/types';
+import { PrimerTextInput } from './inputs/PrimerTextInput';
+import { CountrySelectorRow } from './inputs/CountrySelectorRow';
+import type { PrimerBillingAddressFormProps } from './types/BillingAddressFormTypes';
+
+export function PrimerBillingAddressForm({
+  billingForm,
+  style,
+  testID = 'primer-billing-address-form',
+}: PrimerBillingAddressFormProps) {
+  const tokens = useTheme();
+  const { t } = useLocalization();
+  const { push } = useNavigation();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+
+  const handleCountryPress = useCallback(() => {
+    push(CheckoutRoute.countrySelector, { selectedCountryCode: billingForm.countryCode || undefined });
+  }, [push, billingForm.countryCode]);
+
+  if (!billingForm.sectionVisible) return null;
+
+  const { visibleFields } = billingForm;
+  const showNameRow = visibleFields.firstName || visibleFields.lastName;
+  const showPostalCityRow = visibleFields.postalCode || visibleFields.city;
+
+  return (
+    <View style={[styles.container, style]} testID={testID}>
+      {visibleFields.countryCode && (
+        <CountrySelectorRow
+          value={billingForm.countryCode}
+          label={t('primer_card_form_label_country')}
+          placeholder={t('primer_card_form_placeholder_country_code')}
+          onPress={handleCountryPress}
+          testID={`${testID}-country`}
+        />
+      )}
+
+      {showNameRow && (
+        <View style={styles.row}>
+          {visibleFields.firstName && (
+            <View style={styles.halfField}>
+              <PrimerTextInput
+                value={billingForm.firstName}
+                onChangeText={billingForm.updateFirstName}
+                onBlur={() => billingForm.markFieldTouched('firstName')}
+                autoComplete="name-given"
+                autoCapitalize="words"
+                label={t('primer_card_form_label_first_name')}
+                placeholder={t('primer_card_form_placeholder_first_name')}
+                error={billingForm.errors.firstName}
+                returnKeyType="next"
+                testID={`${testID}-first-name`}
+              />
+            </View>
+          )}
+          {visibleFields.lastName && (
+            <View style={styles.halfField}>
+              <PrimerTextInput
+                value={billingForm.lastName}
+                onChangeText={billingForm.updateLastName}
+                onBlur={() => billingForm.markFieldTouched('lastName')}
+                autoComplete="name-family"
+                autoCapitalize="words"
+                label={t('primer_card_form_label_last_name')}
+                placeholder={t('primer_card_form_placeholder_last_name')}
+                error={billingForm.errors.lastName}
+                returnKeyType="next"
+                testID={`${testID}-last-name`}
+              />
+            </View>
+          )}
+        </View>
+      )}
+
+      {visibleFields.addressLine1 && (
+        <PrimerTextInput
+          value={billingForm.addressLine1}
+          onChangeText={billingForm.updateAddressLine1}
+          onBlur={() => billingForm.markFieldTouched('addressLine1')}
+          autoComplete="street-address"
+          autoCapitalize="words"
+          label={t('primer_card_form_label_address1')}
+          placeholder={t('primer_card_form_placeholder_address1')}
+          error={billingForm.errors.addressLine1}
+          returnKeyType="next"
+          testID={`${testID}-address-line-1`}
+        />
+      )}
+
+      {visibleFields.addressLine2 && (
+        <PrimerTextInput
+          value={billingForm.addressLine2}
+          onChangeText={billingForm.updateAddressLine2}
+          onBlur={() => billingForm.markFieldTouched('addressLine2')}
+          autoCapitalize="words"
+          label={t('primer_card_form_label_address2')}
+          placeholder={t('primer_card_form_placeholder_address2')}
+          error={billingForm.errors.addressLine2}
+          returnKeyType="next"
+          testID={`${testID}-address-line-2`}
+        />
+      )}
+
+      {showPostalCityRow && (
+        <View style={styles.row}>
+          {visibleFields.postalCode && (
+            <View style={styles.halfField}>
+              <PrimerTextInput
+                value={billingForm.postalCode}
+                onChangeText={billingForm.updatePostalCode}
+                onBlur={() => billingForm.markFieldTouched('postalCode')}
+                autoComplete="postal-code"
+                autoCapitalize="characters"
+                label={t('primer_card_form_label_postal')}
+                placeholder={t('primer_card_form_placeholder_postal')}
+                error={billingForm.errors.postalCode}
+                returnKeyType="next"
+                testID={`${testID}-postal-code`}
+              />
+            </View>
+          )}
+          {visibleFields.city && (
+            <View style={styles.halfField}>
+              <PrimerTextInput
+                value={billingForm.city}
+                onChangeText={billingForm.updateCity}
+                onBlur={() => billingForm.markFieldTouched('city')}
+                autoCapitalize="words"
+                label={t('primer_card_form_label_city')}
+                placeholder={t('primer_card_form_placeholder_city')}
+                error={billingForm.errors.city}
+                returnKeyType="next"
+                testID={`${testID}-city`}
+              />
+            </View>
+          )}
+        </View>
+      )}
+
+      {visibleFields.state && (
+        <PrimerTextInput
+          value={billingForm.state}
+          onChangeText={billingForm.updateState}
+          onBlur={() => billingForm.markFieldTouched('state')}
+          autoCapitalize="words"
+          label={t('primer_card_form_label_state')}
+          placeholder={t('primer_card_form_placeholder_state')}
+          error={billingForm.errors.state}
+          returnKeyType="done"
+          testID={`${testID}-state`}
+        />
+      )}
+    </View>
+  );
+}
+
+function createStyles(tokens: PrimerTokens) {
+  const { spacing } = tokens;
+  /* eslint-disable react-native/no-unused-styles */
+  return StyleSheet.create({
+    container: {
+      gap: spacing.medium,
+      width: '100%',
+    },
+    halfField: {
+      flex: 1,
+    },
+    row: {
+      flexDirection: 'row',
+      gap: spacing.medium,
+    },
+  });
+  /* eslint-enable react-native/no-unused-styles */
+}

--- a/src/Components/PrimerBillingAddressForm.tsx
+++ b/src/Components/PrimerBillingAddressForm.tsx
@@ -7,7 +7,18 @@ import { useNavigation } from './internal/navigation/useNavigation';
 import { CheckoutRoute } from './internal/navigation/types';
 import { PrimerTextInput } from './inputs/PrimerTextInput';
 import { CountrySelectorRow } from './inputs/CountrySelectorRow';
-import type { PrimerBillingAddressFormProps } from './types/BillingAddressFormTypes';
+import type { PrimerBillingAddressFormProps, BillingAddressField } from './types/BillingAddressFormTypes';
+
+// Render order of text inputs in the form; first match (reversed) is the last visible field.
+const FIELD_ORDER: readonly BillingAddressField[] = [
+  'firstName',
+  'lastName',
+  'addressLine1',
+  'addressLine2',
+  'postalCode',
+  'city',
+  'state',
+];
 
 export function PrimerBillingAddressForm({
   billingForm,
@@ -28,6 +39,8 @@ export function PrimerBillingAddressForm({
   const { visibleFields } = billingForm;
   const showNameRow = visibleFields.firstName || visibleFields.lastName;
   const showPostalCityRow = visibleFields.postalCode || visibleFields.city;
+  const lastVisibleField = [...FIELD_ORDER].reverse().find((f) => visibleFields[f]);
+  const returnKey = (field: BillingAddressField): 'next' | 'done' => (field === lastVisibleField ? 'done' : 'next');
 
   return (
     <View style={[styles.container, style]} testID={testID}>
@@ -54,7 +67,7 @@ export function PrimerBillingAddressForm({
                 label={t('primer_card_form_label_first_name')}
                 placeholder={t('primer_card_form_placeholder_first_name')}
                 error={billingForm.errors.firstName}
-                returnKeyType="next"
+                returnKeyType={returnKey('firstName')}
                 testID={`${testID}-first-name`}
               />
             </View>
@@ -70,7 +83,7 @@ export function PrimerBillingAddressForm({
                 label={t('primer_card_form_label_last_name')}
                 placeholder={t('primer_card_form_placeholder_last_name')}
                 error={billingForm.errors.lastName}
-                returnKeyType="next"
+                returnKeyType={returnKey('lastName')}
                 testID={`${testID}-last-name`}
               />
             </View>
@@ -88,7 +101,7 @@ export function PrimerBillingAddressForm({
           label={t('primer_card_form_label_address1')}
           placeholder={t('primer_card_form_placeholder_address1')}
           error={billingForm.errors.addressLine1}
-          returnKeyType="next"
+          returnKeyType={returnKey('addressLine1')}
           testID={`${testID}-address-line-1`}
         />
       )}
@@ -102,7 +115,7 @@ export function PrimerBillingAddressForm({
           label={t('primer_card_form_label_address2')}
           placeholder={t('primer_card_form_placeholder_address2')}
           error={billingForm.errors.addressLine2}
-          returnKeyType="next"
+          returnKeyType={returnKey('addressLine2')}
           testID={`${testID}-address-line-2`}
         />
       )}
@@ -120,7 +133,7 @@ export function PrimerBillingAddressForm({
                 label={t('primer_card_form_label_postal')}
                 placeholder={t('primer_card_form_placeholder_postal')}
                 error={billingForm.errors.postalCode}
-                returnKeyType="next"
+                returnKeyType={returnKey('postalCode')}
                 testID={`${testID}-postal-code`}
               />
             </View>
@@ -135,7 +148,7 @@ export function PrimerBillingAddressForm({
                 label={t('primer_card_form_label_city')}
                 placeholder={t('primer_card_form_placeholder_city')}
                 error={billingForm.errors.city}
-                returnKeyType="next"
+                returnKeyType={returnKey('city')}
                 testID={`${testID}-city`}
               />
             </View>
@@ -152,7 +165,7 @@ export function PrimerBillingAddressForm({
           label={t('primer_card_form_label_state')}
           placeholder={t('primer_card_form_placeholder_state')}
           error={billingForm.errors.state}
-          returnKeyType="done"
+          returnKeyType={returnKey('state')}
           testID={`${testID}-state`}
         />
       )}

--- a/src/Components/PrimerCardForm.tsx
+++ b/src/Components/PrimerCardForm.tsx
@@ -61,22 +61,24 @@ export function PrimerCardForm({
             ref={cvvRef}
             cardForm={cardForm}
             editable={!disabled}
-            returnKeyType="next"
-            onSubmitEditing={() => nameRef.current?.focus()}
+            returnKeyType={cardForm.isCardholderNameVisible ? 'next' : 'done'}
+            onSubmitEditing={cardForm.isCardholderNameVisible ? () => nameRef.current?.focus() : onSubmit}
             testID={`${testID}-cvv`}
             label={cardForm.descriptor.cvvLabel}
           />
         </View>
       </View>
 
-      <CardholderNameInput
-        ref={nameRef}
-        cardForm={cardForm}
-        editable={!disabled}
-        returnKeyType="done"
-        onSubmitEditing={onSubmit}
-        testID={`${testID}-cardholder-name`}
-      />
+      {cardForm.isCardholderNameVisible && (
+        <CardholderNameInput
+          ref={nameRef}
+          cardForm={cardForm}
+          editable={!disabled}
+          returnKeyType="done"
+          onSubmitEditing={onSubmit}
+          testID={`${testID}-cardholder-name`}
+        />
+      )}
     </View>
   );
 }

--- a/src/Components/PrimerCheckoutProvider.tsx
+++ b/src/Components/PrimerCheckoutProvider.tsx
@@ -11,6 +11,7 @@ import type { PrimerSettings } from '../models/PrimerSettings';
 import { PrimerError } from '../models/PrimerError';
 import type { PrimerCheckoutData } from '../models/PrimerCheckoutData';
 import type { PrimerRawData } from '../models/PrimerRawData';
+import type { PrimerAddress } from '../models/PrimerClientSession';
 import type { PrimerBinData } from '../models/PrimerBinData';
 import type { PrimerVaultedPaymentMethod } from '../models/PrimerVaultedPaymentMethod';
 import type {
@@ -537,6 +538,20 @@ export function PrimerCheckoutProvider({
     }
   }, []);
 
+  const setBillingAddress = useCallback(async (address: PrimerAddress) => {
+    const m = managerRef.current;
+    if (!m) {
+      console.warn(`${LOG} setBillingAddress: no manager (activeMethod=${stateRef.current.activeMethod})`);
+      return;
+    }
+    try {
+      await m.setBillingAddress(address);
+    } catch (err) {
+      console.warn(`${LOG} setBillingAddress failed ${fmt(err)}`);
+      throw err;
+    }
+  }, []);
+
   const submit = useCallback(async () => {
     const m = managerRef.current;
     if (!m) {
@@ -674,6 +689,7 @@ export function PrimerCheckoutProvider({
       vaultDisplayOverride: state.vaultDisplayOverride,
       setActiveMethod,
       setRawData,
+      setBillingAddress,
       submit,
       retry,
       clearPaymentOutcome,
@@ -685,6 +701,7 @@ export function PrimerCheckoutProvider({
       state,
       setActiveMethod,
       setRawData,
+      setBillingAddress,
       submit,
       retry,
       clearPaymentOutcome,

--- a/src/Components/PrimerCheckoutProvider.tsx
+++ b/src/Components/PrimerCheckoutProvider.tsx
@@ -457,8 +457,8 @@ export function PrimerCheckoutProvider({
 
     const method = state.activeMethod;
     let cancelled = false;
-    const m = new PrimerHeadlessUniversalCheckoutRawDataManager();
-    managerRef.current = m;
+    const manager = new PrimerHeadlessUniversalCheckoutRawDataManager();
+    managerRef.current = manager;
 
     const callbacks = {
       onValidation: (isValid: boolean, errors: PrimerError[] | undefined) => {
@@ -485,9 +485,9 @@ export function PrimerCheckoutProvider({
 
     (async () => {
       try {
-        await m.configure({ paymentMethodType: method, ...callbacks });
+        await manager.configure({ paymentMethodType: method, ...callbacks });
         if (cancelled) return;
-        const requiredFields = await m.getRequiredInputElementTypes();
+        const requiredFields = await manager.getRequiredInputElementTypes();
         if (cancelled) return;
         setState((prev) => ({
           ...prev,
@@ -502,13 +502,13 @@ export function PrimerCheckoutProvider({
       cancelled = true;
       // If retry() holds this manager, defer destroy until retry's finally
       // runs — otherwise we'd cleanUp() between its awaited configure/submit.
-      if (retryingManagerRef.current === m) {
-        pendingCleanupRef.current = m;
+      if (retryingManagerRef.current === manager) {
+        pendingCleanupRef.current = manager;
         return;
       }
-      m.cleanUp().catch((err) => console.warn(`${LOG} manager cleanUp failed ${fmt(err)}`));
-      m.removeAllListeners();
-      if (managerRef.current === m) {
+      manager.cleanUp().catch((err) => console.warn(`${LOG} manager cleanUp failed ${fmt(err)}`));
+      manager.removeAllListeners();
+      if (managerRef.current === manager) {
         managerRef.current = null;
       }
       lastManagerCallbacksRef.current = null;
@@ -525,13 +525,13 @@ export function PrimerCheckoutProvider({
 
   const setRawData = useCallback(async (data: PrimerRawData) => {
     lastRawDataRef.current = data;
-    const m = managerRef.current;
-    if (!m) {
+    const manager = managerRef.current;
+    if (!manager) {
       console.warn(`${LOG} setRawData: no manager (activeMethod=${stateRef.current.activeMethod})`);
       return;
     }
     try {
-      await m.setRawData(data);
+      await manager.setRawData(data);
     } catch (err) {
       console.warn(`${LOG} setRawData failed: ${err instanceof PrimerError ? err.errorId : 'unknown'}`);
       throw err;
@@ -539,13 +539,13 @@ export function PrimerCheckoutProvider({
   }, []);
 
   const setBillingAddress = useCallback(async (address: PrimerAddress) => {
-    const m = managerRef.current;
-    if (!m) {
+    const manager = managerRef.current;
+    if (!manager) {
       console.warn(`${LOG} setBillingAddress: no manager (activeMethod=${stateRef.current.activeMethod})`);
       return;
     }
     try {
-      await m.setBillingAddress(address);
+      await manager.setBillingAddress(address);
     } catch (err) {
       console.warn(`${LOG} setBillingAddress failed ${fmt(err)}`);
       throw err;
@@ -553,38 +553,38 @@ export function PrimerCheckoutProvider({
   }, []);
 
   const submit = useCallback(async () => {
-    const m = managerRef.current;
-    if (!m) {
+    const manager = managerRef.current;
+    if (!manager) {
       console.warn(`${LOG} submit: no manager`);
       return;
     }
-    await m.submit();
+    await manager.submit();
   }, []);
 
   const retry = useCallback(async () => {
     const method = stateRef.current.activeMethod;
-    const m = managerRef.current;
-    if (!method || !m) {
-      console.warn(`${LOG} retry: no active method or manager ${fmt({ method, hasManager: !!m })}`);
+    const manager = managerRef.current;
+    if (!method || !manager) {
+      console.warn(`${LOG} retry: no active method or manager ${fmt({ method, hasManager: !!manager })}`);
       return;
     }
     // TODO(iOS native fix): ios .../RawDataManager.swift:237 nullifies its delegate on
     // successful tokenization, so any post-tokenize failure would silently drop subsequent
     // submit() outcomes. Reconfiguring here rebuilds the delegate binding. Harmless on
     // Android. Remove the reconfigure once the iOS SDK stops nullifying.
-    retryingManagerRef.current = m;
+    retryingManagerRef.current = manager;
     try {
       // Re-pass the original callbacks so the JS-wrapper's listeners get re-registered.
       // Otherwise native would emit onValidation/onBinDataChange/onMetadataChange during
       // the retry attempt with no JS-side subscribers → RN warns "no listeners registered".
       const callbacks = lastManagerCallbacksRef.current;
-      await m.configure(callbacks ? { paymentMethodType: method, ...callbacks } : { paymentMethodType: method });
+      await manager.configure(callbacks ? { paymentMethodType: method, ...callbacks } : { paymentMethodType: method });
       if (lastRawDataRef.current) {
-        await m.setRawData(lastRawDataRef.current);
+        await manager.setRawData(lastRawDataRef.current);
       }
       // Clear the previous outcome so the transitioner fires for the new attempt.
       setState((prev) => (prev.paymentOutcome === null ? prev : { ...prev, paymentOutcome: null }));
-      await m.submit();
+      await manager.submit();
     } catch (err) {
       console.error(`${LOG} retry failed ${fmt(err)}`);
       throw err;
@@ -592,7 +592,7 @@ export function PrimerCheckoutProvider({
       retryingManagerRef.current = null;
       // Run a teardown that the effect cleanup deferred while retry was in flight.
       const pending = pendingCleanupRef.current;
-      if (pending === m) {
+      if (pending === manager) {
         pendingCleanupRef.current = null;
         pending.cleanUp().catch((err) => console.warn(`${LOG} deferred cleanUp failed ${fmt(err)}`));
         pending.removeAllListeners();

--- a/src/Components/hooks/useBillingAddressForm.ts
+++ b/src/Components/hooks/useBillingAddressForm.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+import { useBillingAddressFormStateContext } from '../internal/form-state/BillingAddressFormStateProvider';
+import type { UseBillingAddressFormOptions, UseBillingAddressFormReturn } from '../types/BillingAddressFormTypes';
+
+/**
+ * Billing-address form adapter hook. Thin wrapper over
+ * `BillingAddressFormStateProvider` — the provider owns the field state,
+ * touched map, and debouncer. This hook reads the shared state and wires the
+ * per-caller `onValidationChange` callback.
+ *
+ * Must be used inside a `<PrimerCheckoutProvider>` tree that also mounts
+ * `<BillingAddressFormStateProvider>` (the drop-in `CheckoutFlow` does this
+ * for you).
+ */
+export function useBillingAddressForm(options: UseBillingAddressFormOptions = {}): UseBillingAddressFormReturn {
+  const state = useBillingAddressFormStateContext();
+  if (!state) {
+    throw new Error(
+      'useBillingAddressForm must be used within a <BillingAddressFormStateProvider>. ' +
+        'The built-in <PrimerCheckoutSheet>/<CheckoutFlow> wires this automatically.'
+    );
+  }
+
+  const onValidationChangeRef = useRef(options.onValidationChange);
+  onValidationChangeRef.current = options.onValidationChange;
+
+  useEffect(() => {
+    onValidationChangeRef.current?.(state.isValid, state.errors);
+  }, [state.isValid, state.errors]);
+
+  return state;
+}

--- a/src/Components/hooks/useCardForm.ts
+++ b/src/Components/hooks/useCardForm.ts
@@ -1,295 +1,50 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
+import { useCardFormStateContext } from '../internal/form-state/CardFormStateProvider';
 import { usePrimerCheckout } from './usePrimerCheckout';
-import { useCardNetwork } from './useCardNetwork';
-import { debounce, type DebouncedFunction } from '../../utils/debounce';
-import { fmt } from '../internal/debug';
-import { PrimerError } from '../../models/PrimerError';
-import { formatDigitsWithGaps, maxFormattedCardNumberLength, maxPanDigits } from '../internal/cardFormat';
-import type { CardFormField, CardFormErrors, UseCardFormOptions, UseCardFormReturn } from '../types/CardFormTypes';
-
-const LOG = '[useCardForm]';
-const DEBOUNCE_MS = 150;
-const PAYMENT_METHOD_TYPE = 'PAYMENT_CARD';
-
-function formatCardNumber(value: string, gapPattern: readonly number[], maxDigits: number): string {
-  const digits = value.replace(/\D/g, '').slice(0, maxDigits);
-  const out = formatDigitsWithGaps(digits, gapPattern);
-  console.log(`${LOG} formatCardNumber ${fmt({ raw: value, digits, gapPattern, maxDigits, out })}`);
-  return out;
-}
-
-function formatExpiryDate(value: string, previous: string): string {
-  const digits = value.replace(/\D/g, '').slice(0, 4);
-  if (value.length < previous.length) {
-    return digits;
-  }
-  if (digits.length >= 2) {
-    return digits.slice(0, 2) + '/' + digits.slice(2);
-  }
-  return digits;
-}
-
-function formatCVV(value: string, maxDigits: 3 | 4): string {
-  return value.replace(/\D/g, '').slice(0, maxDigits);
-}
-
-function stripCardNumberForNative(formatted: string): string {
-  return formatted.replace(/\s/g, '');
-}
-
-// Display is MM/YY but Android's validator requires MM/YYYY; iOS accepts both.
-// Expand only once the year is fully typed (4-char "MM/YY"); partial edits
-// pass through unchanged so native can keep reporting "cannot be blank".
-function expandExpiryYearForNative(formatted: string): string {
-  const match = /^(\d{2})\/(\d{2})$/.exec(formatted);
-  return match ? `${match[1]}/20${match[2]}` : formatted;
-}
+import type { UseCardFormOptions, UseCardFormReturn } from '../types/CardFormTypes';
 
 /**
- * Card form adapter hook. Reads validation state from the session-owned raw-data
- * manager on the provider; forwards field updates to it; surfaces a stable
- * submit() that the form renders behind its button.
+ * Card form adapter hook. Thin wrapper over `CardFormStateProvider` — the
+ * provider owns the field state, focus tracking, debouncer, and submit lifecycle.
+ * This hook reads the shared state and wires per-caller option callbacks
+ * (`onValidationChange`, `onBinDataChange`, `onMetadataChange`).
  *
- * The native manager lifecycle lives on PrimerCheckoutProvider and is keyed by
- * `activeMethod`, which the method-selection screen sets when the user picks
- * a payment method. This hook deliberately does NOT touch `activeMethod`, so the
- * manager survives the card-form view's mount/unmount across nav transitions.
+ * Must be used inside a `<PrimerCheckoutProvider>` tree that also mounts
+ * `<CardFormStateProvider>` (the drop-in `CheckoutFlow` does this for you).
  */
 export function useCardForm(options: UseCardFormOptions = {}): UseCardFormReturn {
-  const { onValidationChange, onMetadataChange, onBinDataChange } = options;
-  const {
-    isReady,
-    activeMethod,
-    cardFormState,
-    setRawData: providerSetRawData,
-    submit: providerSubmit,
-  } = usePrimerCheckout();
+  const state = useCardFormStateContext();
+  if (!state) {
+    throw new Error(
+      'useCardForm must be used within a <CardFormStateProvider>. ' +
+        'The built-in <PrimerCheckoutSheet>/<CheckoutFlow> wires this automatically.'
+    );
+  }
 
-  const [cardNumber, setCardNumber] = useState('');
-  const [expiryDate, setExpiryDate] = useState('');
-  const [cvv, setCVV] = useState('');
-  const [cardholderName, setCardholderName] = useState('');
+  const { cardFormState } = usePrimerCheckout();
 
-  const [hasBeenFocused, setHasBeenFocused] = useState<Record<CardFormField, boolean>>({
-    cardNumber: false,
-    expiryDate: false,
-    cvv: false,
-    cardholderName: false,
-  });
-  const [hasBeenBlurred, setHasBeenBlurred] = useState<Record<CardFormField, boolean>>({
-    cardNumber: false,
-    expiryDate: false,
-    cvv: false,
-    cardholderName: false,
-  });
-  const [submitAttempted, setSubmitAttempted] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const onValidationChangeRef = useRef(onValidationChange);
-  onValidationChangeRef.current = onValidationChange;
-  const onBinDataChangeRef = useRef(onBinDataChange);
-  onBinDataChangeRef.current = onBinDataChange;
-  const onMetadataChangeRef = useRef(onMetadataChange);
-  onMetadataChangeRef.current = onMetadataChange;
+  const onValidationChangeRef = useRef(options.onValidationChange);
+  onValidationChangeRef.current = options.onValidationChange;
+  const onBinDataChangeRef = useRef(options.onBinDataChange);
+  onBinDataChangeRef.current = options.onBinDataChange;
+  const onMetadataChangeRef = useRef(options.onMetadataChange);
+  onMetadataChangeRef.current = options.onMetadataChange;
 
   useEffect(() => {
-    onValidationChangeRef.current?.(cardFormState.isValid, cardFormState.errors);
-  }, [cardFormState.isValid, cardFormState.errors]);
+    onValidationChangeRef.current?.(state.isValid, state.errors);
+  }, [state.isValid, state.errors]);
+
   useEffect(() => {
-    if (cardFormState.binData) {
-      onBinDataChangeRef.current?.(cardFormState.binData);
+    if (state.binData) {
+      onBinDataChangeRef.current?.(state.binData);
     }
-  }, [cardFormState.binData]);
+  }, [state.binData]);
+
   useEffect(() => {
     if (cardFormState.metadata) {
       onMetadataChangeRef.current?.(cardFormState.metadata);
     }
   }, [cardFormState.metadata]);
 
-  const fieldsRef = useRef({ cardNumber: '', expiryDate: '', cvv: '', cardholderName: '' });
-  const debouncedRef = useRef<DebouncedFunction<
-    (data: { cardNumber: string; expiryDate: string; cvv: string; cardholderName: string }) => void
-  > | null>(null);
-
-  useEffect(() => {
-    debouncedRef.current = debounce(
-      (data: { cardNumber: string; expiryDate: string; cvv: string; cardholderName: string }) => {
-        providerSetRawData(data).catch(() => {
-          // Provider already logs (sanitized); swallow to prevent unhandled rejection.
-        });
-      },
-      DEBOUNCE_MS
-    );
-    return () => debouncedRef.current?.cancel();
-  }, [providerSetRawData]);
-
-  // Always include cardholderName in the payload — the native SDK's required-fields set
-  // varies by client session; sending the field unconditionally keeps validation honest
-  // regardless of whether the merchant has required it server-side.
-  const syncToNative = useCallback(() => {
-    const fields = fieldsRef.current;
-    const data = {
-      cardNumber: stripCardNumberForNative(fields.cardNumber),
-      expiryDate: expandExpiryYearForNative(fields.expiryDate),
-      cvv: fields.cvv,
-      cardholderName: fields.cardholderName,
-    };
-    debouncedRef.current?.(data);
-  }, []);
-
-  // Descriptor resolves asynchronously (see useCardNetwork). Capture via a ref so
-  // updateCardNumber's useCallback dep array doesn't re-close over descriptor each
-  // render; the ref is refreshed below whenever descriptor changes.
-  const { descriptor } = useCardNetwork();
-  const descriptorRef = useRef(descriptor);
-  descriptorRef.current = descriptor;
-
-  const updateCardNumber = useCallback(
-    (value: string) => {
-      const d = descriptorRef.current;
-      const gap = d?.gapPattern ?? [4, 8, 12];
-      const max = d ? maxPanDigits(d) : 19;
-      const formatted = formatCardNumber(value, gap, max);
-      setCardNumber(formatted);
-      fieldsRef.current.cardNumber = formatted;
-      syncToNative();
-    },
-    [syncToNative]
-  );
-
-  const updateExpiryDate = useCallback(
-    (value: string) => {
-      const formatted = formatExpiryDate(value, fieldsRef.current.expiryDate);
-      setExpiryDate(formatted);
-      fieldsRef.current.expiryDate = formatted;
-      syncToNative();
-    },
-    [syncToNative]
-  );
-
-  const updateCVV = useCallback(
-    (value: string) => {
-      const formatted = formatCVV(value, descriptorRef.current.cvvLength);
-      setCVV(formatted);
-      fieldsRef.current.cvv = formatted;
-      syncToNative();
-    },
-    [syncToNative]
-  );
-
-  const updateCardholderName = useCallback(
-    (value: string) => {
-      setCardholderName(value);
-      fieldsRef.current.cardholderName = value;
-      syncToNative();
-    },
-    [syncToNative]
-  );
-
-  // Re-arm: focusing a previously-blurred field clears its blur flag so its error
-  // disappears until the user blurs again. A submit attempt overrides this gate
-  // so the user can't hide errors by tapping a field after a failed submit.
-  const markFieldFocused = useCallback((field: CardFormField) => {
-    setHasBeenFocused((prev) => (prev[field] ? prev : { ...prev, [field]: true }));
-    setHasBeenBlurred((prev) => (!prev[field] ? prev : { ...prev, [field]: false }));
-  }, []);
-
-  const markFieldBlurred = useCallback((field: CardFormField) => {
-    setHasBeenBlurred((prev) => (prev[field] ? prev : { ...prev, [field]: true }));
-  }, []);
-
-  const markSubmitAttempted = useCallback(() => {
-    setSubmitAttempted(true);
-  }, []);
-
-  const errors = useMemo(() => {
-    const visible: CardFormErrors = {};
-    for (const field of Object.keys(cardFormState.errors) as CardFormField[]) {
-      const show = submitAttempted || (hasBeenFocused[field] && hasBeenBlurred[field]);
-      if (show) visible[field] = cardFormState.errors[field];
-    }
-    return visible;
-  }, [cardFormState.errors, hasBeenFocused, hasBeenBlurred, submitAttempted]);
-
-  // Mid-typing re-format: when the detected network flips (e.g. first 4 digits
-  // resolve to AMEX), reformat what's already in the field so spacing matches the
-  // new gap pattern AND truncate if the new max is shorter (OTHER 19 → Amex 15).
-  useEffect(() => {
-    const currentDigits = fieldsRef.current.cardNumber.replace(/\D/g, '');
-    if (!currentDigits) return;
-    const maxDigits = maxPanDigits(descriptor);
-    const truncated = currentDigits.slice(0, maxDigits);
-    const reformatted = formatDigitsWithGaps(truncated, descriptor.gapPattern);
-    if (reformatted === fieldsRef.current.cardNumber) return;
-    console.log(
-      `${LOG} reformat on network change ${fmt({ before: fieldsRef.current.cardNumber, after: reformatted, gapPattern: descriptor.gapPattern, maxDigits })}`
-    );
-    fieldsRef.current.cardNumber = reformatted;
-    setCardNumber(reformatted);
-    // If truncation actually dropped digits, tell native so validation matches
-    // what the user sees.
-    if (truncated.length !== currentDigits.length) syncToNative();
-  }, [descriptor, syncToNative]);
-
-  const isSubmittingRef = useRef(false);
-  const submit = useCallback(async () => {
-    // Flip submit-attempted before any guard returns so a failed submit reveals every error.
-    setSubmitAttempted(true);
-    if (!isReady || activeMethod !== PAYMENT_METHOD_TYPE) {
-      console.warn(`${LOG} submit: not ready ${fmt({ isReady, activeMethod })}`);
-      return;
-    }
-    if (isSubmittingRef.current) return;
-    debouncedRef.current?.flush();
-    if (!cardFormState.isValid) return;
-    isSubmittingRef.current = true;
-    setIsSubmitting(true);
-    try {
-      await providerSubmit();
-    } catch (err) {
-      console.error(`${LOG} submit failed: ${err instanceof PrimerError ? err.errorId : 'unknown'}`);
-    } finally {
-      isSubmittingRef.current = false;
-      setIsSubmitting(false);
-    }
-  }, [isReady, activeMethod, cardFormState.isValid, providerSubmit]);
-
-  const reset = useCallback(() => {
-    setCardNumber('');
-    setExpiryDate('');
-    setCVV('');
-    setCardholderName('');
-    setHasBeenFocused({ cardNumber: false, expiryDate: false, cvv: false, cardholderName: false });
-    setHasBeenBlurred({ cardNumber: false, expiryDate: false, cvv: false, cardholderName: false });
-    setSubmitAttempted(false);
-    setIsSubmitting(false);
-    isSubmittingRef.current = false;
-    fieldsRef.current = { cardNumber: '', expiryDate: '', cvv: '', cardholderName: '' };
-    debouncedRef.current?.cancel();
-    providerSetRawData({ cardNumber: '', expiryDate: '', cvv: '', cardholderName: '' }).catch(() => {});
-  }, [providerSetRawData]);
-
-  return {
-    cardNumber,
-    expiryDate,
-    cvv,
-    cardholderName,
-    updateCardNumber,
-    updateExpiryDate,
-    updateCVV,
-    updateCardholderName,
-    isValid: cardFormState.isValid,
-    errors,
-    markFieldFocused,
-    markFieldBlurred,
-    markSubmitAttempted,
-    submit,
-    isSubmitting,
-    submitAttempted,
-    requiredFields: cardFormState.requiredFields,
-    binData: cardFormState.binData,
-    descriptor,
-    cardNumberMaxLength: maxFormattedCardNumberLength(descriptor),
-    reset,
-  };
+  return state;
 }

--- a/src/Components/index.ts
+++ b/src/Components/index.ts
@@ -20,6 +20,14 @@ export type { UseCardFormOptions, UseCardFormReturn, CardFormErrors, CardFormFie
 export { useCardNetwork } from './hooks/useCardNetwork';
 export type { UseCardNetworkReturn } from './hooks/useCardNetwork';
 export type { CardNetworkDescriptor, CardNetworkId, CardNetworkIconSource, CvvLabel } from './internal/cardNetwork';
+export { useBillingAddressForm } from './hooks/useBillingAddressForm';
+export type {
+  UseBillingAddressFormOptions,
+  UseBillingAddressFormReturn,
+  BillingAddressFormErrors,
+  BillingAddressField,
+  PrimerBillingAddressFormProps,
+} from './types/BillingAddressFormTypes';
 export { PrimerPaymentMethodList } from './PrimerPaymentMethodList';
 export type { PrimerPaymentMethodListProps } from './types/PrimerPaymentMethodListTypes';
 export { PrimerVaultedPaymentMethod } from './PrimerVaultedPaymentMethod';
@@ -33,7 +41,16 @@ export { PrimerCheckoutSheet } from './PrimerCheckoutSheet';
 export type { PrimerCheckoutSheetProps } from './PrimerCheckoutSheet';
 export { PrimerCardForm } from './PrimerCardForm';
 export type { PrimerCardFormProps } from './types/PrimerCardFormTypes';
-export { PrimerTextInput, CardNumberInput, ExpiryDateInput, CVVInput, CardholderNameInput } from './inputs';
+export { PrimerBillingAddressForm } from './PrimerBillingAddressForm';
+export {
+  PrimerTextInput,
+  CardNumberInput,
+  ExpiryDateInput,
+  CVVInput,
+  CardholderNameInput,
+  CountrySelectorRow,
+} from './inputs';
+export type { CountrySelectorRowProps } from './inputs';
 export type {
   PrimerTextInputTheme,
   PrimerTextInputProps,

--- a/src/Components/inputs/CountrySelectorRow.tsx
+++ b/src/Components/inputs/CountrySelectorRow.tsx
@@ -1,0 +1,115 @@
+import { useMemo } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View, type StyleProp, type ViewStyle } from 'react-native';
+import { useTheme } from '../internal/theme';
+import type { PrimerTokens } from '../internal/theme';
+import { FIELD_HEIGHT, LINE_HEIGHT_RATIO } from './dimensions';
+
+export interface CountrySelectorRowProps {
+  /** ISO country code currently selected, or empty if none. */
+  value: string;
+  /** Human-readable country name, when available. Falls back to the code, then the placeholder. */
+  displayName?: string;
+  /** Field label shown above the row. */
+  label: string;
+  /** Placeholder shown when no country is selected. */
+  placeholder: string;
+  /** Fires when the row is pressed — host wires navigation to the country selector screen. */
+  onPress: () => void;
+  /** Disables the row. */
+  editable?: boolean;
+  /** Optional outer container style. */
+  style?: StyleProp<ViewStyle>;
+  /** Test ID root. */
+  testID?: string;
+}
+
+export function CountrySelectorRow({
+  value,
+  displayName,
+  label,
+  placeholder,
+  onPress,
+  editable = true,
+  style,
+  testID,
+}: CountrySelectorRowProps) {
+  const tokens = useTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+
+  const hasValue = !!value;
+  const text = hasValue ? (displayName ?? value) : placeholder;
+
+  return (
+    <View style={[styles.container, style]} testID={testID}>
+      <Text style={styles.label}>{label}</Text>
+      <TouchableOpacity
+        onPress={onPress}
+        disabled={!editable}
+        activeOpacity={0.7}
+        style={[styles.row, !editable && styles.rowDisabled]}
+        accessibilityRole="button"
+        accessibilityState={{ disabled: !editable }}
+        accessibilityLabel={label}
+        accessibilityValue={{ text: hasValue ? text : '' }}
+        testID={testID ? `${testID}-row` : undefined}
+      >
+        <Text
+          style={[styles.value, !hasValue && styles.placeholder]}
+          numberOfLines={1}
+          testID={testID ? `${testID}-value` : undefined}
+        >
+          {text}
+        </Text>
+        <Text style={styles.chevron} accessibilityElementsHidden>
+          ›
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+function createStyles(tokens: PrimerTokens) {
+  const { colors, radii, spacing, typography, borders } = tokens;
+  /* eslint-disable react-native/no-unused-styles */
+  return StyleSheet.create({
+    chevron: {
+      color: tokens.colors.textSecondary,
+      fontSize: typography.bodyLarge.fontSize + 4,
+      lineHeight: FIELD_HEIGHT,
+      marginLeft: spacing.small,
+    },
+    container: {},
+    label: {
+      color: colors.textPrimary,
+      fontFamily: typography.fontFamily,
+      fontSize: typography.bodySmall.fontSize,
+      marginBottom: spacing.xsmall,
+    },
+    placeholder: {
+      color: colors.textPlaceholder,
+    },
+    row: {
+      alignItems: 'center',
+      backgroundColor: colors.background,
+      borderColor: colors.border,
+      borderRadius: radii.small,
+      borderWidth: borders.input,
+      flexDirection: 'row',
+      height: FIELD_HEIGHT,
+      paddingHorizontal: spacing.medium,
+    },
+    rowDisabled: {
+      backgroundColor: colors.surface,
+      borderColor: colors.borderDisabled,
+    },
+    value: {
+      color: colors.textPrimary,
+      flex: 1,
+      fontFamily: typography.fontFamily,
+      fontSize: typography.bodyLarge.fontSize,
+      letterSpacing: typography.bodyLarge.letterSpacing,
+      lineHeight: Math.round(typography.bodyLarge.fontSize * LINE_HEIGHT_RATIO),
+    },
+  });
+  /* eslint-enable react-native/no-unused-styles */
+}

--- a/src/Components/inputs/index.ts
+++ b/src/Components/inputs/index.ts
@@ -3,3 +3,5 @@ export { CardNumberInput } from './CardNumberInput';
 export { ExpiryDateInput } from './ExpiryDateInput';
 export { CVVInput } from './CVVInput';
 export { CardholderNameInput } from './CardholderNameInput';
+export { CountrySelectorRow } from './CountrySelectorRow';
+export type { CountrySelectorRowProps } from './CountrySelectorRow';

--- a/src/Components/internal/billingAddressOptions.ts
+++ b/src/Components/internal/billingAddressOptions.ts
@@ -1,0 +1,47 @@
+import type { PrimerClientSession } from '../../models/PrimerClientSession';
+import type { BillingAddressField } from '../types/BillingAddressFormTypes';
+
+const BILLING_ADDRESS_FIELDS: ReadonlyArray<BillingAddressField> = [
+  'firstName',
+  'lastName',
+  'addressLine1',
+  'addressLine2',
+  'city',
+  'state',
+  'postalCode',
+  'countryCode',
+];
+
+export type BillingAddressVisibility = Record<BillingAddressField, boolean>;
+
+export interface BillingAddressVisibilityResult {
+  fields: BillingAddressVisibility;
+  sectionVisible: boolean;
+}
+
+const ALL_HIDDEN: BillingAddressVisibility = {
+  firstName: false,
+  lastName: false,
+  addressLine1: false,
+  addressLine2: false,
+  city: false,
+  state: false,
+  postalCode: false,
+  countryCode: false,
+};
+
+export function getBillingAddressVisibility(
+  session: PrimerClientSession | null | undefined
+): BillingAddressVisibilityResult {
+  const module = session?.checkoutModules?.find((m) => m.type === 'BILLING_ADDRESS');
+  const options = module?.options ?? {};
+  const fields = BILLING_ADDRESS_FIELDS.reduce<BillingAddressVisibility>(
+    (acc, f) => {
+      acc[f] = options[f] === true;
+      return acc;
+    },
+    { ...ALL_HIDDEN }
+  );
+  const sectionVisible = Object.values(fields).some(Boolean);
+  return { fields, sectionVisible };
+}

--- a/src/Components/internal/checkout-flow/CheckoutFlow.tsx
+++ b/src/Components/internal/checkout-flow/CheckoutFlow.tsx
@@ -11,6 +11,7 @@ import { CardFormScreen } from '../screens/CardFormScreen';
 import { ErrorScreen } from '../screens/ErrorScreen';
 import { SuccessScreen } from '../screens/SuccessScreen';
 import { VaultedMethodsScreen } from '../screens/VaultedMethodsScreen';
+import { CardFormStateProvider, BillingAddressFormStateProvider } from '../form-state';
 import { CheckoutFlowContext } from './CheckoutFlowContext';
 
 const SUCCESS_AUTO_DISMISS_MS = 5000;
@@ -110,7 +111,11 @@ export function CheckoutFlow({ onCancel }: CheckoutFlowProps = {}) {
       <NavigationProvider initialRoute={CheckoutRoute.splash}>
         <ReadinessTransitioner />
         <PaymentOutcomeTransitioner />
-        <NavigationContainer screenMap={screenMap} />
+        <CardFormStateProvider>
+          <BillingAddressFormStateProvider>
+            <NavigationContainer screenMap={screenMap} />
+          </BillingAddressFormStateProvider>
+        </CardFormStateProvider>
       </NavigationProvider>
     </CheckoutFlowContext.Provider>
   );

--- a/src/Components/internal/form-state/BillingAddressFormStateProvider.tsx
+++ b/src/Components/internal/form-state/BillingAddressFormStateProvider.tsx
@@ -1,0 +1,251 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
+import { debounce, type DebouncedFunction } from '../../../utils/debounce';
+import { fmt } from '../debug';
+import { getBillingAddressVisibility } from '../billingAddressOptions';
+import type { PrimerAddress } from '../../../models/PrimerClientSession';
+import type {
+  BillingAddressField,
+  BillingAddressFormErrors,
+  UseBillingAddressFormReturn,
+} from '../../types/BillingAddressFormTypes';
+
+const LOG = '[BillingAddressFormState]';
+const DEBOUNCE_MS = 150;
+
+interface BillingFields {
+  firstName: string;
+  lastName: string;
+  addressLine1: string;
+  addressLine2: string;
+  city: string;
+  state: string;
+  postalCode: string;
+  countryCode: string;
+}
+
+const EMPTY_FIELDS: BillingFields = {
+  firstName: '',
+  lastName: '',
+  addressLine1: '',
+  addressLine2: '',
+  city: '',
+  state: '',
+  postalCode: '',
+  countryCode: '',
+};
+
+const EMPTY_TOUCHED: Record<BillingAddressField, boolean> = {
+  firstName: false,
+  lastName: false,
+  addressLine1: false,
+  addressLine2: false,
+  city: false,
+  state: false,
+  postalCode: false,
+  countryCode: false,
+};
+
+const REQUIRED_FIELDS: BillingAddressField[] = [
+  'firstName',
+  'lastName',
+  'addressLine1',
+  'city',
+  'state',
+  'postalCode',
+  'countryCode',
+];
+
+function fieldsToAddress(fields: BillingFields): PrimerAddress {
+  return {
+    firstName: fields.firstName || undefined,
+    lastName: fields.lastName || undefined,
+    addressLine1: fields.addressLine1 || undefined,
+    addressLine2: fields.addressLine2 || undefined,
+    city: fields.city || undefined,
+    state: fields.state || undefined,
+    postalCode: fields.postalCode || undefined,
+    countryCode: fields.countryCode || undefined,
+  };
+}
+
+const BillingAddressFormStateContext = createContext<UseBillingAddressFormReturn | null>(null);
+
+/**
+ * Holds billing-address state above the navigation stack so values survive screen
+ * unmounts (specifically: CardFormScreen unmounts when CountrySelectorScreen is
+ * pushed on top). Also means every `useBillingAddressForm()` call shares the same
+ * state — the country selector can write while the form screen reads.
+ */
+export function BillingAddressFormStateProvider({ children }: { children: ReactNode }) {
+  const { setBillingAddress: providerSetBillingAddress, clientSession } = usePrimerCheckout();
+
+  const { fields: visibleFields, sectionVisible } = useMemo(
+    () => getBillingAddressVisibility(clientSession),
+    [clientSession]
+  );
+
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [addressLine1, setAddressLine1] = useState('');
+  const [addressLine2, setAddressLine2] = useState('');
+  const [city, setCity] = useState('');
+  const [stateValue, setStateValue] = useState('');
+  const [postalCode, setPostalCode] = useState('');
+  const [countryCode, setCountryCode] = useState('');
+  const [touched, setTouched] = useState<Record<BillingAddressField, boolean>>(EMPTY_TOUCHED);
+
+  const fieldsRef = useRef<BillingFields>({ ...EMPTY_FIELDS });
+  const debouncedRef = useRef<DebouncedFunction<(address: PrimerAddress) => void> | null>(null);
+
+  useEffect(() => {
+    debouncedRef.current = debounce((address: PrimerAddress) => {
+      providerSetBillingAddress(address).catch((err) => {
+        console.warn(`${LOG} setBillingAddress error ${fmt(err)}`);
+      });
+    }, DEBOUNCE_MS);
+    return () => debouncedRef.current?.cancel();
+  }, [providerSetBillingAddress]);
+
+  const syncToNative = useCallback(() => {
+    debouncedRef.current?.(fieldsToAddress(fieldsRef.current));
+  }, []);
+
+  const makeUpdater = useCallback(
+    (field: BillingAddressField, setState: (value: string) => void) => {
+      return (value: string) => {
+        setState(value);
+        fieldsRef.current = { ...fieldsRef.current, [field]: value };
+        syncToNative();
+      };
+    },
+    [syncToNative]
+  );
+
+  const updateFirstName = useMemo(() => makeUpdater('firstName', setFirstName), [makeUpdater]);
+  const updateLastName = useMemo(() => makeUpdater('lastName', setLastName), [makeUpdater]);
+  const updateAddressLine1 = useMemo(() => makeUpdater('addressLine1', setAddressLine1), [makeUpdater]);
+  const updateAddressLine2 = useMemo(() => makeUpdater('addressLine2', setAddressLine2), [makeUpdater]);
+  const updateCity = useMemo(() => makeUpdater('city', setCity), [makeUpdater]);
+  const updateState = useMemo(() => makeUpdater('state', setStateValue), [makeUpdater]);
+  const updatePostalCode = useMemo(() => makeUpdater('postalCode', setPostalCode), [makeUpdater]);
+  const updateCountryCode = useMemo(() => makeUpdater('countryCode', setCountryCode), [makeUpdater]);
+
+  const markFieldTouched = useCallback((field: BillingAddressField) => {
+    setTouched((prev) => (prev[field] ? prev : { ...prev, [field]: true }));
+  }, []);
+
+  const currentFields: BillingFields = {
+    firstName,
+    lastName,
+    addressLine1,
+    addressLine2,
+    city,
+    state: stateValue,
+    postalCode,
+    countryCode,
+  };
+
+  const effectiveRequired = useMemo(() => REQUIRED_FIELDS.filter((f) => visibleFields[f]), [visibleFields]);
+
+  const isValid = useMemo(
+    () => effectiveRequired.every((f) => currentFields[f].trim().length > 0),
+    [effectiveRequired, firstName, lastName, addressLine1, city, stateValue, postalCode, countryCode]
+  );
+
+  const errors = useMemo(() => {
+    const visible: BillingAddressFormErrors = {};
+    for (const field of effectiveRequired) {
+      if (touched[field] && currentFields[field].trim().length === 0) {
+        visible[field] = 'required';
+      }
+    }
+    return visible;
+  }, [effectiveRequired, touched, firstName, lastName, addressLine1, city, stateValue, postalCode, countryCode]);
+
+  const flush = useCallback(async () => {
+    debouncedRef.current?.flush();
+    try {
+      await providerSetBillingAddress(fieldsToAddress(fieldsRef.current));
+    } catch (err) {
+      console.warn(`${LOG} flush error ${fmt(err)}`);
+    }
+  }, [providerSetBillingAddress]);
+
+  const getAddress = useCallback((): PrimerAddress => fieldsToAddress(fieldsRef.current), []);
+
+  const reset = useCallback(() => {
+    setFirstName('');
+    setLastName('');
+    setAddressLine1('');
+    setAddressLine2('');
+    setCity('');
+    setStateValue('');
+    setPostalCode('');
+    setCountryCode('');
+    setTouched(EMPTY_TOUCHED);
+    fieldsRef.current = { ...EMPTY_FIELDS };
+    debouncedRef.current?.cancel();
+  }, []);
+
+  const value = useMemo<UseBillingAddressFormReturn>(
+    () => ({
+      firstName,
+      lastName,
+      addressLine1,
+      addressLine2,
+      city,
+      state: stateValue,
+      postalCode,
+      countryCode,
+      updateFirstName,
+      updateLastName,
+      updateAddressLine1,
+      updateAddressLine2,
+      updateCity,
+      updateState,
+      updatePostalCode,
+      updateCountryCode,
+      isValid,
+      errors,
+      markFieldTouched,
+      visibleFields,
+      sectionVisible,
+      flush,
+      getAddress,
+      reset,
+    }),
+    [
+      firstName,
+      lastName,
+      addressLine1,
+      addressLine2,
+      city,
+      stateValue,
+      postalCode,
+      countryCode,
+      updateFirstName,
+      updateLastName,
+      updateAddressLine1,
+      updateAddressLine2,
+      updateCity,
+      updateState,
+      updatePostalCode,
+      updateCountryCode,
+      isValid,
+      errors,
+      markFieldTouched,
+      visibleFields,
+      sectionVisible,
+      flush,
+      getAddress,
+      reset,
+    ]
+  );
+
+  return <BillingAddressFormStateContext.Provider value={value}>{children}</BillingAddressFormStateContext.Provider>;
+}
+
+export function useBillingAddressFormStateContext(): UseBillingAddressFormReturn | null {
+  return useContext(BillingAddressFormStateContext);
+}

--- a/src/Components/internal/form-state/BillingAddressFormStateProvider.tsx
+++ b/src/Components/internal/form-state/BillingAddressFormStateProvider.tsx
@@ -11,7 +11,7 @@ import type {
 } from '../../types/BillingAddressFormTypes';
 
 const LOG = '[BillingAddressFormState]';
-const DEBOUNCE_MS = 150;
+const DEBOUNCE_MS = 275;
 
 interface BillingFields {
   firstName: string;

--- a/src/Components/internal/form-state/BillingAddressFormStateProvider.tsx
+++ b/src/Components/internal/form-state/BillingAddressFormStateProvider.tsx
@@ -97,6 +97,38 @@ export function BillingAddressFormStateProvider({ children }: { children: ReactN
 
   const fieldsRef = useRef<BillingFields>({ ...EMPTY_FIELDS });
   const debouncedRef = useRef<DebouncedFunction<(address: PrimerAddress) => void> | null>(null);
+  // Prefill from clientSession.customer.billingAddress runs at most once per provider
+  // lifecycle. Subsequent client-session updates do not re-seed fields — otherwise the
+  // shopper's edits would be clobbered every time the session refreshes.
+  const hasPrefilledRef = useRef(false);
+
+  useEffect(() => {
+    if (hasPrefilledRef.current) return;
+    const initial = clientSession?.customer?.billingAddress;
+    if (!initial) return;
+
+    const next: BillingFields = { ...fieldsRef.current };
+    let changed = false;
+    (Object.keys(EMPTY_FIELDS) as BillingAddressField[]).forEach((field) => {
+      const value = initial[field];
+      if (typeof value === 'string' && value.length > 0 && next[field] === '') {
+        next[field] = value;
+        changed = true;
+      }
+    });
+    if (!changed) return;
+
+    fieldsRef.current = next;
+    setFirstName(next.firstName);
+    setLastName(next.lastName);
+    setAddressLine1(next.addressLine1);
+    setAddressLine2(next.addressLine2);
+    setCity(next.city);
+    setStateValue(next.state);
+    setPostalCode(next.postalCode);
+    setCountryCode(next.countryCode);
+    hasPrefilledRef.current = true;
+  }, [clientSession]);
 
   useEffect(() => {
     debouncedRef.current = debounce((address: PrimerAddress) => {

--- a/src/Components/internal/form-state/CardFormStateProvider.tsx
+++ b/src/Components/internal/form-state/CardFormStateProvider.tsx
@@ -68,9 +68,17 @@ export function CardFormStateProvider({ children }: { children: ReactNode }) {
     isReady,
     activeMethod,
     cardFormState,
+    clientSession,
     setRawData: providerSetRawData,
     submit: providerSubmit,
   } = usePrimerCheckout();
+
+  // CARD_INFORMATION.options.cardHolderName === false hides the field. Any other shape
+  // (no module, no options, or `true`) keeps it visible — matches native iOS/Android behavior.
+  const isCardholderNameVisible = useMemo(() => {
+    const module = clientSession?.checkoutModules?.find((m) => m.type === 'CARD_INFORMATION');
+    return module?.options?.cardHolderName !== false;
+  }, [clientSession]);
 
   const [cardNumber, setCardNumber] = useState('');
   const [expiryDate, setExpiryDate] = useState('');
@@ -267,6 +275,7 @@ export function CardFormStateProvider({ children }: { children: ReactNode }) {
       binData: cardFormState.binData,
       descriptor,
       cardNumberMaxLength: maxFormattedCardNumberLength(descriptor),
+      isCardholderNameVisible,
       reset,
     }),
     [
@@ -289,6 +298,7 @@ export function CardFormStateProvider({ children }: { children: ReactNode }) {
       isSubmitting,
       submitAttempted,
       descriptor,
+      isCardholderNameVisible,
       reset,
     ]
   );

--- a/src/Components/internal/form-state/CardFormStateProvider.tsx
+++ b/src/Components/internal/form-state/CardFormStateProvider.tsx
@@ -1,0 +1,301 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
+import { useCardNetwork } from '../../hooks/useCardNetwork';
+import { debounce, type DebouncedFunction } from '../../../utils/debounce';
+import { fmt } from '../debug';
+import { PrimerError } from '../../../models/PrimerError';
+import { formatDigitsWithGaps, maxFormattedCardNumberLength, maxPanDigits } from '../cardFormat';
+import type { CardFormField, CardFormErrors, UseCardFormReturn } from '../../types/CardFormTypes';
+
+const LOG = '[CardFormState]';
+const DEBOUNCE_MS = 150;
+const PAYMENT_METHOD_TYPE = 'PAYMENT_CARD';
+
+function formatCardNumber(value: string, gapPattern: readonly number[], maxDigits: number): string {
+  const digits = value.replace(/\D/g, '').slice(0, maxDigits);
+  const out = formatDigitsWithGaps(digits, gapPattern);
+  console.log(`${LOG} formatCardNumber ${fmt({ raw: value, digits, gapPattern, maxDigits, out })}`);
+  return out;
+}
+
+function formatExpiryDate(value: string, previous: string): string {
+  const digits = value.replace(/\D/g, '').slice(0, 4);
+  if (value.length < previous.length) {
+    return digits;
+  }
+  if (digits.length >= 2) {
+    return digits.slice(0, 2) + '/' + digits.slice(2);
+  }
+  return digits;
+}
+
+function formatCVV(value: string, maxDigits: 3 | 4): string {
+  return value.replace(/\D/g, '').slice(0, maxDigits);
+}
+
+function stripCardNumberForNative(formatted: string): string {
+  return formatted.replace(/\s/g, '');
+}
+
+// Display is MM/YY but Android's validator requires MM/YYYY; iOS accepts both.
+// Expand only once the year is fully typed (4-char "MM/YY"); partial edits
+// pass through unchanged so native can keep reporting "cannot be blank".
+function expandExpiryYearForNative(formatted: string): string {
+  const match = /^(\d{2})\/(\d{2})$/.exec(formatted);
+  return match ? `${match[1]}/20${match[2]}` : formatted;
+}
+
+const INITIAL_FOCUS: Record<CardFormField, boolean> = {
+  cardNumber: false,
+  expiryDate: false,
+  cvv: false,
+  cardholderName: false,
+};
+
+const CardFormStateContext = createContext<UseCardFormReturn | null>(null);
+
+/**
+ * Holds card-form state above the navigation stack so values survive screen
+ * unmounts (e.g. when CardFormScreen is pushed past by the country selector).
+ * Also gives every caller of `useCardForm()` the same singleton state.
+ *
+ * Consumes `PrimerCheckoutContext` for the native validation state + the
+ * `setRawData` / `submit` dispatch surfaces, so it must mount below
+ * `PrimerCheckoutProvider`.
+ */
+export function CardFormStateProvider({ children }: { children: ReactNode }) {
+  const {
+    isReady,
+    activeMethod,
+    cardFormState,
+    setRawData: providerSetRawData,
+    submit: providerSubmit,
+  } = usePrimerCheckout();
+
+  const [cardNumber, setCardNumber] = useState('');
+  const [expiryDate, setExpiryDate] = useState('');
+  const [cvv, setCVV] = useState('');
+  const [cardholderName, setCardholderName] = useState('');
+
+  const [hasBeenFocused, setHasBeenFocused] = useState<Record<CardFormField, boolean>>(INITIAL_FOCUS);
+  const [hasBeenBlurred, setHasBeenBlurred] = useState<Record<CardFormField, boolean>>(INITIAL_FOCUS);
+  const [submitAttempted, setSubmitAttempted] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const fieldsRef = useRef({ cardNumber: '', expiryDate: '', cvv: '', cardholderName: '' });
+  const debouncedRef = useRef<DebouncedFunction<
+    (data: { cardNumber: string; expiryDate: string; cvv: string; cardholderName: string }) => void
+  > | null>(null);
+  const isSubmittingRef = useRef(false);
+
+  useEffect(() => {
+    debouncedRef.current = debounce(
+      (data: { cardNumber: string; expiryDate: string; cvv: string; cardholderName: string }) => {
+        providerSetRawData(data).catch(() => {
+          // Provider already logs (sanitized); swallow to prevent unhandled rejection.
+        });
+      },
+      DEBOUNCE_MS
+    );
+    return () => debouncedRef.current?.cancel();
+  }, [providerSetRawData]);
+
+  // Always include cardholderName in the payload — the native SDK's required-fields set
+  // varies by client session; sending the field unconditionally keeps validation honest
+  // regardless of whether the merchant has required it server-side.
+  const syncToNative = useCallback(() => {
+    const fields = fieldsRef.current;
+    const data = {
+      cardNumber: stripCardNumberForNative(fields.cardNumber),
+      expiryDate: expandExpiryYearForNative(fields.expiryDate),
+      cvv: fields.cvv,
+      cardholderName: fields.cardholderName,
+    };
+    debouncedRef.current?.(data);
+  }, []);
+
+  // Descriptor resolves asynchronously (see useCardNetwork). Capture via a ref so
+  // updateCardNumber's useCallback dep array doesn't re-close over descriptor each
+  // render; the ref is refreshed below whenever descriptor changes.
+  const { descriptor } = useCardNetwork();
+  const descriptorRef = useRef(descriptor);
+  descriptorRef.current = descriptor;
+
+  const updateCardNumber = useCallback(
+    (value: string) => {
+      const d = descriptorRef.current;
+      const gap = d?.gapPattern ?? [4, 8, 12];
+      const max = d ? maxPanDigits(d) : 19;
+      const formatted = formatCardNumber(value, gap, max);
+      setCardNumber(formatted);
+      fieldsRef.current.cardNumber = formatted;
+      syncToNative();
+    },
+    [syncToNative]
+  );
+
+  const updateExpiryDate = useCallback(
+    (value: string) => {
+      const formatted = formatExpiryDate(value, fieldsRef.current.expiryDate);
+      setExpiryDate(formatted);
+      fieldsRef.current.expiryDate = formatted;
+      syncToNative();
+    },
+    [syncToNative]
+  );
+
+  const updateCVV = useCallback(
+    (value: string) => {
+      const formatted = formatCVV(value, descriptorRef.current.cvvLength);
+      setCVV(formatted);
+      fieldsRef.current.cvv = formatted;
+      syncToNative();
+    },
+    [syncToNative]
+  );
+
+  const updateCardholderName = useCallback(
+    (value: string) => {
+      setCardholderName(value);
+      fieldsRef.current.cardholderName = value;
+      syncToNative();
+    },
+    [syncToNative]
+  );
+
+  // Re-arm: focusing a previously-blurred field clears its blur flag so its error
+  // disappears until the user blurs again. A submit attempt overrides this gate
+  // so the user can't hide errors by tapping a field after a failed submit.
+  const markFieldFocused = useCallback((field: CardFormField) => {
+    setHasBeenFocused((prev) => (prev[field] ? prev : { ...prev, [field]: true }));
+    setHasBeenBlurred((prev) => (!prev[field] ? prev : { ...prev, [field]: false }));
+  }, []);
+
+  const markFieldBlurred = useCallback((field: CardFormField) => {
+    setHasBeenBlurred((prev) => (prev[field] ? prev : { ...prev, [field]: true }));
+  }, []);
+
+  const markSubmitAttempted = useCallback(() => {
+    setSubmitAttempted(true);
+  }, []);
+
+  const errors = useMemo(() => {
+    const visible: CardFormErrors = {};
+    for (const field of Object.keys(cardFormState.errors) as CardFormField[]) {
+      const show = submitAttempted || (hasBeenFocused[field] && hasBeenBlurred[field]);
+      if (show) visible[field] = cardFormState.errors[field];
+    }
+    return visible;
+  }, [cardFormState.errors, hasBeenFocused, hasBeenBlurred, submitAttempted]);
+
+  // Mid-typing re-format: when the detected network flips (e.g. first 4 digits
+  // resolve to AMEX), reformat what's already in the field so spacing matches the
+  // new gap pattern AND truncate if the new max is shorter (OTHER 19 → Amex 15).
+  useEffect(() => {
+    const currentDigits = fieldsRef.current.cardNumber.replace(/\D/g, '');
+    if (!currentDigits) return;
+    const maxDigits = maxPanDigits(descriptor);
+    const truncated = currentDigits.slice(0, maxDigits);
+    const reformatted = formatDigitsWithGaps(truncated, descriptor.gapPattern);
+    if (reformatted === fieldsRef.current.cardNumber) return;
+    console.log(
+      `${LOG} reformat on network change ${fmt({ before: fieldsRef.current.cardNumber, after: reformatted, gapPattern: descriptor.gapPattern, maxDigits })}`
+    );
+    fieldsRef.current.cardNumber = reformatted;
+    setCardNumber(reformatted);
+    // If truncation actually dropped digits, tell native so validation matches
+    // what the user sees.
+    if (truncated.length !== currentDigits.length) syncToNative();
+  }, [descriptor, syncToNative]);
+
+  const submit = useCallback(async () => {
+    // Flip submit-attempted before any guard returns so a failed submit reveals every error.
+    setSubmitAttempted(true);
+    if (!isReady || activeMethod !== PAYMENT_METHOD_TYPE) {
+      console.warn(`${LOG} submit: not ready ${fmt({ isReady, activeMethod })}`);
+      return;
+    }
+    if (isSubmittingRef.current) return;
+    debouncedRef.current?.flush();
+    if (!cardFormState.isValid) return;
+    isSubmittingRef.current = true;
+    setIsSubmitting(true);
+    try {
+      await providerSubmit();
+    } catch (err) {
+      console.error(`${LOG} submit failed: ${err instanceof PrimerError ? err.errorId : 'unknown'}`);
+    } finally {
+      isSubmittingRef.current = false;
+      setIsSubmitting(false);
+    }
+  }, [isReady, activeMethod, cardFormState.isValid, providerSubmit]);
+
+  const reset = useCallback(() => {
+    setCardNumber('');
+    setExpiryDate('');
+    setCVV('');
+    setCardholderName('');
+    setHasBeenFocused(INITIAL_FOCUS);
+    setHasBeenBlurred(INITIAL_FOCUS);
+    setSubmitAttempted(false);
+    setIsSubmitting(false);
+    isSubmittingRef.current = false;
+    fieldsRef.current = { cardNumber: '', expiryDate: '', cvv: '', cardholderName: '' };
+    debouncedRef.current?.cancel();
+    providerSetRawData({ cardNumber: '', expiryDate: '', cvv: '', cardholderName: '' }).catch(() => {});
+  }, [providerSetRawData]);
+
+  const value = useMemo<UseCardFormReturn>(
+    () => ({
+      cardNumber,
+      expiryDate,
+      cvv,
+      cardholderName,
+      updateCardNumber,
+      updateExpiryDate,
+      updateCVV,
+      updateCardholderName,
+      isValid: cardFormState.isValid,
+      errors,
+      markFieldFocused,
+      markFieldBlurred,
+      markSubmitAttempted,
+      submit,
+      isSubmitting,
+      submitAttempted,
+      requiredFields: cardFormState.requiredFields,
+      binData: cardFormState.binData,
+      descriptor,
+      cardNumberMaxLength: maxFormattedCardNumberLength(descriptor),
+      reset,
+    }),
+    [
+      cardNumber,
+      expiryDate,
+      cvv,
+      cardholderName,
+      updateCardNumber,
+      updateExpiryDate,
+      updateCVV,
+      updateCardholderName,
+      cardFormState.isValid,
+      cardFormState.requiredFields,
+      cardFormState.binData,
+      errors,
+      markFieldFocused,
+      markFieldBlurred,
+      markSubmitAttempted,
+      submit,
+      isSubmitting,
+      submitAttempted,
+      descriptor,
+      reset,
+    ]
+  );
+
+  return <CardFormStateContext.Provider value={value}>{children}</CardFormStateContext.Provider>;
+}
+
+export function useCardFormStateContext(): UseCardFormReturn | null {
+  return useContext(CardFormStateContext);
+}

--- a/src/Components/internal/form-state/CardFormStateProvider.tsx
+++ b/src/Components/internal/form-state/CardFormStateProvider.tsx
@@ -2,7 +2,6 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
 import { useCardNetwork } from '../../hooks/useCardNetwork';
 import { debounce, type DebouncedFunction } from '../../../utils/debounce';
-import { fmt } from '../debug';
 import { PrimerError } from '../../../models/PrimerError';
 import { formatDigitsWithGaps, maxFormattedCardNumberLength, maxPanDigits } from '../cardFormat';
 import type { CardFormField, CardFormErrors, UseCardFormReturn } from '../../types/CardFormTypes';
@@ -13,9 +12,7 @@ const PAYMENT_METHOD_TYPE = 'PAYMENT_CARD';
 
 function formatCardNumber(value: string, gapPattern: readonly number[], maxDigits: number): string {
   const digits = value.replace(/\D/g, '').slice(0, maxDigits);
-  const out = formatDigitsWithGaps(digits, gapPattern);
-  console.log(`${LOG} formatCardNumber ${fmt({ raw: value, digits, gapPattern, maxDigits, out })}`);
-  return out;
+  return formatDigitsWithGaps(digits, gapPattern);
 }
 
 function formatExpiryDate(value: string, previous: string): string {
@@ -206,9 +203,6 @@ export function CardFormStateProvider({ children }: { children: ReactNode }) {
     const truncated = currentDigits.slice(0, maxDigits);
     const reformatted = formatDigitsWithGaps(truncated, descriptor.gapPattern);
     if (reformatted === fieldsRef.current.cardNumber) return;
-    console.log(
-      `${LOG} reformat on network change ${fmt({ before: fieldsRef.current.cardNumber, after: reformatted, gapPattern: descriptor.gapPattern, maxDigits })}`
-    );
     fieldsRef.current.cardNumber = reformatted;
     setCardNumber(reformatted);
     // If truncation actually dropped digits, tell native so validation matches
@@ -219,10 +213,7 @@ export function CardFormStateProvider({ children }: { children: ReactNode }) {
   const submit = useCallback(async () => {
     // Flip submit-attempted before any guard returns so a failed submit reveals every error.
     setSubmitAttempted(true);
-    if (!isReady || activeMethod !== PAYMENT_METHOD_TYPE) {
-      console.warn(`${LOG} submit: not ready ${fmt({ isReady, activeMethod })}`);
-      return;
-    }
+    if (!isReady || activeMethod !== PAYMENT_METHOD_TYPE) return;
     if (isSubmittingRef.current) return;
     debouncedRef.current?.flush();
     if (!cardFormState.isValid) return;

--- a/src/Components/internal/form-state/index.ts
+++ b/src/Components/internal/form-state/index.ts
@@ -1,0 +1,2 @@
+export { CardFormStateProvider, useCardFormStateContext } from './CardFormStateProvider';
+export { BillingAddressFormStateProvider, useBillingAddressFormStateContext } from './BillingAddressFormStateProvider';

--- a/src/Components/internal/screens/CardFormScreen.tsx
+++ b/src/Components/internal/screens/CardFormScreen.tsx
@@ -9,7 +9,9 @@ import { CheckoutRoute } from '../navigation/types';
 import { useLocalization } from '../localization';
 import { useCheckoutFlow } from '../checkout-flow/CheckoutFlowContext';
 import { PrimerCardForm } from '../../PrimerCardForm';
+import { PrimerBillingAddressForm } from '../../PrimerBillingAddressForm';
 import { useCardForm } from '../../hooks/useCardForm';
+import { useBillingAddressForm } from '../../hooks/useBillingAddressForm';
 
 export function CardFormScreen() {
   const tokens = useTheme();
@@ -17,16 +19,22 @@ export function CardFormScreen() {
   const { pop, replace, canGoBack } = useNavigation();
   const { onCancel } = useCheckoutFlow();
   const cardForm = useCardForm();
+  const billingForm = useBillingAddressForm();
   const styles = useMemo(() => createStyles(tokens), [tokens]);
 
-  const canSubmit = cardForm.isValid && !cardForm.isSubmitting;
+  const canSubmit = cardForm.isValid && billingForm.isValid && !cardForm.isSubmitting;
 
-  // Jump to processing on Pay so the user doesn't stare at a stale form during tokenization.
-  const handlePay = useCallback(() => {
+  // Flush pending billing-address debounce before navigating so native has the full address;
+  // if anything fails before submit dispatches, the user stays on the form instead of stranded
+  // on the processing screen with nothing in flight.
+  const handlePay = useCallback(async () => {
     if (!canSubmit) return;
+    if (billingForm.sectionVisible) {
+      await billingForm.flush();
+    }
     replace(CheckoutRoute.processing);
     cardForm.submit();
-  }, [canSubmit, cardForm, replace]);
+  }, [canSubmit, cardForm, billingForm, replace]);
 
   return (
     <View style={styles.root}>
@@ -45,6 +53,13 @@ export function CardFormScreen() {
         />
         <View style={styles.body}>
           <PrimerCardForm cardForm={cardForm} autoFocus onSubmit={handlePay} />
+          {billingForm.sectionVisible && (
+            <>
+              <View style={styles.divider} />
+              <Text style={styles.sectionTitle}>{t('primer_card_form_billing_address_title')}</Text>
+              <PrimerBillingAddressForm billingForm={billingForm} />
+            </>
+          )}
           <TouchableOpacity
             onPress={handlePay}
             disabled={!canSubmit}
@@ -84,6 +99,11 @@ function createStyles(tokens: PrimerTokens) {
       paddingHorizontal: spacing.large,
       paddingTop: spacing.large,
     },
+    divider: {
+      backgroundColor: colors.border,
+      height: StyleSheet.hairlineWidth,
+      marginVertical: spacing.small,
+    },
     payButton: {
       alignItems: 'center',
       backgroundColor: colors.primary,
@@ -112,6 +132,14 @@ function createStyles(tokens: PrimerTokens) {
     scroll: {
       flexGrow: 1,
       paddingTop: spacing.large,
+    },
+    sectionTitle: {
+      color: colors.textPrimary,
+      fontFamily: typography.titleLarge.fontFamily,
+      fontSize: typography.titleLarge.fontSize,
+      fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],
+      letterSpacing: typography.titleLarge.letterSpacing,
+      lineHeight: typography.titleLarge.lineHeight,
     },
   });
   /* eslint-enable react-native/no-unused-styles */

--- a/src/Components/types/BillingAddressFormTypes.ts
+++ b/src/Components/types/BillingAddressFormTypes.ts
@@ -1,0 +1,75 @@
+import type { StyleProp, ViewStyle } from 'react-native';
+import type { PrimerAddress } from '../../models/PrimerClientSession';
+import type { BillingAddressVisibility } from '../internal/billingAddressOptions';
+
+export type BillingAddressField =
+  | 'firstName'
+  | 'lastName'
+  | 'addressLine1'
+  | 'addressLine2'
+  | 'city'
+  | 'state'
+  | 'postalCode'
+  | 'countryCode';
+
+export type BillingAddressFormErrors = Partial<Record<BillingAddressField, string>>;
+
+export interface UseBillingAddressFormOptions {
+  /** Called when the billing-address validity changes. */
+  onValidationChange?: (isValid: boolean, errors: BillingAddressFormErrors) => void;
+}
+
+export interface UseBillingAddressFormReturn {
+  firstName: string;
+  lastName: string;
+  addressLine1: string;
+  addressLine2: string;
+  city: string;
+  state: string;
+  postalCode: string;
+  countryCode: string;
+
+  updateFirstName: (value: string) => void;
+  updateLastName: (value: string) => void;
+  updateAddressLine1: (value: string) => void;
+  updateAddressLine2: (value: string) => void;
+  updateCity: (value: string) => void;
+  updateState: (value: string) => void;
+  updatePostalCode: (value: string) => void;
+  updateCountryCode: (value: string) => void;
+
+  /** Overall validity — all visible required fields are non-blank. */
+  isValid: boolean;
+  /** Per-field errors, surfaced only for touched + visible required fields. */
+  errors: BillingAddressFormErrors;
+  /** Marks a field as touched so its error can appear on blur. */
+  markFieldTouched: (field: BillingAddressField) => void;
+
+  /** Per-field visibility derived from the client session's `BILLING_ADDRESS` checkout module. */
+  visibleFields: BillingAddressVisibility;
+  /** Whether any billing field is visible. False ⇒ host should hide the entire billing block. */
+  sectionVisible: boolean;
+
+  /** Flush any pending debounced `setBillingAddress` call to the native manager. */
+  flush: () => Promise<void>;
+
+  /** Snapshot of the current fields as a `PrimerAddress`. */
+  getAddress: () => PrimerAddress;
+
+  /** Clear all fields and reset local state. */
+  reset: () => void;
+}
+
+/** Merchant-facing props for the composed `<PrimerBillingAddressForm />` component. */
+export interface PrimerBillingAddressFormProps {
+  /**
+   * The billing-address state returned by `useBillingAddressForm()`. Hoisted so the host screen
+   * can share it with a Pay button rendered outside the form and coordinate submission with
+   * other forms (e.g. the card form).
+   */
+  billingForm: UseBillingAddressFormReturn;
+  /** Optional outer container style. */
+  style?: StyleProp<ViewStyle>;
+  /** Test ID root for the form. Nested elements derive suffixed IDs. */
+  testID?: string;
+}

--- a/src/Components/types/CardFormTypes.ts
+++ b/src/Components/types/CardFormTypes.ts
@@ -70,6 +70,14 @@ export interface UseCardFormReturn {
    */
   cardNumberMaxLength: number;
 
+  /**
+   * Whether the cardholder-name field should be rendered. Driven by the
+   * `CARD_INFORMATION` checkout module (`options.cardHolderName`). Defaults to
+   * `true` when no module is present or the flag is unset; `false` only when
+   * the merchant explicitly disables the field.
+   */
+  isCardholderNameVisible: boolean;
+
   /** Clear all fields and reset local state. */
   reset: () => void;
 }

--- a/src/Components/types/PrimerCheckoutProviderTypes.ts
+++ b/src/Components/types/PrimerCheckoutProviderTypes.ts
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import type { PrimerSettings } from '../../models/PrimerSettings';
 import type { PrimerError } from '../../models/PrimerError';
-import type { PrimerClientSession } from '../../models/PrimerClientSession';
+import type { PrimerAddress, PrimerClientSession } from '../../models/PrimerClientSession';
 import type { PrimerCheckoutData } from '../../models/PrimerCheckoutData';
 import type { PrimerCheckoutPaymentMethodData } from '../../models/PrimerCheckoutPaymentMethodData';
 import type { PrimerPaymentMethodTokenData } from '../../models/PrimerPaymentMethodTokenData';
@@ -86,6 +86,11 @@ export interface PrimerCheckoutContextValue {
   setActiveMethod: (method: string | null) => void;
   /** Forward raw data to the active native manager. */
   setRawData: (data: PrimerRawData) => Promise<void>;
+  /**
+   * Forward a billing address to the active native manager. Dispatched as a separate
+   * client-session action, independent of raw card data, before submit.
+   */
+  setBillingAddress: (address: PrimerAddress) => Promise<void>;
   /** Fire the active manager's submit. First-attempt path. */
   submit: () => Promise<void>;
   /**

--- a/src/__tests__/components/hooks/useCardForm.test.tsx
+++ b/src/__tests__/components/hooks/useCardForm.test.tsx
@@ -2,6 +2,7 @@ import { createElement, type ReactNode } from 'react';
 // @ts-expect-error -- react-test-renderer has no types for React 19
 import { act, create } from 'react-test-renderer';
 import { PrimerCheckoutContext } from '../../../Components/internal/PrimerCheckoutContext';
+import { CardFormStateProvider } from '../../../Components/internal/form-state/CardFormStateProvider';
 import { useCardForm } from '../../../Components/hooks/useCardForm';
 import type { CardNetworkDescriptor } from '../../../Components/internal/cardNetwork';
 import type { PrimerCheckoutContextValue } from '../../../Components/types/PrimerCheckoutProviderTypes';
@@ -48,6 +49,7 @@ const baseContext: PrimerCheckoutContextValue = {
   vaultedError: null,
   setActiveMethod: () => {},
   setRawData: async () => {},
+  setBillingAddress: async () => {},
   submit: async () => {},
   retry: async () => {},
   clearPaymentOutcome: () => {},
@@ -63,7 +65,8 @@ function withErrors(errors: CardFormErrors): PrimerCheckoutContextValue {
 }
 
 function contextWrapper(value: PrimerCheckoutContextValue) {
-  return ({ children }: { children: ReactNode }) => createElement(PrimerCheckoutContext.Provider, { value }, children);
+  return ({ children }: { children: ReactNode }) =>
+    createElement(PrimerCheckoutContext.Provider, { value }, createElement(CardFormStateProvider, null, children));
 }
 
 function renderHook<T>(hook: () => T, Wrapper: (props: { children: ReactNode }) => ReactNode) {

--- a/src/__tests__/components/usePaymentMethods.test.ts
+++ b/src/__tests__/components/usePaymentMethods.test.ts
@@ -103,6 +103,7 @@ const readyContext: PrimerCheckoutContextValue = {
   vaultedError: null,
   setActiveMethod: () => {},
   setRawData: async () => {},
+  setBillingAddress: async () => {},
   submit: async () => {},
   retry: async () => {},
   clearPaymentOutcome: () => {},

--- a/src/__tests__/components/useVaultedPaymentMethods.test.ts
+++ b/src/__tests__/components/useVaultedPaymentMethods.test.ts
@@ -67,6 +67,7 @@ const baseContext: PrimerCheckoutContextValue = {
   vaultedError: null,
   setActiveMethod: () => {},
   setRawData: async () => {},
+  setBillingAddress: async () => {},
   submit: async () => {},
   retry: async () => {},
   clearPaymentOutcome: () => {},

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -147,13 +147,30 @@ export type {
 } from './Components';
 export { useCardForm } from './Components';
 export type { UseCardFormOptions, UseCardFormReturn, CardFormErrors, CardFormField } from './Components';
+export { useBillingAddressForm } from './Components';
+export type {
+  UseBillingAddressFormOptions,
+  UseBillingAddressFormReturn,
+  BillingAddressFormErrors,
+  BillingAddressField,
+  PrimerBillingAddressFormProps,
+} from './Components';
 export { PrimerPaymentMethodList } from './Components';
 export type { PrimerPaymentMethodListProps } from './Components';
 export { PrimerCheckoutSheet } from './Components';
 export type { PrimerCheckoutSheetProps } from './Components';
 export { PrimerCardForm } from './Components';
 export type { PrimerCardFormProps } from './Components';
-export { PrimerTextInput, CardNumberInput, ExpiryDateInput, CVVInput, CardholderNameInput } from './Components';
+export { PrimerBillingAddressForm } from './Components';
+export {
+  PrimerTextInput,
+  CardNumberInput,
+  ExpiryDateInput,
+  CVVInput,
+  CardholderNameInput,
+  CountrySelectorRow,
+} from './Components';
+export type { CountrySelectorRowProps } from './Components';
 export type {
   PrimerTextInputTheme,
   PrimerTextInputProps,

--- a/src/models/PrimerClientSession.ts
+++ b/src/models/PrimerClientSession.ts
@@ -8,7 +8,15 @@ interface IPrimerClientSession {
   lineItems?: IPrimerLineItem[];
   orderDetails?: IPrimerOrder;
   customer?: IPrimerCustomer;
+  checkoutModules?: IPrimerCheckoutModule[];
   paymentMethodOptions?: Record<string, IPrimerClientSessionPaymentMethodOption>;
+}
+
+export type PrimerCheckoutModule = IPrimerCheckoutModule;
+
+interface IPrimerCheckoutModule {
+  type: string;
+  options?: Record<string, boolean>;
 }
 
 export type PrimerClientSessionPaymentMethodOption = IPrimerClientSessionPaymentMethodOption;


### PR DESCRIPTION
## Summary

- Adds `PrimerBillingAddressForm` — controlled public component with country row + first/last name + address1/2 + postal/city + state fields.
- Adds `useBillingAddressForm` hook backed by a `BillingAddressFormStateProvider` so form state survives nav transitions.
- Refactors `useCardForm` to read from a matching `CardFormStateProvider` (same lifecycle reason).
- Exposes `setBillingAddress` on `PrimerCheckoutContextValue`; the form debounces writes through it.
- Integrates billing section into `CardFormScreen`: card form → divider → billing section → shared Pay.

## Out of scope (follow-ups)

- Country selector screen lives in ACC-7226 (stacked on this branch). The row here navigates to the route, but the screen is mounted there.
- Per-field gating via `checkoutModules` — ACC-7224 (iOS bridge) + ACC-7225 (Android bridge) first.

## Jira

[ACC-6921]

## Test plan

- [ ] `yarn typecheck` clean
- [ ] `yarn lint` exit 0
- [ ] `yarn test` — 104 tests pass (same baseline)
- [ ] iOS simulator: drop-in flow → card form shows billing section → fill fields → Pay enables when card + billing both valid
- [ ] Android emulator: same

[ACC-6921]: https://primerapi.atlassian.net/browse/ACC-6921