### PR TITLE
fix(card-form): keep Pay button above keyboard, fit sheet to content

### DIFF
--- a/src/Components/inputs/PrimerTextInput.tsx
+++ b/src/Components/inputs/PrimerTextInput.tsx
@@ -5,6 +5,10 @@ import { FIELD_HEIGHT, LINE_HEIGHT_RATIO } from './dimensions';
 import type { PrimerTextInputProps, PrimerTextInputRef, PrimerTextInputTheme } from '../types/CardInputTypes';
 import type { PrimerTokens } from '../internal/theme/types';
 
+// Shared nativeID for an empty InputAccessoryView rendered once in CheckoutSheet.
+// Suppresses iOS's auto-added Previous/Next/Done navigation toolbar above the keyboard.
+export const PRIMER_EMPTY_ACCESSORY_ID = 'primer-empty-input-accessory';
+
 function resolveTheme(tokens: PrimerTokens, override?: PrimerTextInputTheme) {
   const borderWidth = override?.borderWidth ?? tokens.borders.input;
   const focusedBorderWidth = Math.max(override?.focusedBorderWidth ?? tokens.borders.strong, borderWidth);
@@ -174,6 +178,7 @@ export const PrimerTextInput = forwardRef<PrimerTextInputRef, PrimerTextInputPro
           returnKeyType={returnKeyType}
           onSubmitEditing={onSubmitEditing}
           blurOnSubmit={returnKeyType !== 'next'}
+          inputAccessoryViewID={Platform.OS === 'ios' ? PRIMER_EMPTY_ACCESSORY_ID : undefined}
           accessibilityState={{ disabled: !editable }}
           aria-invalid={hasError}
           testID={testID ? `${testID}-input` : undefined}

--- a/src/Components/internal/checkout-sheet/CheckoutSheet.tsx
+++ b/src/Components/internal/checkout-sheet/CheckoutSheet.tsx
@@ -3,8 +3,10 @@ import type { HeightReleaseFn } from './SheetHeightContext';
 import {
   Animated,
   Easing,
+  InputAccessoryView,
   Modal,
   PanResponder,
+  Platform,
   StyleSheet,
   TouchableWithoutFeedback,
   View,
@@ -12,6 +14,7 @@ import {
 } from 'react-native';
 import { useTheme } from '../theme';
 import type { PrimerTokens } from '../theme';
+import { PRIMER_EMPTY_ACCESSORY_ID } from '../../inputs/PrimerTextInput';
 import { SheetHeightContext } from './SheetHeightContext';
 import type { SheetHeightContextValue } from './SheetHeightContext';
 import type { CheckoutSheetProps } from './types';
@@ -218,8 +221,26 @@ export function CheckoutSheet({
           <Animated.View style={[styles.backdrop, { opacity: backdropOpacity }]} />
         </TouchableWithoutFeedback>
 
+        {/*
+         * Empty InputAccessoryView shared by every PrimerTextInput via inputAccessoryViewID.
+         * Claims the accessory slot above the iOS keyboard so the system's auto Previous/Next/Done
+         * toolbar isn't shown. iOS-only — no-op on Android.
+         */}
+        {Platform.OS === 'ios' && (
+          <InputAccessoryView nativeID={PRIMER_EMPTY_ACCESSORY_ID}>
+            <View />
+          </InputAccessoryView>
+        )}
+
         <Animated.View style={[styles.sheetContainer, { transform: [{ translateY }] }]} pointerEvents="box-none">
-          <View style={styles.sheetContent}>
+          {/*
+           * `sheetContent` is constrained to the *visible* height so the inner ScrollView
+           * knows when content overflows. Without this, the sheetContainer is full-screen
+           * (absoluteFillObject) and ScrollView measures itself as full-screen too — the
+           * bottom of the content silently extends past the visible window (which is only
+           * `sheetHeight` tall after the translateY) and ScrollView never enters scroll mode.
+           */}
+          <View style={[styles.sheetContent, { height: sheetHeight }]}>
             {shouldRenderDragHandle && (
               <View style={styles.dragHandleArea} {...panResponder.panHandlers}>
                 <View style={styles.dragHandle} />
@@ -271,7 +292,6 @@ function createStyles(tokens: PrimerTokens) {
     },
     sheetContent: {
       backgroundColor: colors.background,
-      flex: 1,
     },
   });
 }

--- a/src/Components/internal/checkout-sheet/CheckoutSheet.tsx
+++ b/src/Components/internal/checkout-sheet/CheckoutSheet.tsx
@@ -221,11 +221,8 @@ export function CheckoutSheet({
           <Animated.View style={[styles.backdrop, { opacity: backdropOpacity }]} />
         </TouchableWithoutFeedback>
 
-        {/*
-         * Empty InputAccessoryView shared by every PrimerTextInput via inputAccessoryViewID.
-         * Claims the accessory slot above the iOS keyboard so the system's auto Previous/Next/Done
-         * toolbar isn't shown. iOS-only — no-op on Android.
-         */}
+        {/* Empty accessory claimed by every PrimerTextInput to suppress iOS's auto
+          Previous/Next/Done toolbar. See PRIMER_EMPTY_ACCESSORY_ID. */}
         {Platform.OS === 'ios' && (
           <InputAccessoryView nativeID={PRIMER_EMPTY_ACCESSORY_ID}>
             <View />
@@ -233,13 +230,9 @@ export function CheckoutSheet({
         )}
 
         <Animated.View style={[styles.sheetContainer, { transform: [{ translateY }] }]} pointerEvents="box-none">
-          {/*
-           * `sheetContent` is constrained to the *visible* height so the inner ScrollView
-           * knows when content overflows. Without this, the sheetContainer is full-screen
-           * (absoluteFillObject) and ScrollView measures itself as full-screen too — the
-           * bottom of the content silently extends past the visible window (which is only
-           * `sheetHeight` tall after the translateY) and ScrollView never enters scroll mode.
-           */}
+          {/* Constrained to the visible height so the inner ScrollView can detect overflow.
+            The container is full-screen (absoluteFillObject), so without this the ScrollView
+            measures itself as full-screen and never enters scroll mode. */}
           <View style={[styles.sheetContent, { height: sheetHeight }]}>
             {shouldRenderDragHandle && (
               <View style={styles.dragHandleArea} {...panResponder.panHandlers}>
@@ -286,11 +279,8 @@ function createStyles(tokens: PrimerTokens) {
     },
     sheetContainer: {
       ...StyleSheet.absoluteFillObject,
-      // Same color as sheetContent so the area below sheetContent (within the
-      // full-screen container) doesn't flash dark when sheetContent's height shrinks
-      // instantly while translateY animates to catch up — e.g. when the keyboard
-      // hides and the sheet resizes from "fits form + keyboard" back down to
-      // "fits form only".
+      // Matches sheetContent so no dark gap flashes below it: on resize sheetContent's
+      // height shrinks instantly while translateY animates to catch up.
       backgroundColor: colors.background,
       borderTopLeftRadius: radii.large,
       borderTopRightRadius: radii.large,

--- a/src/Components/internal/checkout-sheet/CheckoutSheet.tsx
+++ b/src/Components/internal/checkout-sheet/CheckoutSheet.tsx
@@ -286,6 +286,12 @@ function createStyles(tokens: PrimerTokens) {
     },
     sheetContainer: {
       ...StyleSheet.absoluteFillObject,
+      // Same color as sheetContent so the area below sheetContent (within the
+      // full-screen container) doesn't flash dark when sheetContent's height shrinks
+      // instantly while translateY animates to catch up — e.g. when the keyboard
+      // hides and the sheet resizes from "fits form + keyboard" back down to
+      // "fits form only".
+      backgroundColor: colors.background,
       borderTopLeftRadius: radii.large,
       borderTopRightRadius: radii.large,
       overflow: 'hidden',

--- a/src/Components/internal/screens/CardFormScreen.tsx
+++ b/src/Components/internal/screens/CardFormScreen.tsx
@@ -25,12 +25,9 @@ import { useSheetHeight } from '../checkout-sheet';
 import { useBottomSafeArea } from './useBottomSafeArea';
 import { useKeyboardPadding } from './useKeyboardPadding';
 
-// CheckoutSheet.dragHandleArea = paddingTop(12) + handle(4) + paddingBottom(4) = 20.
-// Included when sizing the sheet to fit content so it accounts for the chrome above
-// CardFormScreen's content.
+// CheckoutSheet drag-handle chrome above our content: paddingTop(12) + handle(4) + paddingBottom(4).
 const DRAG_HANDLE_AREA = 20;
-// Cap on the dynamic sheet height — matches CheckoutSheet's DEFAULT_HEIGHT_RATIO so
-// the sheet never exceeds 92% of the screen.
+// Matches CheckoutSheet's DEFAULT_HEIGHT_RATIO — the sheet never exceeds 92% of the screen.
 const MAX_SHEET_HEIGHT_RATIO = 0.92;
 
 export function CardFormScreen() {
@@ -45,21 +42,14 @@ export function CardFormScreen() {
   const { height: screenHeight } = useWindowDimensions();
   const { requestHeight } = useSheetHeight();
 
-  // Measure header / scroll-content / footer so the sheet can shrink to fit content
-  // when the form is short (e.g. only the card section is visible). The default 92%
-  // height is the *cap*; without the request the sheet would be too tall and leave an
-  // empty gap between the last field and the Pay button.
+  // Measured so the sheet can shrink to fit a short form (92% height is just the cap).
   const [headerHeight, setHeaderHeight] = useState(0);
   const [scrollContentHeight, setScrollContentHeight] = useState(0);
   const [footerHeight, setFooterHeight] = useState(0);
 
-  // Re-request on every state — including with the keyboard open — because the form
-  // auto-focuses on mount, the keyboard pops before content measures, and we still
-  // want a snug fit. `scrollContentHeight` already inflates by `keyboardPadding` (via
-  // the ScrollView's paddingBottom below), so the sheet grows by the keyboard's
-  // height; sheet-bottom sits at screen-bottom, the keyboard covers the bottom
-  // `keyboardPadding`, and the visible portion above the keyboard exactly fits
-  // header + form + Pay button.
+  // Re-request even with the keyboard open: `scrollContentHeight` already inflates by
+  // `keyboardPadding`, so the sheet grows by the keyboard height and the portion above
+  // the keyboard fits header + form + Pay button exactly.
   useEffect(() => {
     if (headerHeight === 0 || scrollContentHeight === 0 || footerHeight === 0) return;
     const desired = DRAG_HANDLE_AREA + headerHeight + scrollContentHeight + footerHeight;
@@ -96,8 +86,6 @@ export function CardFormScreen() {
     cardForm.submit();
   }, [canSubmit, cardForm, billingForm, replace]);
 
-  // Fixed-footer layout: header pinned to top, footer pinned to bottom, only
-  // the form fields scroll in between.
   return (
     <View style={styles.root}>
       <View onLayout={(e) => setHeaderHeight(e.nativeEvent.layout.height)}>
@@ -125,12 +113,8 @@ export function CardFormScreen() {
           </>
         )}
       </ScrollView>
-      {/*
-       * Opaque overlay covering exactly the keyboard's area. Sits between the ScrollView
-       * and the footer in tree order so it draws over any form fields that would otherwise
-       * be visible through the (slightly translucent) iOS keyboard. Position:absolute so
-       * it doesn't affect flex layout — only the footer's translateY moves the Pay button.
-       */}
+      {/* Opaque overlay over the keyboard's area so form fields don't show through the
+        translucent iOS keyboard. Absolute so it stays out of the flex layout. */}
       {keyboardPadding > 0 && (
         <View pointerEvents="none" style={[styles.keyboardOverlay, { height: keyboardPadding }]} />
       )}

--- a/src/Components/internal/screens/CardFormScreen.tsx
+++ b/src/Components/internal/screens/CardFormScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { ActivityIndicator, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Platform, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import type { TextStyle } from 'react-native';
 import { useTheme } from '../theme';
 import type { PrimerTokens } from '../theme';
@@ -12,6 +12,8 @@ import { PrimerCardForm } from '../../PrimerCardForm';
 import { PrimerBillingAddressForm } from '../../PrimerBillingAddressForm';
 import { useCardForm } from '../../hooks/useCardForm';
 import { useBillingAddressForm } from '../../hooks/useBillingAddressForm';
+import { useBottomSafeArea } from './useBottomSafeArea';
+import { useKeyboardPadding } from './useKeyboardPadding';
 
 export function CardFormScreen() {
   const tokens = useTheme();
@@ -20,6 +22,21 @@ export function CardFormScreen() {
   const { onCancel } = useCheckoutFlow();
   const cardForm = useCardForm();
   const billingForm = useBillingAddressForm();
+  const bottomInset = useBottomSafeArea();
+  const keyboardPadding = useKeyboardPadding();
+  // Gap between the Pay button and the keyboard / system inset:
+  //   - keyboard closed: max(bottomInset, spacing.large) — clears home indicator / gesture pill.
+  //   - iOS keyboard open: spacing.large (16). `keyboard.endCoordinates.height` already
+  //     includes the home-indicator area, so the bottom inset isn't needed.
+  //   - Android keyboard open: spacing.large + bottomInset (≈40). Android reports just the
+  //     keys area in `endCoordinates.height`, NOT the suggestion / GIF strip above. The extra
+  //     `bottomInset` compensates so the visible gap matches iOS.
+  const footerPaddingBottom =
+    keyboardPadding === 0
+      ? Math.max(bottomInset, tokens.spacing.large)
+      : Platform.OS === 'ios'
+        ? tokens.spacing.large
+        : tokens.spacing.large + Math.max(bottomInset, tokens.spacing.large);
   const styles = useMemo(() => createStyles(tokens), [tokens]);
 
   const canSubmit = cardForm.isValid && billingForm.isValid && !cardForm.isSubmitting;
@@ -36,55 +53,74 @@ export function CardFormScreen() {
     cardForm.submit();
   }, [canSubmit, cardForm, billingForm, replace]);
 
+  // Fixed-footer layout: header pinned to top, footer pinned to bottom, only
+  // the form fields scroll in between.
   return (
     <View style={styles.root}>
+      <NavigationHeader
+        title={t('primer_card_form_title')}
+        showBackButton={canGoBack}
+        backLabel={t('primer_common_back')}
+        onBackPress={pop}
+        rightAction={{ label: t('primer_common_button_cancel'), onPress: onCancel }}
+      />
       <ScrollView
-        contentContainerStyle={styles.scroll}
+        style={styles.scrollView}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: tokens.spacing.medium + keyboardPadding }]}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
-        automaticallyAdjustKeyboardInsets
       >
-        <NavigationHeader
-          title={t('primer_card_form_title')}
-          showBackButton={canGoBack}
-          backLabel={t('primer_common_back')}
-          onBackPress={pop}
-          rightAction={{ label: t('primer_common_button_cancel'), onPress: onCancel }}
-        />
-        <View style={styles.body}>
-          <PrimerCardForm cardForm={cardForm} autoFocus onSubmit={handlePay} />
-          {billingForm.sectionVisible && (
-            <>
-              <View style={styles.divider} />
-              <Text style={styles.sectionTitle}>{t('primer_card_form_billing_address_title')}</Text>
-              <PrimerBillingAddressForm billingForm={billingForm} />
-            </>
-          )}
-          <TouchableOpacity
-            onPress={handlePay}
-            disabled={!canSubmit}
-            activeOpacity={0.7}
-            style={[styles.payButton, !canSubmit && styles.payButtonDisabled]}
-            accessibilityRole="button"
-            accessibilityState={{ disabled: !canSubmit, busy: cardForm.isSubmitting }}
-            accessibilityLabel={t('accessibility_card_form_submit_label')}
-            accessibilityHint={
-              cardForm.isSubmitting
-                ? t('accessibility_card_form_submit_loading')
-                : canSubmit
-                  ? t('accessibility_card_form_submit_hint')
-                  : t('accessibility_card_form_submit_disabled')
-            }
-            testID="primer-card-form-submit"
-          >
-            {cardForm.isSubmitting ? (
-              <ActivityIndicator color={tokens.colors.background} />
-            ) : (
-              <Text style={styles.payButtonText}>{t('primer_common_button_pay')}</Text>
-            )}
-          </TouchableOpacity>
-        </View>
+        <PrimerCardForm cardForm={cardForm} autoFocus onSubmit={handlePay} />
+        {billingForm.sectionVisible && (
+          <>
+            <View style={styles.divider} />
+            <Text style={styles.sectionTitle}>{t('primer_card_form_billing_address_title')}</Text>
+            <PrimerBillingAddressForm billingForm={billingForm} />
+          </>
+        )}
       </ScrollView>
+      {/*
+       * Opaque overlay covering exactly the keyboard's area. Sits between the ScrollView
+       * and the footer in tree order so it draws over any form fields that would otherwise
+       * be visible through the (slightly translucent) iOS keyboard. Position:absolute so
+       * it doesn't affect flex layout — only the footer's translateY moves the Pay button.
+       */}
+      {keyboardPadding > 0 && (
+        <View pointerEvents="none" style={[styles.keyboardOverlay, { height: keyboardPadding }]} />
+      )}
+      <View
+        style={[
+          styles.footer,
+          {
+            paddingBottom: footerPaddingBottom,
+            transform: [{ translateY: -keyboardPadding }],
+          },
+        ]}
+      >
+        <TouchableOpacity
+          onPress={handlePay}
+          disabled={!canSubmit}
+          activeOpacity={0.7}
+          style={[styles.payButton, !canSubmit && styles.payButtonDisabled]}
+          accessibilityRole="button"
+          accessibilityState={{ disabled: !canSubmit, busy: cardForm.isSubmitting }}
+          accessibilityLabel={t('accessibility_card_form_submit_label')}
+          accessibilityHint={
+            cardForm.isSubmitting
+              ? t('accessibility_card_form_submit_loading')
+              : canSubmit
+                ? t('accessibility_card_form_submit_hint')
+                : t('accessibility_card_form_submit_disabled')
+          }
+          testID="primer-card-form-submit"
+        >
+          {cardForm.isSubmitting ? (
+            <ActivityIndicator color={tokens.colors.background} />
+          ) : (
+            <Text style={styles.payButtonText}>{t('primer_common_button_pay')}</Text>
+          )}
+        </TouchableOpacity>
+      </View>
     </View>
   );
 }
@@ -93,23 +129,28 @@ function createStyles(tokens: PrimerTokens) {
   const { colors, radii, spacing, typography } = tokens;
   /* eslint-disable react-native/no-unused-styles */
   return StyleSheet.create({
-    body: {
-      gap: spacing.medium,
-      paddingBottom: spacing.large,
-      paddingHorizontal: spacing.large,
-      paddingTop: spacing.xxlarge,
-    },
     divider: {
       backgroundColor: colors.border,
       height: StyleSheet.hairlineWidth,
       marginVertical: spacing.small,
+    },
+    footer: {
+      backgroundColor: colors.background,
+      paddingHorizontal: spacing.large,
+      paddingTop: spacing.small,
+    },
+    keyboardOverlay: {
+      backgroundColor: colors.background,
+      bottom: 0,
+      left: 0,
+      position: 'absolute',
+      right: 0,
     },
     payButton: {
       alignItems: 'center',
       backgroundColor: colors.primary,
       borderRadius: radii.medium,
       justifyContent: 'center',
-      marginTop: spacing.small,
       minHeight: 44,
       padding: spacing.medium,
       width: '100%',
@@ -129,9 +170,14 @@ function createStyles(tokens: PrimerTokens) {
     root: {
       flex: 1,
     },
-    scroll: {
-      flexGrow: 1,
+    scrollContent: {
+      gap: spacing.medium,
+      paddingBottom: spacing.medium,
+      paddingHorizontal: spacing.large,
       paddingTop: spacing.large,
+    },
+    scrollView: {
+      flex: 1,
     },
     sectionTitle: {
       color: colors.textPrimary,

--- a/src/Components/internal/screens/CardFormScreen.tsx
+++ b/src/Components/internal/screens/CardFormScreen.tsx
@@ -1,5 +1,14 @@
-import { useCallback, useMemo } from 'react';
-import { ActivityIndicator, Platform, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  useWindowDimensions,
+} from 'react-native';
 import type { TextStyle } from 'react-native';
 import { useTheme } from '../theme';
 import type { PrimerTokens } from '../theme';
@@ -12,8 +21,17 @@ import { PrimerCardForm } from '../../PrimerCardForm';
 import { PrimerBillingAddressForm } from '../../PrimerBillingAddressForm';
 import { useCardForm } from '../../hooks/useCardForm';
 import { useBillingAddressForm } from '../../hooks/useBillingAddressForm';
+import { useSheetHeight } from '../checkout-sheet';
 import { useBottomSafeArea } from './useBottomSafeArea';
 import { useKeyboardPadding } from './useKeyboardPadding';
+
+// CheckoutSheet.dragHandleArea = paddingTop(12) + handle(4) + paddingBottom(4) = 20.
+// Included when sizing the sheet to fit content so it accounts for the chrome above
+// CardFormScreen's content.
+const DRAG_HANDLE_AREA = 20;
+// Cap on the dynamic sheet height — matches CheckoutSheet's DEFAULT_HEIGHT_RATIO so
+// the sheet never exceeds 92% of the screen.
+const MAX_SHEET_HEIGHT_RATIO = 0.92;
 
 export function CardFormScreen() {
   const tokens = useTheme();
@@ -24,6 +42,31 @@ export function CardFormScreen() {
   const billingForm = useBillingAddressForm();
   const bottomInset = useBottomSafeArea();
   const keyboardPadding = useKeyboardPadding();
+  const { height: screenHeight } = useWindowDimensions();
+  const { requestHeight } = useSheetHeight();
+
+  // Measure header / scroll-content / footer so the sheet can shrink to fit content
+  // when the form is short (e.g. only the card section is visible). The default 92%
+  // height is the *cap*; without the request the sheet would be too tall and leave an
+  // empty gap between the last field and the Pay button.
+  const [headerHeight, setHeaderHeight] = useState(0);
+  const [scrollContentHeight, setScrollContentHeight] = useState(0);
+  const [footerHeight, setFooterHeight] = useState(0);
+
+  // Re-request on every state — including with the keyboard open — because the form
+  // auto-focuses on mount, the keyboard pops before content measures, and we still
+  // want a snug fit. `scrollContentHeight` already inflates by `keyboardPadding` (via
+  // the ScrollView's paddingBottom below), so the sheet grows by the keyboard's
+  // height; sheet-bottom sits at screen-bottom, the keyboard covers the bottom
+  // `keyboardPadding`, and the visible portion above the keyboard exactly fits
+  // header + form + Pay button.
+  useEffect(() => {
+    if (headerHeight === 0 || scrollContentHeight === 0 || footerHeight === 0) return;
+    const desired = DRAG_HANDLE_AREA + headerHeight + scrollContentHeight + footerHeight;
+    const max = screenHeight * MAX_SHEET_HEIGHT_RATIO;
+    const release = requestHeight(Math.min(desired, max));
+    return release;
+  }, [headerHeight, scrollContentHeight, footerHeight, screenHeight, requestHeight]);
   // Gap between the Pay button and the keyboard / system inset:
   //   - keyboard closed: max(bottomInset, spacing.large) — clears home indicator / gesture pill.
   //   - iOS keyboard open: spacing.large (16). `keyboard.endCoordinates.height` already
@@ -57,18 +100,21 @@ export function CardFormScreen() {
   // the form fields scroll in between.
   return (
     <View style={styles.root}>
-      <NavigationHeader
-        title={t('primer_card_form_title')}
-        showBackButton={canGoBack}
-        backLabel={t('primer_common_back')}
-        onBackPress={pop}
-        rightAction={{ label: t('primer_common_button_cancel'), onPress: onCancel }}
-      />
+      <View onLayout={(e) => setHeaderHeight(e.nativeEvent.layout.height)}>
+        <NavigationHeader
+          title={t('primer_card_form_title')}
+          showBackButton={canGoBack}
+          backLabel={t('primer_common_back')}
+          onBackPress={pop}
+          rightAction={{ label: t('primer_common_button_cancel'), onPress: onCancel }}
+        />
+      </View>
       <ScrollView
         style={styles.scrollView}
         contentContainerStyle={[styles.scrollContent, { paddingBottom: tokens.spacing.medium + keyboardPadding }]}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
+        onContentSizeChange={(_, h) => setScrollContentHeight(h)}
       >
         <PrimerCardForm cardForm={cardForm} autoFocus onSubmit={handlePay} />
         {billingForm.sectionVisible && (
@@ -89,6 +135,7 @@ export function CardFormScreen() {
         <View pointerEvents="none" style={[styles.keyboardOverlay, { height: keyboardPadding }]} />
       )}
       <View
+        onLayout={(e) => setFooterHeight(e.nativeEvent.layout.height)}
         style={[
           styles.footer,
           {

--- a/src/Components/internal/screens/useKeyboardPadding.ts
+++ b/src/Components/internal/screens/useKeyboardPadding.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import { Keyboard, Platform } from 'react-native';
+
+// Returns the keyboard height in dp, or 0 when the keyboard is hidden.
+// Used by screens to drive a manual `paddingBottom` instead of relying on
+// `KeyboardAvoidingView`, which is unreliable inside a Modal on Android and
+// gets thrown off on iOS when an empty InputAccessoryView is present.
+export function useKeyboardPadding(): number {
+  const [height, setHeight] = useState(0);
+
+  useEffect(() => {
+    const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+    const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+
+    const showSub = Keyboard.addListener(showEvent, (e) => {
+      setHeight(e.endCoordinates.height);
+    });
+    const hideSub = Keyboard.addListener(hideEvent, () => {
+      setHeight(0);
+    });
+
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
+
+  return height;
+}


### PR DESCRIPTION
## Summary

- Pay button pinned above the keyboard via a fixed footer with `translateY(-keyboardPadding)`; iOS keyboard's auto Previous/Next/Done bar suppressed via a shared empty `InputAccessoryView`.
- Sheet height fits header + form + Pay + keyboard (capped at 92%), so there's no gap between the last field and the Pay button when the keyboard is up.
- `sheetContainer` painted with the sheet background so the area below `sheetContent` doesn't flash dark while `translateY` animates between heights (e.g. keyboard hides → sheet shrinks).
- Opaque overlay between the ScrollView and footer covers the keyboard area, so form fields don't bleed through iOS's translucent keyboard while scrolling.

## Stacked on

#355 (`ov/feat/ACC-6921-billing-address-form`)

## Test plan

- [ ] `yarn typecheck` clean
- [ ] `yarn lint` exit 0
- [ ] `yarn test` passes
- [ ] iOS: card-only form, Pay button sits just above the keyboard with no gap; dismiss keyboard → sheet shrinks with no dark flash
- [ ] iOS: with billing address visible, form scrolls behind the keyboard, Pay button stays pinned above
- [ ] Android: same as above