### PR TITLE
feat: card validation and focus-aware error display (ACC-6932)

### DIFF
--- a/src/Components/PrimerCardForm.tsx
+++ b/src/Components/PrimerCardForm.tsx
@@ -64,6 +64,7 @@ export function PrimerCardForm({
             returnKeyType="next"
             onSubmitEditing={() => nameRef.current?.focus()}
             testID={`${testID}-cvv`}
+            label={cardForm.descriptor.cvvLabel}
           />
         </View>
       </View>

--- a/src/Components/PrimerCheckoutProvider.tsx
+++ b/src/Components/PrimerCheckoutProvider.tsx
@@ -19,7 +19,7 @@ import type {
   PaymentOutcome,
   CardFormState,
 } from './types/PrimerCheckoutProviderTypes';
-import type { CardFormErrors } from './types/CardFormTypes';
+import type { CardFormErrors, CardFormField } from './types/CardFormTypes';
 import { fmt } from './internal/debug';
 import { toError } from './internal/utils/errors';
 
@@ -91,6 +91,16 @@ function buildPaymentOutcome(checkoutData: PrimerCheckoutData): PaymentOutcome {
   };
 }
 
+// Native validation errors carry a free-form `errorId` like `invalid-card-number`. The table
+// below routes each id to a `CardFormField`. First match wins. When native gains a typed
+// `inputElementType` field on the error object, swap this for a direct enum-keyed lookup.
+const ERROR_FIELD_TABLE: ReadonlyArray<{ test: (id: string) => boolean; field: CardFormField }> = [
+  { test: (id) => id.includes('card') && id.includes('number'), field: 'cardNumber' },
+  { test: (id) => id.includes('expir'), field: 'expiryDate' },
+  { test: (id) => id.includes('cvv') || id.includes('cvc'), field: 'cvv' },
+  { test: (id) => id.includes('cardholder') || id.includes('card_holder'), field: 'cardholderName' },
+];
+
 /** Map native validation errors to per-field typed errors the UI can render. */
 function parseValidationErrors(errors: PrimerError[] | undefined): CardFormErrors {
   const fieldErrors: CardFormErrors = {};
@@ -98,15 +108,8 @@ function parseValidationErrors(errors: PrimerError[] | undefined): CardFormError
   for (const error of errors) {
     const id = (error.errorId ?? '').toLowerCase();
     const description = error.description ?? error.message ?? 'Invalid';
-    if (id.includes('card') && id.includes('number')) {
-      fieldErrors.cardNumber = description;
-    } else if (id.includes('expir') || id.includes('expiry')) {
-      fieldErrors.expiryDate = description;
-    } else if (id.includes('cvv') || id.includes('cvc')) {
-      fieldErrors.cvv = description;
-    } else if (id.includes('cardholder') || id.includes('card_holder')) {
-      fieldErrors.cardholderName = description;
-    }
+    const match = ERROR_FIELD_TABLE.find((entry) => entry.test(id));
+    if (match) fieldErrors[match.field] = description;
   }
   return fieldErrors;
 }

--- a/src/Components/hooks/useCardForm.ts
+++ b/src/Components/hooks/useCardForm.ts
@@ -1,17 +1,21 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePrimerCheckout } from './usePrimerCheckout';
+import { useCardNetwork } from './useCardNetwork';
 import { debounce, type DebouncedFunction } from '../../utils/debounce';
 import { fmt } from '../internal/debug';
 import { PrimerError } from '../../models/PrimerError';
+import { formatDigitsWithGaps, maxFormattedCardNumberLength, maxPanDigits } from '../internal/cardFormat';
 import type { CardFormField, CardFormErrors, UseCardFormOptions, UseCardFormReturn } from '../types/CardFormTypes';
 
 const LOG = '[useCardForm]';
 const DEBOUNCE_MS = 150;
 const PAYMENT_METHOD_TYPE = 'PAYMENT_CARD';
 
