### PR TITLE
chore: bump iOS minimum deployment target to 15

### DIFF
--- a/example/ios/example_0_70_6.xcodeproj/project.pbxproj
+++ b/example/ios/example_0_70_6.xcodeproj/project.pbxproj
@@ -558,7 +558,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = example_0_70_6Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -594,7 +594,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = example_0_70_6Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -629,7 +629,7 @@
 				DEVELOPMENT_TEAM = N8UN9TR5DY;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = example_0_70_6/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -662,7 +662,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = N8UN9TR5DY;
 				INFOPLIST_FILE = example_0_70_6/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -746,7 +746,7 @@
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",
@@ -831,7 +831,7 @@
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",

--- a/example/ios/example_0_70_6/Project.swift
+++ b/example/ios/example_0_70_6/Project.swift
@@ -6,7 +6,7 @@ enum BaseSettings {
 
     static let settingsDictionary: [String: SettingValue] = [
         "DEVELOPMENT_TEAM": .string("N8UN9TR5DY"),
-        "IPHONEOS_DEPLOYMENT_TARGET": .string("11.0")
+        "IPHONEOS_DEPLOYMENT_TARGET": .string("15.1")
     ]
 }
 

--- a/ios/Sources/DataModels/PrimerThemeRN.swift
+++ b/ios/Sources/DataModels/PrimerThemeRN.swift
@@ -72,7 +72,6 @@ extension ColorThemeRN {
         )
     }
 
-    @available(iOS 13.0, *)
     var primerDarkModeTheme: ColorTheme {
         return PrimerDefaultTheme(
             text1: text?.uiColor ?? .white,

--- a/ios/Sources/Headless Universal Checkout/Managers/Payment Method Managers/RNTRawDataManager.swift
+++ b/ios/Sources/Headless Universal Checkout/Managers/Payment Method Managers/RNTRawDataManager.swift
@@ -189,15 +189,6 @@ class RNTPrimerHeadlessUniversalCheckoutRawDataManager: RCTEventEmitter {
       return
     }
 
-    guard #available(iOS 15.0, *) else {
-      let err = RNTNativeError(
-        errorId: "native-ios",
-        errorDescription: "setBillingAddress requires iOS 15.0 or later.",
-        recoverySuggestion: "Update the deployment target or run on iOS 15+.")
-      rejecter(err.rnError["errorId"]!, err.rnError["description"], err)
-      return
-    }
-
     Task {
       do {
         try await ComponentsBillingAddressBridge().setBillingAddress(billingAddress)

--- a/ios/Sources/Headless Universal Checkout/RNTPrimerHeadlessUniversalCheckout.swift
+++ b/ios/Sources/Headless Universal Checkout/RNTPrimerHeadlessUniversalCheckout.swift
@@ -269,10 +269,8 @@ extension RNTPrimerHeadlessUniversalCheckout: PrimerHeadlessUniversalCheckoutDel
       // The native SDK only fires `primerHeadlessUniversalCheckoutDidUpdateClientSession`
       // on subsequent updates, never on initial load. Read the current session via
       // `ComponentsClientSessionBridge` and synthesize the update event so JS receives
-      // the initial session at startup. iOS < 15 has no bridge access; the JS-side
-      // `onClientSessionUpdate` callback then fires only on subsequent updates.
-      if self.implementedRNCallbacks?.isOnClientSessionUpdateImplemented == true,
-         #available(iOS 15.0, *) {
+      // the initial session at startup.
+      if self.implementedRNCallbacks?.isOnClientSessionUpdateImplemented == true {
         let bridge = ComponentsClientSessionBridge()
         if let initialClientSession = bridge.getClientSession() {
           let updateCallbackName = PrimerHeadlessUniversalCheckoutEvents.onClientSessionUpdate.stringValue
@@ -556,10 +554,7 @@ extension RNTPrimerHeadlessUniversalCheckout: PrimerHeadlessUniversalCheckoutDel
         do {
           // Augment the SDK-provided `clientSession` with `checkoutModules` from the
           // bridge — these are not surfaced on the public `PrimerClientSession` type.
-          var checkoutModules: [ComponentsCheckoutModule]?
-          if #available(iOS 15.0, *) {
-            checkoutModules = ComponentsClientSessionBridge().getCheckoutModules()
-          }
+          let checkoutModules = ComponentsClientSessionBridge().getCheckoutModules()
           let payload = try Self.makeClientSessionPayload(
             clientSession: clientSession,
             checkoutModules: checkoutModules
@@ -588,7 +583,7 @@ extension RNTPrimerHeadlessUniversalCheckout: PrimerHeadlessUniversalCheckoutDel
     let json = try clientSession.toJsonObject()
     var dict = (json as? [String: Any]) ?? [:]
 
-    if #available(iOS 15.0, *), let modules = checkoutModules as? [ComponentsCheckoutModule] {
+    if let modules = checkoutModules as? [ComponentsCheckoutModule] {
       dict["checkoutModules"] = modules.map { module -> [String: Any] in
         var moduleDict: [String: Any] = ["type": module.type]
         if let options = module.options {

--- a/primer-io-react-native.podspec
+++ b/primer-io-react-native.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "13.0" }
+  s.platforms    = { :ios => "15.0" }
   s.source       = { :git => "https://github.com/primer-io/primer-sdk-react-native.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"


### PR DESCRIPTION
## Summary

- SDK podspec `s.platforms` 13.0 → 15.0 — matches the iOS APIs the bridge actually uses after dropping the iOS 15.0 availability guards below
- Example app deployment target: xcodeproj `IPHONEOS_DEPLOYMENT_TARGET` 15.6 → 15.1 and Tuist `Project.swift` 11.0 → 15.1; the Podfile was already at 15.1, which is React Native 0.81.1's declared `min_ios_version_supported`
- Drop now-obsolete `@available(iOS 13.0, *)` / `#available(iOS 15.0, *)` guards in `RNTPrimerHeadlessUniversalCheckout`, `RNTRawDataManager`, and `PrimerThemeRN`

## Stacked on

#355 (`ov/feat/ACC-6921-billing-address-form`)

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn lint` — clean
- [x] `yarn test` — 149/149 passing
- [x] iOS example app builds and launches on iPhone 17 simulator
- [x] Android example app builds and launches on Pixel 9 emulator