### PR TITLE
chore: add CHANGELOG.md following Keep a Changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to `@primer-io/react-native` are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]


### PR DESCRIPTION
## Summary

- Engineering standard **014 — Package versioning** requires every package to ship a `CHANGELOG.md` in Keep a Changelog format.
- This repo currently has no `CHANGELOG.md`. The standards check flagged: `package.json: CHANGELOG.md not found in package root or docs/`.
- Adds a scaffold with the standard `# Changelog` header, a Keep a Changelog / SemVer reference paragraph, and an empty `[Unreleased]` section.

> Historical release notes were intentionally **not** backfilled here — they can be reconstructed separately from GitHub releases if/when we want a full history. This PR is purely about satisfying the standard.

## Test plan

- [x] Ran `primer-standards --repo-type rn-sdk` against this repo — `014_package_versioning [typescript]` ✅ now passes (was previously failing)