-function formatCardNumber(value: string): string {
-  const digits = value.replace(/\D/g, '').slice(0, 16);
-  return digits.replace(/(\d{4})(?=\d)/g, '$1 ');
+function formatCardNumber(value: string, gapPattern: readonly number[], maxDigits: number): string {
+  const digits = value.replace(/\D/g, '').slice(0, maxDigits);
+  const out = formatDigitsWithGaps(digits, gapPattern);
+  console.log(`${LOG} formatCardNumber ${fmt({ raw: value, digits, gapPattern, maxDigits, out })}`);
+  return out;
 }
 
 function formatExpiryDate(value: string, previous: string): string {
@@ -25,8 +29,8 @@ function formatExpiryDate(value: string, previous: string): string {
   return digits;
 }
 
-function formatCVV(value: string): string {
-  return value.replace(/\D/g, '').slice(0, 4);
+function formatCVV(value: string, maxDigits: 3 | 4): string {
+  return value.replace(/\D/g, '').slice(0, maxDigits);
 }
 
 function stripCardNumberForNative(formatted: string): string {
@@ -66,12 +70,19 @@ export function useCardForm(options: UseCardFormOptions = {}): UseCardFormReturn
   const [cvv, setCVV] = useState('');
   const [cardholderName, setCardholderName] = useState('');
 
-  const [touched, setTouched] = useState<Record<CardFormField, boolean>>({
+  const [hasBeenFocused, setHasBeenFocused] = useState<Record<CardFormField, boolean>>({
     cardNumber: false,
     expiryDate: false,
     cvv: false,
     cardholderName: false,
   });
+  const [hasBeenBlurred, setHasBeenBlurred] = useState<Record<CardFormField, boolean>>({
+    cardNumber: false,
+    expiryDate: false,
+    cvv: false,
+    cardholderName: false,
+  });
+  const [submitAttempted, setSubmitAttempted] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const onValidationChangeRef = useRef(onValidationChange);
@@ -126,9 +137,19 @@ export function useCardForm(options: UseCardFormOptions = {}): UseCardFormReturn
     debouncedRef.current?.(data);
   }, []);
 
+  // Descriptor resolves asynchronously (see useCardNetwork). Capture via a ref so
+  // updateCardNumber's useCallback dep array doesn't re-close over descriptor each
+  // render; the ref is refreshed below whenever descriptor changes.
+  const { descriptor } = useCardNetwork();
+  const descriptorRef = useRef(descriptor);
+  descriptorRef.current = descriptor;
+
   const updateCardNumber = useCallback(
     (value: string) => {
-      const formatted = formatCardNumber(value);
+      const d = descriptorRef.current;
+      const gap = d?.gapPattern ?? [4, 8, 12];
+      const max = d ? maxPanDigits(d) : 19;
+      const formatted = formatCardNumber(value, gap, max);
       setCardNumber(formatted);
       fieldsRef.current.cardNumber = formatted;
       syncToNative();
@@ -148,7 +169,7 @@ export function useCardForm(options: UseCardFormOptions = {}): UseCardFormReturn
 
   const updateCVV = useCallback(
     (value: string) => {
-      const formatted = formatCVV(value);
+      const formatted = formatCVV(value, descriptorRef.current.cvvLength);
       setCVV(formatted);
       fieldsRef.current.cvv = formatted;
       syncToNative();
@@ -165,22 +186,55 @@ export function useCardForm(options: UseCardFormOptions = {}): UseCardFormReturn
     [syncToNative]
   );
 
-  const markFieldTouched = useCallback((field: CardFormField) => {
-    setTouched((prev) => (prev[field] ? prev : { ...prev, [field]: true }));
+  // Re-arm: focusing a previously-blurred field clears its blur flag so its error
+  // disappears until the user blurs again. A submit attempt overrides this gate
+  // so the user can't hide errors by tapping a field after a failed submit.
+  const markFieldFocused = useCallback((field: CardFormField) => {
+    setHasBeenFocused((prev) => (prev[field] ? prev : { ...prev, [field]: true }));
+    setHasBeenBlurred((prev) => (!prev[field] ? prev : { ...prev, [field]: false }));
+  }, []);
+
+  const markFieldBlurred = useCallback((field: CardFormField) => {
+    setHasBeenBlurred((prev) => (prev[field] ? prev : { ...prev, [field]: true }));
+  }, []);
+
+  const markSubmitAttempted = useCallback(() => {
+    setSubmitAttempted(true);
   }, []);
 
   const errors = useMemo(() => {
     const visible: CardFormErrors = {};
     for (const field of Object.keys(cardFormState.errors) as CardFormField[]) {
-      if (touched[field]) {
-        visible[field] = cardFormState.errors[field];
-      }
+      const show = submitAttempted || (hasBeenFocused[field] && hasBeenBlurred[field]);
+      if (show) visible[field] = cardFormState.errors[field];
     }
     return visible;
-  }, [cardFormState.errors, touched]);
+  }, [cardFormState.errors, hasBeenFocused, hasBeenBlurred, submitAttempted]);
+
+  // Mid-typing re-format: when the detected network flips (e.g. first 4 digits
+  // resolve to AMEX), reformat what's already in the field so spacing matches the
+  // new gap pattern AND truncate if the new max is shorter (OTHER 19 → Amex 15).
+  useEffect(() => {
+    const currentDigits = fieldsRef.current.cardNumber.replace(/\D/g, '');
+    if (!currentDigits) return;
+    const maxDigits = maxPanDigits(descriptor);
+    const truncated = currentDigits.slice(0, maxDigits);
+    const reformatted = formatDigitsWithGaps(truncated, descriptor.gapPattern);
+    if (reformatted === fieldsRef.current.cardNumber) return;
+    console.log(
+      `${LOG} reformat on network change ${fmt({ before: fieldsRef.current.cardNumber, after: reformatted, gapPattern: descriptor.gapPattern, maxDigits })}`
+    );
+    fieldsRef.current.cardNumber = reformatted;
+    setCardNumber(reformatted);
+    // If truncation actually dropped digits, tell native so validation matches
+    // what the user sees.
+    if (truncated.length !== currentDigits.length) syncToNative();
+  }, [descriptor, syncToNative]);
 
   const isSubmittingRef = useRef(false);
   const submit = useCallback(async () => {
+    // Flip submit-attempted before any guard returns so a failed submit reveals every error.
+    setSubmitAttempted(true);
     if (!isReady || activeMethod !== PAYMENT_METHOD_TYPE) {
       console.warn(`${LOG} submit: not ready ${fmt({ isReady, activeMethod })}`);
       return;
@@ -205,7 +259,9 @@ export function useCardForm(options: UseCardFormOptions = {}): UseCardFormReturn
     setExpiryDate('');
     setCVV('');
     setCardholderName('');
-    setTouched({ cardNumber: false, expiryDate: false, cvv: false, cardholderName: false });
+    setHasBeenFocused({ cardNumber: false, expiryDate: false, cvv: false, cardholderName: false });
+    setHasBeenBlurred({ cardNumber: false, expiryDate: false, cvv: false, cardholderName: false });
+    setSubmitAttempted(false);
     setIsSubmitting(false);
     isSubmittingRef.current = false;
     fieldsRef.current = { cardNumber: '', expiryDate: '', cvv: '', cardholderName: '' };
@@ -224,11 +280,16 @@ export function useCardForm(options: UseCardFormOptions = {}): UseCardFormReturn
     updateCardholderName,
     isValid: cardFormState.isValid,
     errors,
-    markFieldTouched,
+    markFieldFocused,
+    markFieldBlurred,
+    markSubmitAttempted,
     submit,
     isSubmitting,
+    submitAttempted,
     requiredFields: cardFormState.requiredFields,
     binData: cardFormState.binData,
+    descriptor,
+    cardNumberMaxLength: maxFormattedCardNumberLength(descriptor),
     reset,
   };
 }

--- a/src/Components/inputs/CVVInput.tsx
+++ b/src/Components/inputs/CVVInput.tsx
@@ -20,9 +20,10 @@ export const CVVInput = forwardRef<PrimerTextInputRef, CVVInputProps>(function C
       ref={ref}
       value={cardForm.cvv}
       onChangeText={cardForm.updateCVV}
-      onBlur={() => cardForm.markFieldTouched('cvv')}
+      onFocus={() => cardForm.markFieldFocused('cvv')}
+      onBlur={() => cardForm.markFieldBlurred('cvv')}
       keyboardType="number-pad"
-      maxLength={4}
+      maxLength={cardForm.descriptor.cvvLength}
       secureTextEntry
       autoComplete="cc-csc"
       label={resolvedLabel}

--- a/src/Components/inputs/CardNumberInput.tsx
+++ b/src/Components/inputs/CardNumberInput.tsx
@@ -77,9 +77,10 @@ export const CardNumberInput = forwardRef<PrimerTextInputRef, CardNumberInputPro
       ref={innerRef}
       value={cardForm.cardNumber}
       onChangeText={handleChangeText}
-      onBlur={() => cardForm.markFieldTouched('cardNumber')}
+      onFocus={() => cardForm.markFieldFocused('cardNumber')}
+      onBlur={() => cardForm.markFieldBlurred('cardNumber')}
       keyboardType="number-pad"
-      maxLength={19}
+      maxLength={cardForm.cardNumberMaxLength}
       autoComplete="cc-number"
       label={resolvedLabel}
       placeholder={resolvedPlaceholder}

--- a/src/Components/inputs/CardholderNameInput.tsx
+++ b/src/Components/inputs/CardholderNameInput.tsx
@@ -14,7 +14,8 @@ export const CardholderNameInput = forwardRef<PrimerTextInputRef, CardholderName
         ref={ref}
         value={cardForm.cardholderName}
         onChangeText={cardForm.updateCardholderName}
-        onBlur={() => cardForm.markFieldTouched('cardholderName')}
+        onFocus={() => cardForm.markFieldFocused('cardholderName')}
+        onBlur={() => cardForm.markFieldBlurred('cardholderName')}
         autoComplete="name"
         autoCapitalize="words"
         label={resolvedLabel}

--- a/src/Components/inputs/ExpiryDateInput.tsx
+++ b/src/Components/inputs/ExpiryDateInput.tsx
@@ -69,7 +69,8 @@ export const ExpiryDateInput = forwardRef<PrimerTextInputRef, ExpiryDateInputPro
       ref={innerRef}
       value={cardForm.expiryDate}
       onChangeText={handleChangeText}
-      onBlur={() => cardForm.markFieldTouched('expiryDate')}
+      onFocus={() => cardForm.markFieldFocused('expiryDate')}
+      onBlur={() => cardForm.markFieldBlurred('expiryDate')}
       keyboardType="number-pad"
       maxLength={5}
       autoComplete="cc-exp"

--- a/src/Components/internal/cardFormat.ts
+++ b/src/Components/internal/cardFormat.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure formatting + length helpers for the card-number input. Reads the network
+ * descriptor (defined in `cardNetwork.ts`) and answers questions about display
+ * length and gap placement; no I/O, no React.
+ */
+import type { CardNetworkDescriptor } from './cardNetwork';
+
+/** Max PAN digit count across all accepted lengths for the descriptor's network. */
+export function maxPanDigits(descriptor: CardNetworkDescriptor): number {
+  // Guard against native ever handing back an empty array — `Math.max()` on `[]`
+  // is `-Infinity`, which silently breaks `maxLength` on the TextInput.
+  if (descriptor.panLengths.length === 0) return 19;
+  return Math.max(...descriptor.panLengths);
+}
+
+/**
+ * Max formatted length (digits + gaps that fall within that digit count). Used
+ * as the TextInput `maxLength` so the input won't accept more characters than
+ * the longest valid formatted PAN for this network.
+ */
+export function maxFormattedCardNumberLength(descriptor: CardNetworkDescriptor): number {
+  const digits = maxPanDigits(descriptor);
+  const gapsWithin = descriptor.gapPattern.filter((g) => g > 0 && g < digits).length;
+  return digits + gapsWithin;
+}
+
+/**
+ * Insert spaces into a raw digit string according to a gap pattern.
+ * Example: `formatDigitsWithGaps("4242424242424242", [4,8,12])` → `"4242 4242 4242 4242"`.
+ */
+export function formatDigitsWithGaps(digits: string, gapPattern: readonly number[]): string {
+  if (digits.length === 0) return '';
+  let out = '';
+  for (let i = 0; i < digits.length; i++) {
+    if (i > 0 && gapPattern.includes(i)) out += ' ';
+    out += digits[i];
+  }
+  return out;
+}

--- a/src/Components/types/CardFormTypes.ts
+++ b/src/Components/types/CardFormTypes.ts
@@ -1,5 +1,6 @@
 import type { PrimerBinData } from '../../models/PrimerBinData';
 import type { PrimerInputElementType } from '../../models/PrimerInputElementType';
+import type { CardNetworkDescriptor } from '../internal/cardNetwork';
 
 export type CardFormField = 'cardNumber' | 'expiryDate' | 'cvv' | 'cardholderName';
 
@@ -31,20 +32,43 @@ export interface UseCardFormReturn {
 
   /** Overall form validity as reported by the native SDK. */
   isValid: boolean;
-  /** Per-field errors, surfaced only for touched fields. */
+  /**
+   * Per-field errors, surfaced under the rules: visible after a field has been focused
+   * and then blurred; hidden again when the user re-focuses the field; visible for all
+   * fields once `submit()` has been attempted (until `reset()`).
+   */
   errors: CardFormErrors;
-  /** Marks a field as touched so its error can appear on blur. */
-  markFieldTouched: (field: CardFormField) => void;
+  /** Mark a field focused. Re-focusing a previously-blurred field clears its error until next blur. */
+  markFieldFocused: (field: CardFormField) => void;
+  /** Mark a field blurred. The field's error becomes visible (unless re-focused). */
+  markFieldBlurred: (field: CardFormField) => void;
+  /** Force every field's errors to render. `submit()` calls this automatically; expose for custom submit buttons. */
+  markSubmitAttempted: () => void;
 
-  /** Trigger tokenization. No-op if invalid or already submitting. */
+  /** Trigger tokenization. No-op if invalid or already submitting; always flips submitAttempted. */
   submit: () => Promise<void>;
   isSubmitting: boolean;
+  /** True after the first `submit()` / `markSubmitAttempted()` call, until `reset()`. */
+  submitAttempted: boolean;
 
   /** Fields the active client session requires. */
   requiredFields: PrimerInputElementType[];
 
   /** BIN / card network data from the native SDK. */
   binData: PrimerBinData | null;
+
+  /**
+   * Traits for the detected network (PAN lengths, gap pattern, CVV length/label).
+   * Falls back to default traits when the network is unknown or BIN hasn't resolved yet.
+   */
+  descriptor: CardNetworkDescriptor;
+
+  /**
+   * Max length for the card-number TextInput (digits + gaps) derived from the
+   * current network. Use this for `maxLength` on custom card-number inputs so
+   * users can't type past the longest valid formatted PAN for their card.
+   */
+  cardNumberMaxLength: number;
 
   /** Clear all fields and reset local state. */
   reset: () => void;

--- a/src/__tests__/components/hooks/useCardForm.test.tsx
+++ b/src/__tests__/components/hooks/useCardForm.test.tsx
@@ -1,0 +1,177 @@
+import { createElement, type ReactNode } from 'react';
+// @ts-expect-error -- react-test-renderer has no types for React 19
+import { act, create } from 'react-test-renderer';
+import { PrimerCheckoutContext } from '../../../Components/internal/PrimerCheckoutContext';
+import { useCardForm } from '../../../Components/hooks/useCardForm';
+import type { CardNetworkDescriptor } from '../../../Components/internal/cardNetwork';
+import type { PrimerCheckoutContextValue } from '../../../Components/types/PrimerCheckoutProviderTypes';
+import type { CardFormErrors } from '../../../Components/types/CardFormTypes';
+
+const DEFAULT_DESCRIPTOR: CardNetworkDescriptor = {
+  id: 'OTHER',
+  displayName: 'Card',
+  panLengths: [16, 17, 18, 19],
+  gapPattern: [4, 8, 12],
+  cvvLength: 3,
+  cvvLabel: 'CVV',
+};
+
+// @ts-expect-error -- React 19 concurrent act environment
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('react-native', () => ({ useColorScheme: () => 'light' }), { virtual: true });
+
+let mockDescriptor: CardNetworkDescriptor = DEFAULT_DESCRIPTOR;
+jest.mock('../../../Components/hooks/useCardNetwork', () => ({
+  useCardNetwork: () => ({ network: mockDescriptor.id, descriptor: mockDescriptor, iconSource: null }),
+}));
+
+beforeEach(() => {
+  mockDescriptor = DEFAULT_DESCRIPTOR;
+});
+
+const baseContext: PrimerCheckoutContextValue = {
+  isReady: true,
+  error: null,
+  clientSession: null,
+  availablePaymentMethods: [],
+  paymentMethodResources: [],
+  isLoadingResources: false,
+  resourcesError: null,
+  settings: undefined,
+  paymentOutcome: null,
+  activeMethod: 'PAYMENT_CARD',
+  cardFormState: { isValid: false, errors: {}, binData: null, metadata: null, requiredFields: [] },
+  vaultedMethods: [],
+  vaultedIconUrisById: {},
+  isLoadingVaulted: false,
+  vaultedError: null,
+  setActiveMethod: () => {},
+  setRawData: async () => {},
+  submit: async () => {},
+  retry: async () => {},
+  clearPaymentOutcome: () => {},
+  payFromVault: async () => {},
+  activeVaultedMethodId: null,
+  vaultDisplayOverride: null,
+  selectVaultedMethodId: () => {},
+  requestExpandedVaultDisplay: () => {},
+};
+
+function withErrors(errors: CardFormErrors): PrimerCheckoutContextValue {
+  return { ...baseContext, cardFormState: { ...baseContext.cardFormState, errors } };
+}
+
+function contextWrapper(value: PrimerCheckoutContextValue) {
+  return ({ children }: { children: ReactNode }) => createElement(PrimerCheckoutContext.Provider, { value }, children);
+}
+
+function renderHook<T>(hook: () => T, Wrapper: (props: { children: ReactNode }) => ReactNode) {
+  const result = { current: null as unknown as T };
+  function HookComponent() {
+    result.current = hook();
+    return null;
+  }
+  let renderer: { update: (el: ReactNode) => void } | null = null;
+  act(() => {
+    renderer = create(createElement(Wrapper, { children: createElement(HookComponent) }));
+  });
+  function rerender(value: PrimerCheckoutContextValue) {
+    act(() => {
+      renderer!.update(createElement(contextWrapper(value), { children: createElement(HookComponent) }));
+    });
+  }
+  return { result, rerender };
+}
+
+const ALL_FIELD_ERRORS: CardFormErrors = {
+  cardNumber: 'Invalid card number',
+  expiryDate: 'Invalid expiry',
+  cvv: 'Invalid CVV',
+  cardholderName: 'Cardholder required',
+};
+
+describe('useCardForm — error visibility', () => {
+  it('hides errors before any field has been focused', () => {
+    const { result } = renderHook(() => useCardForm(), contextWrapper(withErrors(ALL_FIELD_ERRORS)));
+    expect(result.current.errors).toEqual({});
+  });
+
+  it('hides errors on a focused-but-not-yet-blurred field', () => {
+    const { result } = renderHook(() => useCardForm(), contextWrapper(withErrors(ALL_FIELD_ERRORS)));
+    act(() => result.current.markFieldFocused('cardNumber'));
+    expect(result.current.errors).toEqual({});
+  });
+
+  it('shows the field error after focus + blur', () => {
+    const { result } = renderHook(() => useCardForm(), contextWrapper(withErrors(ALL_FIELD_ERRORS)));
+    act(() => result.current.markFieldFocused('cardNumber'));
+    act(() => result.current.markFieldBlurred('cardNumber'));
+    expect(result.current.errors).toEqual({ cardNumber: 'Invalid card number' });
+  });
+
+  it('hides the field error when re-focused (on-focus-clear)', () => {
+    const { result } = renderHook(() => useCardForm(), contextWrapper(withErrors(ALL_FIELD_ERRORS)));
+    act(() => result.current.markFieldFocused('cvv'));
+    act(() => result.current.markFieldBlurred('cvv'));
+    expect(result.current.errors).toEqual({ cvv: 'Invalid CVV' });
+    act(() => result.current.markFieldFocused('cvv'));
+    expect(result.current.errors).toEqual({});
+  });
+
+  it('shows every error after markSubmitAttempted regardless of focus state', () => {
+    const { result } = renderHook(() => useCardForm(), contextWrapper(withErrors(ALL_FIELD_ERRORS)));
+    act(() => result.current.markSubmitAttempted());
+    expect(result.current.errors).toEqual(ALL_FIELD_ERRORS);
+    expect(result.current.submitAttempted).toBe(true);
+  });
+
+  it('keeps errors visible when user re-focuses a field after submit attempt', () => {
+    const { result } = renderHook(() => useCardForm(), contextWrapper(withErrors(ALL_FIELD_ERRORS)));
+    act(() => result.current.markSubmitAttempted());
+    act(() => result.current.markFieldFocused('cardNumber'));
+    expect(result.current.errors.cardNumber).toBe('Invalid card number');
+  });
+
+  it('reset() clears submitAttempted and focus/blur state', () => {
+    const { result } = renderHook(() => useCardForm(), contextWrapper(withErrors(ALL_FIELD_ERRORS)));
+    act(() => result.current.markSubmitAttempted());
+    act(() => result.current.reset());
+    expect(result.current.submitAttempted).toBe(false);
+    expect(result.current.errors).toEqual({});
+  });
+});
+
+describe('useCardForm — descriptor-driven dimensions', () => {
+  it('cardNumberMaxLength tracks descriptor (default 22 = 19 digits + 3 gaps within)', () => {
+    const { result } = renderHook(() => useCardForm(), contextWrapper(baseContext));
+    expect(result.current.cardNumberMaxLength).toBe(22);
+  });
+
+  it('cardNumberMaxLength shrinks for Amex (15 digits + 2 gaps = 17)', () => {
+    mockDescriptor = {
+      id: 'AMEX',
+      displayName: 'American Express',
+      panLengths: [15],
+      gapPattern: [4, 10],
+      cvvLength: 4,
+      cvvLabel: 'CID',
+    };
+    const { result } = renderHook(() => useCardForm(), contextWrapper(baseContext));
+    expect(result.current.cardNumberMaxLength).toBe(17);
+  });
+
+  it('descriptor.cvvLength on Amex is 4', () => {
+    mockDescriptor = {
+      id: 'AMEX',
+      displayName: 'American Express',
+      panLengths: [15],
+      gapPattern: [4, 10],
+      cvvLength: 4,
+      cvvLabel: 'CID',
+    };
+    const { result } = renderHook(() => useCardForm(), contextWrapper(baseContext));
+    expect(result.current.descriptor.cvvLength).toBe(4);
+    expect(result.current.descriptor.cvvLabel).toBe('CID');
+  });
+});


### PR DESCRIPTION
## Summary

- Card form reads `gapPattern` / `cardNumberMaxLength` / `cvvLabel` / `cvvLength` from the network descriptor — replaces hardcoded `19` / `4` / `"CVV"` defaults
- Mid-typing reformat when the detected network flips: typing Visa then changing the BIN to Amex truncates from 16 digits to 15 and re-spaces from `4-4-4-4` to `4-6-5`
- CVV `maxLength` follows the network — 3 for Visa / Mastercard, 4 for Amex / Diners; CVV label follows native-reported `cvvLabel` (CVV / CVC / CID / CVN / CVE / CVP2)
- Field errors hide until a field has been blurred at least once. Re-focusing a previously-blurred field clears its error until the next blur. `submit()` (or `markSubmitAttempted()`) reveals every field's errors at once and overrides the focus-clear gate until `reset()`
- `parseValidationErrors` in `PrimerCheckoutProvider` is now a declarative `ERROR_FIELD_TABLE` instead of a nested `if`-ladder. Will switch to enum-keyed lookup once native errors carry `inputElementType`

## API change

`cardForm.markFieldTouched(field)` is replaced by `markFieldFocused(field)` + `markFieldBlurred(field)`. Adds `markSubmitAttempted()` and `submitAttempted: boolean` on the hook return. Internal-only API; no external consumers.

## Stacked on

#352 ([ACC-6915]). Auto-rebases to `ov/feat/components` once #352 lands.

## Jira

[ACC-6932]

## Test plan

- [x] \`yarn typecheck\` — clean
- [x] \`yarn lint\` — clean
- [x] \`yarn test\` — 137/137 passing (10 new in \`useCardForm.test.tsx\`)
- [x] iOS manual: Visa / Mastercard / Amex / Diners → gap pattern + length adapt; CVV 3 vs 4; CVV label CVV / CID
- [x] iOS manual: errors hidden until blur; re-focus clears; submit reveals all four at once
- [x] Android manual: same

[ACC-6915]: https://primerapi.atlassian.net/browse/ACC-6915
[ACC-6932]: https://primerapi.atlassian.net/browse/ACC-6932