### PR TITLE
fix(android): read system dark mode for darkModeColors

### DIFF
--- a/android/src/main/java/com/primerioreactnative/datamodels/PrimerSettingsRN.kt
+++ b/android/src/main/java/com/primerioreactnative/datamodels/PrimerSettingsRN.kt
@@ -1,6 +1,7 @@
 package com.primerioreactnative.datamodels
 
 import android.content.Context
+import android.content.res.Configuration
 import com.primerioreactnative.extensions.toLocale
 import com.primerioreactnative.extensions.toPrimerDebugOptions
 import com.primerioreactnative.extensions.toPrimerPaymentMethodOptions
@@ -62,8 +63,10 @@ data class PrimerThemeRN(
     val colors: ColorThemeRN? = null,
     val darkModeColors: ColorThemeRN? = null,
 ) {
-    fun toPrimerTheme(): PrimerTheme {
-        val isDarkMode = false
+    fun toPrimerTheme(context: Context): PrimerTheme {
+        val isDarkMode =
+            (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
+                Configuration.UI_MODE_NIGHT_YES
 
         return PrimerTheme.buildWithDynamicValues(
             isDarkMode = isDarkMode,
@@ -206,7 +209,7 @@ fun PrimerSettingsRN.toPrimerSettings(context: Context) =
         paymentHandling = paymentHandling,
         locale = localeData.toLocale(),
         paymentMethodOptions = paymentMethodOptions.toPrimerPaymentMethodOptions(context),
-        uiOptions = uiOptions.toPrimerUIOptions(),
+        uiOptions = uiOptions.toPrimerUIOptions(context),
         debugOptions = debugOptions.toPrimerDebugOptions(),
         clientSessionCachingEnabled = clientSessionCachingEnabled,
         apiVersion = when (apiVersion) {

--- a/android/src/main/java/com/primerioreactnative/extensions/PrimerUIOptionsRN.kt
+++ b/android/src/main/java/com/primerioreactnative/extensions/PrimerUIOptionsRN.kt
@@ -1,11 +1,12 @@
 package com.primerioreactnative.extensions
 
+import android.content.Context
 import com.primerioreactnative.datamodels.PrimerUIOptionsRN
 import io.primer.android.data.settings.DismissalMechanism
 import io.primer.android.ui.settings.PrimerUIOptions
 
 @OptIn(kotlin.ExperimentalStdlibApi::class)
-internal fun PrimerUIOptionsRN.toPrimerUIOptions() =
+internal fun PrimerUIOptionsRN.toPrimerUIOptions(context: Context) =
     PrimerUIOptions(
         isInitScreenEnabled,
         isSuccessScreenEnabled,
@@ -19,6 +20,6 @@ internal fun PrimerUIOptionsRN.toPrimerUIOptions() =
                 }
             }
         }.toList().takeIf { it.isNotEmpty() } ?: listOf(DismissalMechanism.GESTURES),
-        theme.toPrimerTheme(),
+        theme.toPrimerTheme(context),
         cardFormUIOptions.toPrimerCardFormUIOptions(),
     )


### PR DESCRIPTION
Fixes Bug 1 from [ESC-974](https://primerapi.atlassian.net/browse/ESC-974).

`PrimerThemeRN.toPrimerTheme()` previously hardcoded `val isDarkMode = false`, so `darkModeColors` was silently ignored on Android. The bridge now reads `Configuration.UI_MODE_NIGHT_MASK` from a threaded `Context` and applies `darkModeColors` when the device is in dark mode — matching the existing iOS behaviour (`UITraitCollection.current.userInterfaceStyle`).

No public API change. `Context` is threaded internally through `toPrimerUIOptions` / `toPrimerTheme`.

### Coordination

Bugs 2 and 3 are fixed in [primer-sdk-android#1253](https://github.com/primer-io/primer-sdk-android/pull/1253). Once that releases, this branch needs one more commit bumping `android/build.gradle`'s `io.primer:android` pin to the new version before merging, so Dabble gets all three fixes together.

### Testing

Verified end-to-end against the example app on a Pixel 9 emulator and iPhone 17 simulator, four scenarios (custom/default × light/dark). All Dabble-reported bugs now visibly fixed on Android; no regression on iOS or Android light mode.

[ESC-974]: https://primerapi.atlassian.net/browse/ESC-974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