### PR TITLE
refactor: split PrimerCheckoutContextValue into focused controllers

### DIFF
--- a/src/Components/hooks/useCardForm.ts
+++ b/src/Components/hooks/useCardForm.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useCardFormStateContext } from '../internal/form-state/CardFormStateProvider';
-import { usePrimerCheckout } from './usePrimerCheckout';
+import { usePrimerCard } from './usePrimerCard';
 import type { UseCardFormOptions, UseCardFormReturn } from '../types/CardFormTypes';
 
 /**
@@ -21,7 +21,7 @@ export function useCardForm(options: UseCardFormOptions = {}): UseCardFormReturn
     );
   }
 
-  const { cardFormState } = usePrimerCheckout();
+  const { cardFormState } = usePrimerCard();
 
   const onValidationChangeRef = useRef(options.onValidationChange);
   onValidationChangeRef.current = options.onValidationChange;

--- a/src/Components/hooks/useCardNetwork.ts
+++ b/src/Components/hooks/useCardNetwork.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { usePrimerCheckout } from './usePrimerCheckout';
+import { usePrimerCard } from './usePrimerCard';
 import { DEFAULT_DESCRIPTOR, fetchCardNetworkDescriptor } from '../internal/cardNetwork';
 import { getCardNetworkIconURL } from '../internal/cardNetworkIcons';
 import type { CardNetworkDescriptor, CardNetworkIconSource } from '../internal/cardNetwork';
@@ -26,7 +26,7 @@ export interface UseCardNetworkReturn {
  * formatting (gaps), max length, and the CVV label; icon is a separate fetch.
  */
 export function useCardNetwork(): UseCardNetworkReturn {
-  const { cardFormState } = usePrimerCheckout();
+  const { cardFormState } = usePrimerCard();
   const network = cardFormState.binData?.preferred?.network ?? null;
 
   const [descriptor, setDescriptor] = useState<CardNetworkDescriptor>(DEFAULT_DESCRIPTOR);

--- a/src/Components/hooks/usePaymentMethods.ts
+++ b/src/Components/hooks/usePaymentMethods.ts
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useColorScheme } from 'react-native';
-import { usePrimerCheckout } from './usePrimerCheckout';
+import { usePrimerSession } from './usePrimerSession';
 import { titleCaseFromType } from '../internal/utils/formatting';
 import { toError } from '../internal/utils/errors';
 import type { PrimerClientSessionPaymentMethodOption } from '../../models/PrimerClientSession';
@@ -53,7 +53,7 @@ export function usePaymentMethods(options: UsePaymentMethodsOptions = {}): UsePa
     resourcesError,
     isReady,
     clientSession,
-  } = usePrimerCheckout();
+  } = usePrimerSession();
 
   const [selectedType, setSelectedType] = useState<string | null>(null);
   const colorScheme = useColorScheme();

--- a/src/Components/hooks/usePrimerCard.ts
+++ b/src/Components/hooks/usePrimerCard.ts
@@ -1,0 +1,18 @@
+import { useContext } from 'react';
+import { PrimerCheckoutContext } from '../internal/PrimerCheckoutContext';
+import type { PrimerCardController } from '../types/PrimerCheckoutProviderTypes';
+
+/**
+ * Read card form state and active-payment actions: `cardFormState`, `activeMethod`,
+ * `paymentOutcome`, plus `setRawData` / `setBillingAddress` / `submit` / `retry`.
+ */
+export function usePrimerCard(): PrimerCardController {
+  const context = useContext(PrimerCheckoutContext);
+  if (context === null) {
+    throw new Error(
+      'usePrimerCard must be used within a <PrimerCheckoutProvider>. ' +
+        'Wrap your component tree with <PrimerCheckoutProvider clientToken="...">.'
+    );
+  }
+  return context;
+}

