### PR TITLE
feat: add PrimerAcceptedCardNetworks chip row above card number (ACC-7158)

### DIFF
--- a/android/src/main/java/com/primerioreactnative/components/manager/asset/PrimerRNHeadlessUniversalCheckoutAssetManager.kt
+++ b/android/src/main/java/com/primerioreactnative/components/manager/asset/PrimerRNHeadlessUniversalCheckoutAssetManager.kt
@@ -22,6 +22,7 @@ import com.primerioreactnative.datamodels.ErrorTypeRN
 import com.primerioreactnative.utils.errorTo
 import com.primerioreactnative.utils.toWritableMap
 import io.primer.android.components.SdkUninitializedException
+import io.primer.android.components.bridge.clientsession.ComponentsClientSessionBridge
 import io.primer.android.components.ui.assets.PrimerHeadlessUniversalCheckoutAssetsManager
 import io.primer.android.components.ui.assets.PrimerPaymentMethodAsset
 import io.primer.android.components.ui.assets.PrimerPaymentMethodNativeView
@@ -102,6 +103,25 @@ internal class PrimerRNHeadlessUniversalCheckoutAssetManager(
                 } catch (e: Exception) {
                     promise.reject(ErrorTypeRN.NativeBridgeFailed.errorId, e.message, e)
                 }
+        }
+    }
+
+    @ReactMethod
+    fun getOrderedAllowedCardNetworks(promise: Promise) {
+        try {
+            val networks = ComponentsClientSessionBridge.create().getOrderedAllowedCardNetworks()
+            val map = Arguments.createMap()
+            if (networks == null) {
+                map.putNull("networks")
+            } else {
+                val array = Arguments.createArray()
+                networks.forEach { array.pushString(it) }
+                map.putArray("networks", array)
+            }
+            promise.resolve(map)
+        } catch (e: Exception) {
+            val exception = ErrorTypeRN.NativeBridgeFailed errorTo e.message.orEmpty()
+            promise.reject(exception.errorId, exception.description, e)
         }
     }
 

--- a/ios/Sources/Headless Universal Checkout/Managers/Assets Manager/RNTAssetsManager.m
+++ b/ios/Sources/Headless Universal Checkout/Managers/Assets Manager/RNTAssetsManager.m
@@ -18,6 +18,9 @@ RCT_EXTERN_METHOD(getCardNetworkImage:(NSString *)cardNetworkStr
                       resolver:(RCTPromiseResolveBlock)resolver
                       rejecter:(RCTPromiseRejectBlock)rejecter)
 
+RCT_EXTERN_METHOD(getOrderedAllowedCardNetworks:(RCTPromiseResolveBlock)resolver
+                      rejecter:(RCTPromiseRejectBlock)rejecter)
+
 RCT_EXTERN_METHOD(getPaymentMethodAsset:(NSString *)paymentMethodType
                       resolver:(RCTPromiseResolveBlock)resolver
                       rejecter:(RCTPromiseRejectBlock)rejecter)

--- a/ios/Sources/Headless Universal Checkout/Managers/Assets Manager/RNTAssetsManager.swift
+++ b/ios/Sources/Headless Universal Checkout/Managers/Assets Manager/RNTAssetsManager.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import PrimerSDK
+@_spi(PrimerInternal) import PrimerSDK
 import React
 
 // swiftlint:disable type_name
@@ -41,6 +41,22 @@ class RNTPrimerHeadlessUniversalCheckoutAssetsManager: RCTEventEmitter {
             "cvvLength": traits.cvvLength,
             "cvvLabel": traits.cvvLabel
         ])
+    }
+
+    @objc
+    func getOrderedAllowedCardNetworks(
+        _ resolver: @escaping RCTPromiseResolveBlock,
+        rejecter: @escaping RCTPromiseRejectBlock
+    ) {
+        guard #available(iOS 15.0, *) else {
+            resolver(["networks": NSNull()])
+            return
+        }
+        if let networks = ComponentsClientSessionBridge().getOrderedAllowedCardNetworks() {
+            resolver(["networks": networks])
+        } else {
+            resolver(["networks": NSNull()])
+        }
     }
 
     @objc