--- a/src/Components/hooks/usePrimerCheckout.ts
+++ b/src/Components/hooks/usePrimerCheckout.ts
@@ -2,6 +2,12 @@ import { useContext } from 'react';
 import { PrimerCheckoutContext } from '../internal/PrimerCheckoutContext';
 import type { PrimerCheckoutContextValue } from '../types/PrimerCheckoutProviderTypes';
 
+/**
+ * @deprecated Returns the full checkout context as a single object. Prefer the focused
+ * hooks: `usePrimerSession()` for session state, `usePrimerCard()` for card-form actions,
+ * `usePrimerVault()` for vaulted-method state. This hook stays exported for backward
+ * compatibility but will be removed in a future major version.
+ */
 export function usePrimerCheckout(): PrimerCheckoutContextValue {
   const context = useContext(PrimerCheckoutContext);
   if (context === null) {

--- a/src/Components/hooks/usePrimerSession.ts
+++ b/src/Components/hooks/usePrimerSession.ts
@@ -1,0 +1,19 @@
+import { useContext } from 'react';
+import { PrimerCheckoutContext } from '../internal/PrimerCheckoutContext';
+import type { PrimerSessionController } from '../types/PrimerCheckoutProviderTypes';
+
+/**
+ * Read session-scoped state: lifecycle (`isReady`, `error`), `clientSession`,
+ * available payment methods, and the resource-loading flags. Read-only — actions
+ * for the active payment attempt live on `usePrimerCard()`.
+ */
+export function usePrimerSession(): PrimerSessionController {
+  const context = useContext(PrimerCheckoutContext);
+  if (context === null) {
+    throw new Error(
+      'usePrimerSession must be used within a <PrimerCheckoutProvider>. ' +
+        'Wrap your component tree with <PrimerCheckoutProvider clientToken="...">.'
+    );
+  }
+  return context;
+}

--- a/src/Components/hooks/usePrimerVault.ts
+++ b/src/Components/hooks/usePrimerVault.ts
@@ -1,0 +1,18 @@
+import { useContext } from 'react';
+import { PrimerCheckoutContext } from '../internal/PrimerCheckoutContext';
+import type { PrimerVaultController } from '../types/PrimerCheckoutProviderTypes';
+
+/**
+ * Read vaulted-method state and actions: `vaultedMethods`, `activeVaultedMethodId`,
+ * loading/error flags, plus `payFromVault` / `selectVaultedMethodId`.
+ */
+export function usePrimerVault(): PrimerVaultController {
+  const context = useContext(PrimerCheckoutContext);
+  if (context === null) {
+    throw new Error(
+      'usePrimerVault must be used within a <PrimerCheckoutProvider>. ' +
+        'Wrap your component tree with <PrimerCheckoutProvider clientToken="...">.'
+    );
+  }
+  return context;
+}

--- a/src/Components/hooks/useVaultedPaymentMethods.ts
+++ b/src/Components/hooks/useVaultedPaymentMethods.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { usePrimerCheckout } from './usePrimerCheckout';
+import { usePrimerVault } from './usePrimerVault';
 import type {
   UseVaultedPaymentMethodsReturn,
   VaultDisplayMode,
@@ -56,7 +56,7 @@ export function useVaultedPaymentMethods(): UseVaultedPaymentMethodsReturn {
     selectVaultedMethodId,
     requestExpandedVaultDisplay,
     deleteVaultedPaymentMethod,
-  } = usePrimerCheckout();
+  } = usePrimerVault();
 
   const vaultedMethods = useMemo<VaultedPaymentMethodItem[]>(
     () => rawMethods.map((m) => toVaultedItem(m, vaultedIconUrisById[m.id])),

--- a/src/Components/index.ts
+++ b/src/Components/index.ts
@@ -1,10 +1,16 @@
 export { PrimerCheckoutProvider } from './PrimerCheckoutProvider';
 export { usePrimerCheckout } from './hooks/usePrimerCheckout';
+export { usePrimerSession } from './hooks/usePrimerSession';
+export { usePrimerCard } from './hooks/usePrimerCard';
+export { usePrimerVault } from './hooks/usePrimerVault';
 export { useLocalization } from './internal/localization';
 export { usePaymentMethods } from './hooks/usePaymentMethods';
 export type {
   PrimerCheckoutProviderProps,
   PrimerCheckoutContextValue,
+  PrimerSessionController,
+  PrimerCardController,
+  PrimerVaultController,
   PaymentOutcome,
   CardFormState,
 } from './types/PrimerCheckoutProviderTypes';

--- a/src/Components/internal/checkout-flow/CheckoutFlow.tsx
+++ b/src/Components/internal/checkout-flow/CheckoutFlow.tsx
@@ -4,7 +4,8 @@ import { NavigationContainer } from '../navigation/NavigationContainer';
 import { useNavigation } from '../navigation/useNavigation';
 import { CheckoutRoute } from '../navigation/types';
 import type { CheckoutRoute as CheckoutRouteType } from '../navigation/types';
-import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
+import { usePrimerCard } from '../../hooks/usePrimerCard';
+import { usePrimerSession } from '../../hooks/usePrimerSession';
 import { LoadingScreen } from '../screens/LoadingScreen';
 import { MethodSelectionScreen } from '../screens/MethodSelectionScreen';
 import { CardFormScreen } from '../screens/CardFormScreen';
@@ -19,7 +20,7 @@ const SUCCESS_AUTO_DISMISS_MS = 3000;
 
 function CheckoutSuccessScreen() {
   const flow = useContext(CheckoutFlowContext);
-  const { clearPaymentOutcome } = usePrimerCheckout();
+  const { clearPaymentOutcome } = usePrimerCard();
 
   useEffect(() => {
     const t = setTimeout(() => {
@@ -44,7 +45,7 @@ const screenMap: Partial<Record<CheckoutRouteType, React.ComponentType>> = {
 };
 
 function ReadinessTransitioner() {
-  const { isReady, isLoadingResources, error } = usePrimerCheckout();
+  const { isReady, isLoadingResources, error } = usePrimerSession();
   const { replace } = useNavigation();
   const hasTransitioned = useRef(false);
 
@@ -67,7 +68,8 @@ function ReadinessTransitioner() {
 }
 
 function PaymentOutcomeTransitioner() {
-  const { paymentOutcome, settings, clearPaymentOutcome } = usePrimerCheckout();
+  const { paymentOutcome, clearPaymentOutcome } = usePrimerCard();
+  const { settings } = usePrimerSession();
   const { replace } = useNavigation();
   const flow = useContext(CheckoutFlowContext);
   const lastOutcomeRef = useRef<typeof paymentOutcome>(null);

--- a/src/Components/internal/form-state/BillingAddressFormStateProvider.tsx
+++ b/src/Components/internal/form-state/BillingAddressFormStateProvider.tsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
+import { usePrimerCard } from '../../hooks/usePrimerCard';
+import { usePrimerSession } from '../../hooks/usePrimerSession';
 import { debounce, type DebouncedFunction } from '../../../utils/debounce';
 import { fmt } from '../debug';
 import { getBillingAddressVisibility } from '../billingAddressOptions';
@@ -78,7 +79,8 @@ const BillingAddressFormStateContext = createContext<UseBillingAddressFormReturn
  * state — the country selector can write while the form screen reads.
  */
 export function BillingAddressFormStateProvider({ children }: { children: ReactNode }) {
-  const { setBillingAddress: providerSetBillingAddress, clientSession } = usePrimerCheckout();
+  const { setBillingAddress: providerSetBillingAddress } = usePrimerCard();
+  const { clientSession } = usePrimerSession();
 
   const { fields: visibleFields, sectionVisible } = useMemo(
     () => getBillingAddressVisibility(clientSession),

--- a/src/Components/internal/form-state/CardFormStateProvider.tsx
+++ b/src/Components/internal/form-state/CardFormStateProvider.tsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
+import { usePrimerCard } from '../../hooks/usePrimerCard';
+import { usePrimerSession } from '../../hooks/usePrimerSession';
 import { useCardNetwork } from '../../hooks/useCardNetwork';
 import { debounce, type DebouncedFunction } from '../../../utils/debounce';
 import { PrimerError } from '../../../models/PrimerError';
@@ -61,14 +62,8 @@ const CardFormStateContext = createContext<UseCardFormReturn | null>(null);
  * `PrimerCheckoutProvider`.
  */
 export function CardFormStateProvider({ children }: { children: ReactNode }) {
-  const {
-    isReady,
-    activeMethod,
-    cardFormState,
-    clientSession,
-    setRawData: providerSetRawData,
-    submit: providerSubmit,
-  } = usePrimerCheckout();
+  const { isReady, clientSession } = usePrimerSession();
+  const { activeMethod, cardFormState, setRawData: providerSetRawData, submit: providerSubmit } = usePrimerCard();
 
   // CARD_INFORMATION.options.cardHolderName === false hides the field. Any other shape
   // (no module, no options, or `true`) keeps it visible — matches native iOS/Android behavior.

--- a/src/Components/internal/screens/ErrorScreen.tsx
+++ b/src/Components/internal/screens/ErrorScreen.tsx
@@ -9,7 +9,8 @@ import { useStatusScreenHeight } from './useStatusScreenHeight';
 import { STATUS_SCREEN_ICON_SIZE } from './constants';
 import { useBottomSafeArea } from './useBottomSafeArea';
 import { CheckoutButton } from '../ui';
-import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
+import { usePrimerCard } from '../../hooks/usePrimerCard';
+import { usePrimerVault } from '../../hooks/usePrimerVault';
 import { fmt } from '../debug';
 import { PrimerError } from '../../../models/PrimerError';
 
@@ -23,7 +24,8 @@ export function ErrorScreen() {
   const { t } = useLocalization();
   const { replace } = useNavigation();
   const { params } = useRoute<CheckoutRoute.error>();
-  const { retry, clearPaymentOutcome, requestExpandedVaultDisplay } = usePrimerCheckout();
+  const { retry, clearPaymentOutcome } = usePrimerCard();
+  const { requestExpandedVaultDisplay } = usePrimerVault();
   const rawBottomInset = useBottomSafeArea();
   const bottomInset = Math.max(rawBottomInset, tokens.spacing.large);
   const sheetHeight = TOP_PADDING + CONTENT_HEIGHT + bottomInset;

--- a/src/Components/internal/screens/MethodSelectionScreen.tsx
+++ b/src/Components/internal/screens/MethodSelectionScreen.tsx
@@ -3,7 +3,7 @@ import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { PrimerAnalytics } from '../../analytics';
 import { usePaymentMethods } from '../../hooks/usePaymentMethods';
-import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
+import { usePrimerCard } from '../../hooks/usePrimerCard';
 import { useVaultedPaymentMethods } from '../../hooks/useVaultedPaymentMethods';
 import { PrimerPaymentMethodList } from '../../PrimerPaymentMethodList';
 import { PrimerVaultedPaymentMethod } from '../../PrimerVaultedPaymentMethod';
@@ -38,7 +38,7 @@ export function MethodSelectionScreen() {
   const { onCancel } = useCheckoutFlow();
   const { paymentMethods } = usePaymentMethods();
   const { push } = useNavigation();
-  const { setActiveMethod } = usePrimerCheckout();
+  const { setActiveMethod } = usePrimerCard();
   const {
     activeMethod: activeVaultedMethod,
     vaultDisplayMode,

--- a/src/Components/types/PrimerCheckoutProviderTypes.ts
+++ b/src/Components/types/PrimerCheckoutProviderTypes.ts
@@ -50,8 +50,8 @@ export interface CardFormState {
   requiredFields: PrimerInputElementType[];
 }
 
-export interface PrimerCheckoutContextValue {
-  // --- Session state ---
+/** Session lifecycle, available methods, and resource loading. Read-only state. */
+export interface PrimerSessionController {
   isReady: boolean;
   /** Init-time errors only (before `isReady`). Payment-time errors land in `paymentOutcome`. */
   error: PrimerError | null;
@@ -67,27 +67,16 @@ export interface PrimerCheckoutContextValue {
   resourcesError: Error | null;
   /** Settings the merchant passed to the provider. Needed for UI-option toggles. */
   settings: PrimerSettings | undefined;
+}
 
-  // --- Active payment attempt ---
+/** Card form state and active-payment actions for the in-flight attempt. */
+export interface PrimerCardController {
   /** Outcome of the most recent payment attempt; `null` before any submit. */
   paymentOutcome: PaymentOutcome | null;
   /** The payment method whose raw-data manager is currently active. */
   activeMethod: string | null;
   /** Validation + metadata state from the active raw-data manager. */
   cardFormState: CardFormState;
-
-  // --- Vaulted payment methods ---
-  vaultedMethods: PrimerVaultedPaymentMethod[];
-  /** Brand-icon URIs keyed by vaulted-method id, resolved via AssetsManager at fetch time. */
-  vaultedIconUrisById: Record<string, string | undefined>;
-  isLoadingVaulted: boolean;
-  vaultedError: Error | null;
-  /** Id of the user-selected vaulted method, or `null` to fall back to the first method. */
-  activeVaultedMethodId: string | null;
-  /** When set to `'expanded'`, force the method-selection view to show APMs even after the shopper has switched vaulted method. Cleared automatically on subsequent selection changes. */
-  vaultDisplayOverride: 'expanded' | null;
-
-  // --- Actions ---
   /** Register/deregister the active payment method. Pass `null` to tear down. */
   setActiveMethod: (method: string | null) => void;
   /**
@@ -120,6 +109,19 @@ export interface PrimerCheckoutContextValue {
   retry: () => Promise<void>;
   /** Clear the last payment outcome (e.g., when leaving the error screen). */
   clearPaymentOutcome: () => void;
+}
+
+/** Vaulted payment methods state and actions. */
+export interface PrimerVaultController {
+  vaultedMethods: PrimerVaultedPaymentMethod[];
+  /** Brand-icon URIs keyed by vaulted-method id, resolved via AssetsManager at fetch time. */
+  vaultedIconUrisById: Record<string, string | undefined>;
+  isLoadingVaulted: boolean;
+  vaultedError: Error | null;
+  /** Id of the user-selected vaulted method, or `null` to fall back to the first method. */
+  activeVaultedMethodId: string | null;
+  /** When set to `'expanded'`, force the method-selection view to show APMs even after the shopper has switched vaulted method. Cleared automatically on subsequent selection changes. */
+  vaultDisplayOverride: 'expanded' | null;
   /** Start the payment flow for a vaulted payment method by id. */
   payFromVault: (vaultedPaymentMethodId: string) => Promise<void>;
   /** Make `id` the active vaulted method. No-op if it already matches the current active id. */
@@ -133,3 +135,10 @@ export interface PrimerCheckoutContextValue {
    */
   deleteVaultedPaymentMethod: (id: string) => Promise<void>;
 }
+
+/**
+ * Aggregate context value exposed by `PrimerCheckoutProvider`. Prefer the focused
+ * `usePrimerSession` / `usePrimerCard` / `usePrimerVault` hooks for new code; this
+ * intersection is the legacy shape returned by `usePrimerCheckout`.
+ */
+export type PrimerCheckoutContextValue = PrimerSessionController & PrimerCardController & PrimerVaultController;

--- a/src/__tests__/components/usePaymentMethods.test.ts
+++ b/src/__tests__/components/usePaymentMethods.test.ts
@@ -121,7 +121,7 @@ const readyContext: PrimerCheckoutContextValue = {
 describe('usePaymentMethods', () => {
   it('throws when used outside provider', () => {
     expect(() => renderHook(() => usePaymentMethods())).toThrow(
-      'usePrimerCheckout must be used within a <PrimerCheckoutProvider>'
+      'usePrimerSession must be used within a <PrimerCheckoutProvider>'
     );
   });
 

--- a/src/__tests__/components/usePrimerCard.test.ts
+++ b/src/__tests__/components/usePrimerCard.test.ts
@@ -1,0 +1,75 @@
+import { createElement, type ReactNode } from 'react';
+// @ts-expect-error -- react-test-renderer has no types for React 19
+import { act, create } from 'react-test-renderer';
+import { PrimerCheckoutContext } from '../../Components/internal/PrimerCheckoutContext';
+import { usePrimerCard } from '../../Components/hooks/usePrimerCard';
+import type { PrimerCheckoutContextValue } from '../../Components/types/PrimerCheckoutProviderTypes';
+
+// @ts-expect-error -- React 19 concurrent act environment
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('react-native', () => ({ useColorScheme: () => 'light' }), { virtual: true });
+
+function renderHook<T>(hook: () => T, Wrapper?: (props: { children: ReactNode }) => ReactNode | null) {
+  const result = { current: null as unknown as T };
+  function HookComponent() {
+    result.current = hook();
+    return null;
+  }
+  act(() => {
+    create(Wrapper ? createElement(Wrapper, { children: createElement(HookComponent) }) : createElement(HookComponent));
+  });
+  return { result };
+}
+
+function contextWrapper(value: PrimerCheckoutContextValue) {
+  return ({ children }: { children: ReactNode }) => createElement(PrimerCheckoutContext.Provider, { value }, children);
+}
+
+const baseContext: PrimerCheckoutContextValue = {
+  isReady: true,
+  error: null,
+  clientSession: null,
+  availablePaymentMethods: [],
+  paymentMethodResources: [],
+  isLoadingResources: false,
+  resourcesError: null,
+  settings: undefined,
+  acceptedCardNetworks: null,
+  paymentOutcome: null,
+  activeMethod: 'PAYMENT_CARD',
+  cardFormState: { isValid: false, errors: {}, binData: null, metadata: null, requiredFields: [] },
+  vaultedMethods: [],
+  vaultedIconUrisById: {},
+  isLoadingVaulted: false,
+  vaultedError: null,
+  activeVaultedMethodId: null,
+  vaultDisplayOverride: null,
+  setActiveMethod: () => {},
+  setRawData: async () => {},
+  setBillingAddress: async () => {},
+  submit: async () => {},
+  retry: async () => {},
+  clearPaymentOutcome: () => {},
+  payFromVault: async () => {},
+  deleteVaultedPaymentMethod: async () => {},
+  selectVaultedMethodId: () => {},
+  requestExpandedVaultDisplay: () => {},
+};
+
+describe('usePrimerCard', () => {
+  it('throws when used outside provider', () => {
+    expect(() => renderHook(() => usePrimerCard())).toThrow(
+      'usePrimerCard must be used within a <PrimerCheckoutProvider>'
+    );
+  });
+
+  it('exposes the card slice fields and actions', () => {
+    const { result } = renderHook(() => usePrimerCard(), contextWrapper(baseContext));
+    expect(result.current.activeMethod).toBe('PAYMENT_CARD');
+    expect(result.current.cardFormState.isValid).toBe(false);
+    expect(typeof result.current.setRawData).toBe('function');
+    expect(typeof result.current.setBillingAddress).toBe('function');
+    expect(typeof result.current.submit).toBe('function');
+  });
+});

--- a/src/__tests__/components/usePrimerSession.test.ts
+++ b/src/__tests__/components/usePrimerSession.test.ts
@@ -1,0 +1,78 @@
+import { createElement, type ReactNode } from 'react';
+// @ts-expect-error -- react-test-renderer has no types for React 19
+import { act, create } from 'react-test-renderer';
+import { PrimerCheckoutContext } from '../../Components/internal/PrimerCheckoutContext';
+import { usePrimerSession } from '../../Components/hooks/usePrimerSession';
+import type { PrimerCheckoutContextValue } from '../../Components/types/PrimerCheckoutProviderTypes';
+
+// @ts-expect-error -- React 19 concurrent act environment
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('react-native', () => ({ useColorScheme: () => 'light' }), { virtual: true });
+
+function renderHook<T>(hook: () => T, Wrapper?: (props: { children: ReactNode }) => ReactNode | null) {
+  const result = { current: null as unknown as T };
+  function HookComponent() {
+    result.current = hook();
+    return null;
+  }
+  act(() => {
+    create(Wrapper ? createElement(Wrapper, { children: createElement(HookComponent) }) : createElement(HookComponent));
+  });
+  return { result };
+}
+
+function contextWrapper(value: PrimerCheckoutContextValue) {
+  return ({ children }: { children: ReactNode }) => createElement(PrimerCheckoutContext.Provider, { value }, children);
+}
+
+const baseContext: PrimerCheckoutContextValue = {
+  isReady: true,
+  error: null,
+  clientSession: null,
+  availablePaymentMethods: [],
+  paymentMethodResources: [],
+  isLoadingResources: false,
+  resourcesError: null,
+  settings: undefined,
+  acceptedCardNetworks: null,
+  paymentOutcome: null,
+  activeMethod: null,
+  cardFormState: { isValid: false, errors: {}, binData: null, metadata: null, requiredFields: [] },
+  vaultedMethods: [],
+  vaultedIconUrisById: {},
+  isLoadingVaulted: false,
+  vaultedError: null,
+  activeVaultedMethodId: null,
+  vaultDisplayOverride: null,
+  setActiveMethod: () => {},
+  setRawData: async () => {},
+  setBillingAddress: async () => {},
+  submit: async () => {},
+  retry: async () => {},
+  clearPaymentOutcome: () => {},
+  payFromVault: async () => {},
+  deleteVaultedPaymentMethod: async () => {},
+  selectVaultedMethodId: () => {},
+  requestExpandedVaultDisplay: () => {},
+};
+
+describe('usePrimerSession', () => {
+  it('throws when used outside provider', () => {
+    expect(() => renderHook(() => usePrimerSession())).toThrow(
+      'usePrimerSession must be used within a <PrimerCheckoutProvider>'
+    );
+  });
+
+  it('exposes the session slice fields', () => {
+    const ctx: PrimerCheckoutContextValue = {
+      ...baseContext,
+      isReady: true,
+      isLoadingResources: true,
+    };
+    const { result } = renderHook(() => usePrimerSession(), contextWrapper(ctx));
+    expect(result.current.isReady).toBe(true);
+    expect(result.current.isLoadingResources).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/__tests__/components/usePrimerVault.test.ts
+++ b/src/__tests__/components/usePrimerVault.test.ts
@@ -1,0 +1,76 @@
+import { createElement, type ReactNode } from 'react';
+// @ts-expect-error -- react-test-renderer has no types for React 19
+import { act, create } from 'react-test-renderer';
+import { PrimerCheckoutContext } from '../../Components/internal/PrimerCheckoutContext';
+import { usePrimerVault } from '../../Components/hooks/usePrimerVault';
+import type { PrimerCheckoutContextValue } from '../../Components/types/PrimerCheckoutProviderTypes';
+
+// @ts-expect-error -- React 19 concurrent act environment
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('react-native', () => ({ useColorScheme: () => 'light' }), { virtual: true });
+
+function renderHook<T>(hook: () => T, Wrapper?: (props: { children: ReactNode }) => ReactNode | null) {
+  const result = { current: null as unknown as T };
+  function HookComponent() {
+    result.current = hook();
+    return null;
+  }
+  act(() => {
+    create(Wrapper ? createElement(Wrapper, { children: createElement(HookComponent) }) : createElement(HookComponent));
+  });
+  return { result };
+}
+
+function contextWrapper(value: PrimerCheckoutContextValue) {
+  return ({ children }: { children: ReactNode }) => createElement(PrimerCheckoutContext.Provider, { value }, children);
+}
+
+const baseContext: PrimerCheckoutContextValue = {
+  isReady: true,
+  error: null,
+  clientSession: null,
+  availablePaymentMethods: [],
+  paymentMethodResources: [],
+  isLoadingResources: false,
+  resourcesError: null,
+  settings: undefined,
+  acceptedCardNetworks: null,
+  paymentOutcome: null,
+  activeMethod: null,
+  cardFormState: { isValid: false, errors: {}, binData: null, metadata: null, requiredFields: [] },
+  vaultedMethods: [],
+  vaultedIconUrisById: {},
+  isLoadingVaulted: true,
+  vaultedError: null,
+  activeVaultedMethodId: 'token-1',
+  vaultDisplayOverride: 'expanded',
+  setActiveMethod: () => {},
+  setRawData: async () => {},
+  setBillingAddress: async () => {},
+  submit: async () => {},
+  retry: async () => {},
+  clearPaymentOutcome: () => {},
+  payFromVault: async () => {},
+  deleteVaultedPaymentMethod: async () => {},
+  selectVaultedMethodId: () => {},
+  requestExpandedVaultDisplay: () => {},
+};
+
+describe('usePrimerVault', () => {
+  it('throws when used outside provider', () => {
+    expect(() => renderHook(() => usePrimerVault())).toThrow(
+      'usePrimerVault must be used within a <PrimerCheckoutProvider>'
+    );
+  });
+
+  it('exposes the vault slice fields and actions', () => {
+    const { result } = renderHook(() => usePrimerVault(), contextWrapper(baseContext));
+    expect(result.current.isLoadingVaulted).toBe(true);
+    expect(result.current.activeVaultedMethodId).toBe('token-1');
+    expect(result.current.vaultDisplayOverride).toBe('expanded');
+    expect(typeof result.current.payFromVault).toBe('function');
+    expect(typeof result.current.selectVaultedMethodId).toBe('function');
+    expect(typeof result.current.requestExpandedVaultDisplay).toBe('function');
+  });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -132,10 +132,16 @@ export type { NamedComponentValidatableData };
 
 export { PrimerCheckoutProvider } from './Components';
 export { usePrimerCheckout } from './Components';
+export { usePrimerSession } from './Components';
+export { usePrimerCard } from './Components';
+export { usePrimerVault } from './Components';
 export { usePaymentMethods } from './Components';
 export type {
   PrimerCheckoutProviderProps,
   PrimerCheckoutContextValue,
+  PrimerSessionController,
+  PrimerCardController,
+  PrimerVaultController,
   PaymentOutcome,
   CardFormState,
 } from './Components';


### PR DESCRIPTION
## Summary

- Adds three focused hooks (`usePrimerSession`, `usePrimerCard`, `usePrimerVault`) backed by matching controller interfaces (`PrimerSessionController`, `PrimerCardController`, `PrimerVaultController`).
- `PrimerCheckoutContextValue` is now an intersection of the three controllers — same runtime shape, no implementation changes to `PrimerCheckoutProvider`.
- `usePrimerCheckout` stays exported and is marked `@deprecated` in JSDoc. External consumers keep working.
- Internal call sites (4 hooks + 3 screens + 2 form-state providers) migrated to the focused hooks.
- Stacked on #356 (ACC-7226). Follow-up for Semir's review comment requesting smaller controllers.

## Test plan

- [ ] `yarn typecheck` clean
- [ ] `yarn lint` clean
- [ ] `yarn test` — 145/145 (3 new test files, 6 new tests)
- [ ] iOS simulator: full flow still works (init → method picker → card form → billing → pay)
- [ ] Android emulator: same