--- a/src/Components/PrimerAcceptedCardNetworks.tsx
+++ b/src/Components/PrimerAcceptedCardNetworks.tsx
@@ -11,22 +11,8 @@ export interface PrimerAcceptedCardNetworksProps {
   testID?: string;
 }
 
-/**
- * Brand-spec backgrounds for chips that ship with a tinted plate behind the logo.
- * Networks not listed render on the theme's surface color with the logo overlaid.
- */
-const BRAND_BACKGROUNDS: Record<string, string> = {
-  AMEX: '#116dd0',
-  DINERS_CLUB: '#254a9b',
-};
-
-/** Abbreviation text color on tinted brand chips. */
-const ON_BRAND_TEXT_COLOR = '#ffffff';
-
 const CHIP_WIDTH = 28;
 const CHIP_HEIGHT = 20;
-const CHIP_RADIUS = 2;
-const CHIP_GAP = 4;
 
 export function PrimerAcceptedCardNetworks({
   networks: propNetworks,
@@ -45,33 +31,30 @@ export function PrimerAcceptedCardNetworks({
       horizontal
       showsHorizontalScrollIndicator={false}
       style={style}
-      contentContainerStyle={styles.row}
+      contentContainerStyle={[styles.row, { gap: tokens.spacing.xsmall }]}
       testID={testID}
       accessibilityElementsHidden
     >
-      {chips.map((chip) => {
-        const brandBg = BRAND_BACKGROUNDS[chip.network];
-        const backgroundColor = brandBg ?? tokens.colors.surface;
-        return (
-          <View key={chip.network} style={[styles.chip, { backgroundColor }]} testID={`${testID}-chip-${chip.network}`}>
-            {chip.iconUri ? (
-              <Image source={{ uri: chip.iconUri }} style={styles.icon} resizeMode="contain" />
-            ) : (
-              <Text
-                style={[
-                  styles.abbreviation,
-                  {
-                    color: brandBg ? ON_BRAND_TEXT_COLOR : tokens.colors.textPrimary,
-                    fontFamily: tokens.typography.fontFamily,
-                  },
-                ]}
-              >
-                {chip.abbreviation}
-              </Text>
-            )}
-          </View>
-        );
-      })}
+      {chips.map((chip) => (
+        <View
+          key={chip.network}
+          style={[styles.chip, { backgroundColor: tokens.colors.surface, borderRadius: tokens.radii.xsmall }]}
+          testID={`${testID}-chip-${chip.network}`}
+        >
+          {chip.iconUri ? (
+            <Image source={{ uri: chip.iconUri }} style={styles.icon} resizeMode="contain" />
+          ) : (
+            <Text
+              style={[
+                styles.abbreviation,
+                { color: tokens.colors.textPrimary, fontFamily: tokens.typography.fontFamily },
+              ]}
+            >
+              {chip.abbreviation}
+            </Text>
+          )}
+        </View>
+      ))}
     </ScrollView>
   );
 }
@@ -80,11 +63,11 @@ const styles = StyleSheet.create({
   abbreviation: { fontSize: 9, fontWeight: '600' },
   chip: {
     alignItems: 'center',
-    borderRadius: CHIP_RADIUS,
     height: CHIP_HEIGHT,
     justifyContent: 'center',
+    overflow: 'hidden',
     width: CHIP_WIDTH,
   },
-  icon: { height: CHIP_HEIGHT - 4, width: CHIP_WIDTH - 4 },
-  row: { flexDirection: 'row', gap: CHIP_GAP },
+  icon: { height: CHIP_HEIGHT, width: CHIP_WIDTH },
+  row: { flexDirection: 'row' },
 });

--- a/src/Components/PrimerAcceptedCardNetworks.tsx
+++ b/src/Components/PrimerAcceptedCardNetworks.tsx
@@ -1,0 +1,90 @@
+import { Image, ScrollView, StyleSheet, Text, View } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
+import { useTheme } from './internal/theme';
+import { usePrimerCheckout } from './hooks/usePrimerCheckout';
+import { useCardNetworkIcons } from './hooks/useCardNetworkIcons';
+
+export interface PrimerAcceptedCardNetworksProps {
+  /** Merchant override for the network list. When `undefined`, falls back to context. */
+  networks?: string[];
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+/**
+ * Brand-spec backgrounds for chips that ship with a tinted plate behind the logo.
+ * Networks not listed render on the theme's surface color with the logo overlaid.
+ */
+const BRAND_BACKGROUNDS: Record<string, string> = {
+  AMEX: '#116dd0',
+  DINERS_CLUB: '#254a9b',
+};
+
+/** Abbreviation text color on tinted brand chips. */
+const ON_BRAND_TEXT_COLOR = '#ffffff';
+
+const CHIP_WIDTH = 28;
+const CHIP_HEIGHT = 20;
+const CHIP_RADIUS = 2;
+const CHIP_GAP = 4;
+
+export function PrimerAcceptedCardNetworks({
+  networks: propNetworks,
+  style,
+  testID = 'primer-accepted-card-networks',
+}: PrimerAcceptedCardNetworksProps) {
+  const tokens = useTheme();
+  const { acceptedCardNetworks } = usePrimerCheckout();
+  const resolved = propNetworks ?? acceptedCardNetworks ?? [];
+  const chips = useCardNetworkIcons(resolved);
+
+  if (chips.length === 0) return null;
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      style={style}
+      contentContainerStyle={styles.row}
+      testID={testID}
+      accessibilityElementsHidden
+    >
+      {chips.map((chip) => {
+        const brandBg = BRAND_BACKGROUNDS[chip.network];
+        const backgroundColor = brandBg ?? tokens.colors.surface;
+        return (
+          <View key={chip.network} style={[styles.chip, { backgroundColor }]} testID={`${testID}-chip-${chip.network}`}>
+            {chip.iconUri ? (
+              <Image source={{ uri: chip.iconUri }} style={styles.icon} resizeMode="contain" />
+            ) : (
+              <Text
+                style={[
+                  styles.abbreviation,
+                  {
+                    color: brandBg ? ON_BRAND_TEXT_COLOR : tokens.colors.textPrimary,
+                    fontFamily: tokens.typography.fontFamily,
+                  },
+                ]}
+              >
+                {chip.abbreviation}
+              </Text>
+            )}
+          </View>
+        );
+      })}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  abbreviation: { fontSize: 9, fontWeight: '600' },
+  chip: {
+    alignItems: 'center',
+    borderRadius: CHIP_RADIUS,
+    height: CHIP_HEIGHT,
+    justifyContent: 'center',
+    width: CHIP_WIDTH,
+  },
+  icon: { height: CHIP_HEIGHT - 4, width: CHIP_WIDTH - 4 },
+  row: { flexDirection: 'row', gap: CHIP_GAP },
+});

--- a/src/Components/PrimerCardForm.tsx
+++ b/src/Components/PrimerCardForm.tsx
@@ -6,6 +6,7 @@ import { CardNumberInput } from './inputs/CardNumberInput';
 import { ExpiryDateInput } from './inputs/ExpiryDateInput';
 import { CVVInput } from './inputs/CVVInput';
 import { CardholderNameInput } from './inputs/CardholderNameInput';
+import { PrimerAcceptedCardNetworks } from './PrimerAcceptedCardNetworks';
 import type { PrimerTextInputRef } from './types/CardInputTypes';
 import type { PrimerCardFormProps } from './types/PrimerCardFormTypes';
 
@@ -36,6 +37,7 @@ export function PrimerCardForm({
 
   return (
     <View style={[styles.container, style]} testID={testID}>
+      <PrimerAcceptedCardNetworks testID={`${testID}-accepted-networks`} />
       <CardNumberInput
         ref={cardRef}
         cardForm={cardForm}

--- a/src/Components/PrimerCheckoutProvider.tsx
+++ b/src/Components/PrimerCheckoutProvider.tsx
@@ -39,6 +39,7 @@ interface InternalState {
   isReady: boolean;
   error: PrimerError | null;
   clientSession: PrimerCheckoutContextValue['clientSession'];
+  acceptedCardNetworks: PrimerCheckoutContextValue['acceptedCardNetworks'];
   availablePaymentMethods: PrimerCheckoutContextValue['availablePaymentMethods'];
   paymentMethodResources: PrimerCheckoutContextValue['paymentMethodResources'];
   isLoadingResources: boolean;
@@ -58,6 +59,7 @@ const initialState: InternalState = {
   isReady: false,
   error: null,
   clientSession: null,
+  acceptedCardNetworks: null,
   availablePaymentMethods: [],
   paymentMethodResources: [],
   isLoadingResources: false,
@@ -433,6 +435,30 @@ export function PrimerCheckoutProvider({
     };
   }, [state.isReady, state.clientSession]);
 
+  // Fetch the merchant's accepted card networks once the session is ready, and
+  // re-fetch when the client session mutates. Cached in context so chip-row consumers
+  // read synchronously.
+  useEffect(() => {
+    if (!state.isReady) return;
+    let cancelled = false;
+    assetsManager
+      .getOrderedAllowedCardNetworks()
+      .then((networks) => {
+        if (cancelled) return;
+        setState((prev) =>
+          prev.acceptedCardNetworks === networks ? prev : { ...prev, acceptedCardNetworks: networks }
+        );
+      })
+      .catch((err) => {
+        console.warn(`${LOG} getOrderedAllowedCardNetworks failed ${fmt(err)}`);
+        if (cancelled) return;
+        setState((prev) => (prev.acceptedCardNetworks === null ? prev : { ...prev, acceptedCardNetworks: null }));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [state.isReady, state.clientSession]);
+
   // -----------------------------------------------------------------------
   // Raw-data manager lifecycle.
   //
@@ -655,6 +681,7 @@ export function PrimerCheckoutProvider({
       isReady: state.isReady,
       error: state.error,
       clientSession: state.clientSession,
+      acceptedCardNetworks: state.acceptedCardNetworks,
       availablePaymentMethods: state.availablePaymentMethods,
       paymentMethodResources: state.paymentMethodResources,
       isLoadingResources: state.isLoadingResources,

--- a/src/Components/PrimerCheckoutProvider.tsx
+++ b/src/Components/PrimerCheckoutProvider.tsx
@@ -445,9 +445,15 @@ export function PrimerCheckoutProvider({
       .getOrderedAllowedCardNetworks()
       .then((networks) => {
         if (cancelled) return;
-        setState((prev) =>
-          prev.acceptedCardNetworks === networks ? prev : { ...prev, acceptedCardNetworks: networks }
-        );
+        setState((prev) => {
+          if (networks === null) {
+            return prev.acceptedCardNetworks === null ? prev : { ...prev, acceptedCardNetworks: null };
+          }
+          const same =
+            prev.acceptedCardNetworks?.length === networks.length &&
+            prev.acceptedCardNetworks.every((n, i) => n === networks[i]);
+          return same ? prev : { ...prev, acceptedCardNetworks: networks };
+        });
       })
       .catch((err) => {
         console.warn(`${LOG} getOrderedAllowedCardNetworks failed ${fmt(err)}`);

--- a/src/Components/hooks/useCardNetwork.ts
+++ b/src/Components/hooks/useCardNetwork.ts
@@ -1,28 +1,10 @@
 import { useEffect, useState } from 'react';
 import { usePrimerCheckout } from './usePrimerCheckout';
-import PrimerHeadlessUniversalCheckoutAssetsManager from '../../HeadlessUniversalCheckout/Managers/AssetsManager';
 import { DEFAULT_DESCRIPTOR, fetchCardNetworkDescriptor } from '../internal/cardNetwork';
+import { getCardNetworkIconURL } from '../internal/cardNetworkIcons';
 import type { CardNetworkDescriptor, CardNetworkIconSource } from '../internal/cardNetwork';
 
 const LOG = '[useCardNetwork]';
-
-const assetsManager = new PrimerHeadlessUniversalCheckoutAssetsManager();
-
-// Promise cache dedupes in-flight icon requests and persists resolved URLs across hook
-// instances. Keyed on the upper-cased network id.
-const iconUrlCache = new Map<string, Promise<string>>();
-
-function getCardNetworkIconURL(network: string): Promise<string> {
-  const key = network.toUpperCase();
-  const existing = iconUrlCache.get(key);
-  if (existing) return existing;
-  const promise = assetsManager.getCardNetworkImageURL(key).catch((err) => {
-    iconUrlCache.delete(key);
-    throw err;
-  });
-  iconUrlCache.set(key, promise);
-  return promise;
-}
 
 export interface UseCardNetworkReturn {
   /** Raw network identifier as reported by native (`"VISA"`, `"AMEX"`, ...), or `null` before BIN detection. */

--- a/src/Components/hooks/useCardNetworkIcons.ts
+++ b/src/Components/hooks/useCardNetworkIcons.ts
@@ -1,0 +1,55 @@
+import { useEffect, useMemo, useState } from 'react';
+import { getCardNetworkIconURL } from '../internal/cardNetworkIcons';
+import { getNetworkAbbreviation } from '../internal/cardNetwork';
+
+export interface CardNetworkIconState {
+  /** Upper-cased network id (`"VISA"`, `"AMEX"`, …). */
+  network: string;
+  /** Resolved image URI, or `null` while loading or when the fetch failed. */
+  iconUri: string | null;
+  /** Two-letter fallback (`"VI"`, `"AM"`, …) for chips without an icon. */
+  abbreviation: string;
+}
+
+/**
+ * Batch-resolves icon URIs for an ordered list of card networks. Preserves input order,
+ * dedupes case-insensitively, and shares the module-level promise cache with
+ * `useCardNetwork`, so an icon fetched once anywhere on the page is reused everywhere.
+ */
+export function useCardNetworkIcons(networks: string[]): CardNetworkIconState[] {
+  const key = useMemo(() => [...new Set(networks.map((n) => n.toUpperCase()))].join('|'), [networks]);
+  const upperNetworks = useMemo(() => key.split('|').filter(Boolean), [key]);
+
+  const [iconUris, setIconUris] = useState<Record<string, string | null>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    upperNetworks.forEach((network) => {
+      if (network === 'OTHER') return;
+      getCardNetworkIconURL(network)
+        .then((uri) => {
+          if (!cancelled) {
+            setIconUris((prev) => (prev[network] === uri ? prev : { ...prev, [network]: uri }));
+          }
+        })
+        .catch(() => {
+          if (!cancelled) {
+            setIconUris((prev) => (network in prev ? prev : { ...prev, [network]: null }));
+          }
+        });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [key, upperNetworks]);
+
+  return useMemo(
+    () =>
+      upperNetworks.map((network) => ({
+        network,
+        iconUri: iconUris[network] ?? null,
+        abbreviation: getNetworkAbbreviation(network),
+      })),
+    [upperNetworks, iconUris]
+  );
+}

--- a/src/Components/hooks/useCardNetworkIcons.ts
+++ b/src/Components/hooks/useCardNetworkIcons.ts
@@ -1,10 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
 import { getCardNetworkIconURL } from '../internal/cardNetworkIcons';
-import { getNetworkAbbreviation } from '../internal/cardNetwork';
+import { getNetworkAbbreviation, type CardNetworkId } from '../internal/cardNetwork';
 
 export interface CardNetworkIconState {
-  /** Upper-cased network id (`"VISA"`, `"AMEX"`, …). */
-  network: string;
+  /**
+   * Upper-cased network id (`"VISA"`, `"AMEX"`, …). Native can report ids outside the
+   * known union, so we allow any string while keeping autocomplete for known ids.
+   */
+  network: CardNetworkId | (string & {});
   /** Resolved image URI, or `null` while loading or when the fetch failed. */
   iconUri: string | null;
   /** Two-letter fallback (`"VI"`, `"AM"`, …) for chips without an icon. */
@@ -25,7 +28,6 @@ export function useCardNetworkIcons(networks: string[]): CardNetworkIconState[] 
   useEffect(() => {
     let cancelled = false;
     upperNetworks.forEach((network) => {
-      if (network === 'OTHER') return;
       getCardNetworkIconURL(network)
         .then((uri) => {
           if (!cancelled) {

--- a/src/Components/index.ts
+++ b/src/Components/index.ts
@@ -33,6 +33,8 @@ export { PrimerCheckoutSheet } from './PrimerCheckoutSheet';
 export type { PrimerCheckoutSheetProps } from './PrimerCheckoutSheet';
 export { PrimerCardForm } from './PrimerCardForm';
 export type { PrimerCardFormProps } from './types/PrimerCardFormTypes';
+export { PrimerAcceptedCardNetworks } from './PrimerAcceptedCardNetworks';
+export type { PrimerAcceptedCardNetworksProps } from './PrimerAcceptedCardNetworks';
 export { PrimerTextInput, CardNumberInput, ExpiryDateInput, CVVInput, CardholderNameInput } from './inputs';
 export type {
   PrimerTextInputTheme,

--- a/src/Components/internal/cardNetworkIcons.ts
+++ b/src/Components/internal/cardNetworkIcons.ts
@@ -1,0 +1,27 @@
+import { NativeModules } from 'react-native';
+
+const { RNTPrimerHeadlessUniversalCheckoutAssetsManager } = NativeModules;
+
+const iconUrlCache = new Map<string, Promise<string>>();
+
+/**
+ * Module-level promise cache for card-network icon URIs.
+ *
+ * Calls the native module directly rather than `AssetsManager.getCardNetworkImageURL`,
+ * which logs every rejection via `console.error` (LogBox red box in dev). Unknown
+ * networks legitimately have no asset — the chip row falls back to the abbreviation —
+ * so the rejection is expected, not an error worth surfacing.
+ */
+export function getCardNetworkIconURL(network: string): Promise<string> {
+  const key = network.toUpperCase();
+  const existing = iconUrlCache.get(key);
+  if (existing) return existing;
+  const promise = RNTPrimerHeadlessUniversalCheckoutAssetsManager.getCardNetworkImage(key)
+    .then((data: { cardNetworkImageURL: string }) => data.cardNetworkImageURL)
+    .catch((err: Error) => {
+      iconUrlCache.delete(key);
+      throw err;
+    });
+  iconUrlCache.set(key, promise);
+  return promise;
+}

--- a/src/Components/internal/screens/CardFormScreen.tsx
+++ b/src/Components/internal/screens/CardFormScreen.tsx
@@ -82,7 +82,7 @@ function createStyles(tokens: PrimerTokens) {
       gap: spacing.medium,
       paddingBottom: spacing.large,
       paddingHorizontal: spacing.large,
-      paddingTop: spacing.large,
+      paddingTop: spacing.xxlarge,
     },
     payButton: {
       alignItems: 'center',

--- a/src/Components/types/PrimerCheckoutProviderTypes.ts
+++ b/src/Components/types/PrimerCheckoutProviderTypes.ts
@@ -55,6 +55,11 @@ export interface PrimerCheckoutContextValue {
   /** Init-time errors only (before `isReady`). Payment-time errors land in `paymentOutcome`. */
   error: PrimerError | null;
   clientSession: PrimerClientSession | null;
+  /**
+   * Ordered list of card networks the merchant accepts for the session, e.g. `['VISA', 'MASTERCARD']`.
+   * `null` until the bridge resolves or when the session has no `paymentMethod`; `[]` when explicitly empty.
+   */
+  acceptedCardNetworks: string[] | null;
   availablePaymentMethods: IPrimerHeadlessUniversalCheckoutPaymentMethod[];
   paymentMethodResources: Array<PrimerPaymentMethodAsset | PrimerPaymentMethodNativeView>;
   isLoadingResources: boolean;

--- a/src/HeadlessUniversalCheckout/Managers/AssetsManager.ts
+++ b/src/HeadlessUniversalCheckout/Managers/AssetsManager.ts
@@ -57,6 +57,11 @@ class PrimerHeadlessUniversalCheckoutAssetsManager {
     });
   }
 
+  async getOrderedAllowedCardNetworks(): Promise<string[] | null> {
+    const data = await RNTPrimerHeadlessUniversalCheckoutAssetsManager.getOrderedAllowedCardNetworks();
+    return (data?.networks ?? null) as string[] | null;
+  }
+
   /**
    * @deprecated Use getPaymentMethodResource instead
    */

--- a/src/__tests__/components/usePaymentMethods.test.ts
+++ b/src/__tests__/components/usePaymentMethods.test.ts
@@ -79,6 +79,7 @@ const readyContext: PrimerCheckoutContextValue = {
   isReady: true,
   error: null,
   clientSession: null,
+  acceptedCardNetworks: null,
   availablePaymentMethods: [makeMethod('PAYMENT_CARD'), makeMethod('PAYPAL'), makeMethod('APPLE_PAY')],
   paymentMethodResources: [
     makeResource('PAYMENT_CARD', 'Card'),

--- a/src/__tests__/components/useVaultedPaymentMethods.test.ts
+++ b/src/__tests__/components/useVaultedPaymentMethods.test.ts
@@ -53,6 +53,7 @@ const baseContext: PrimerCheckoutContextValue = {
   isReady: true,
   error: null,
   clientSession: null,
+  acceptedCardNetworks: null,
   availablePaymentMethods: [],
   paymentMethodResources: [],
   isLoadingResources: false,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -153,6 +153,8 @@ export { PrimerCheckoutSheet } from './Components';
 export type { PrimerCheckoutSheetProps } from './Components';
 export { PrimerCardForm } from './Components';
 export type { PrimerCardFormProps } from './Components';
+export { PrimerAcceptedCardNetworks } from './Components';
+export type { PrimerAcceptedCardNetworksProps } from './Components';
 export { PrimerTextInput, CardNumberInput, ExpiryDateInput, CVVInput, CardholderNameInput } from './Components';
 export type {
   PrimerTextInputTheme,


### PR DESCRIPTION
## Summary

- New `<PrimerAcceptedCardNetworks />` component renders a horizontal scrollable row of brand chips (28×20, 4px gap, radius 2) above the card number input
- Auto-derives from `paymentMethod.orderedAllowedCardNetworks` on the merchant's client session; `networks?: string[]` prop overrides the auto-derived list
- Empty list or missing `paymentMethod` → component renders nothing
- Unknown networks (no icon asset on native) → abbreviation fallback chip (e.g. "HI" for HIPER); brand-tinted backgrounds for AMEX and DINERS_CLUB
- Inserted as the first child of `<PrimerCardForm />`; 24px gap above (bumped `CardFormScreen` body padding) and 12px below (existing container gap)
- Extracted the icon-URL cache from `useCardNetwork.ts` into `internal/cardNetworkIcons.ts` so the new batch hook (`useCardNetworkIcons`) and the existing single-network hook share one cache and avoid duplicate native fetches
- Icon cache now calls the native module directly to avoid the LogBox red box that `AssetsManager.getCardNetworkImageURL`'s `console.error` triggers on legitimate "no asset for this network" rejections

## Stacked on

`ov/feat/components`. Depends on:
- iOS: [primer-io/primer-sdk-ios#1747](https://github.com/primer-io/primer-sdk-ios/pull/1747)
- Android: [primer-io/primer-sdk-android#1256](https://github.com/primer-io/primer-sdk-android/pull/1256)

The two native PRs add the `getOrderedAllowedCardNetworks()` accessor to the `ComponentsClientSessionBridge`. Both need to merge + ship before the RN podspec / `io.primer:components-bridge` version pins can be bumped on `ov/feat/components`. Tested locally via Podfile `:path` and `mavenLocal()` SNAPSHOT.

## iOS asset follow-up

Some networks (JCB, MIR, ELO, MAESTRO, UNIONPAY) render with the iOS SDK's generic placeholder artwork because the bundled `*-card-icon-colored` asset for those networks looks like a default card stripe rather than a brand logo. Android renders proper brand logos for the same set. Shipping as-is; iOS asset bundle is the right place to fix later.

## Jira

[ACC-7158](https://primerapi.atlassian.net/browse/ACC-7158)

## Test plan

- [x] \`yarn typecheck\` — clean
- [x] \`yarn lint\` — clean
- [x] \`yarn test\` — 139/139 passing
- [x] iOS example app (iPhone 17 sim) — chip row renders above card number with the sandbox network list
- [x] Android example app (Pixel_9 emulator) — same

[ACC-7158]: https://primerapi.atlassian.net/browse/ACC-7158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