### PR TITLE
feat: add Apple Pay support to Checkout Components (ACC-6923)

### DIFF
--- a/example/ios/example_0_70_6/example_0_70_6.entitlements
+++ b/example/ios/example_0_70_6/example_0_70_6.entitlements
@@ -4,8 +4,7 @@
 <dict>
 	<key>com.apple.developer.in-app-payments</key>
 	<array>
-		<string>merchant.checkout.team</string>
-		<string>merchant.dx.team</string>
+		<string>merchant.acceptance.team</string>
 	</array>
 </dict>
 </plist>

--- a/example/src/screens/CheckoutComponentsListScreen.tsx
+++ b/example/src/screens/CheckoutComponentsListScreen.tsx
@@ -76,7 +76,7 @@ export function CheckoutComponentsListScreen() {
 
   if (appPaymentParameters.merchantName) {
     settings.paymentMethodOptions!.applePayOptions = {
-      merchantIdentifier: 'merchant.checkout.team',
+      merchantIdentifier: 'merchant.acceptance.team',
       merchantName: appPaymentParameters.merchantName,
       isCaptureBillingAddressEnabled: false,
     };

--- a/example/src/screens/CheckoutScreen.tsx
+++ b/example/src/screens/CheckoutScreen.tsx
@@ -265,7 +265,7 @@ const CheckoutScreen = (props: any) => {
         recurringPaymentDescription: 'Recurring payment description',
       },
       applePayOptions: {
-        merchantIdentifier: 'merchant.checkout.team',
+        merchantIdentifier: 'merchant.acceptance.team',
         merchantName: appPaymentParameters.merchantName || 'Merchant name',
         isCaptureBillingAddressEnabled: true,
         showApplePayForUnsupportedDevice: true,

--- a/example/src/screens/HeadlessCheckoutScreen.tsx
+++ b/example/src/screens/HeadlessCheckoutScreen.tsx
@@ -296,7 +296,7 @@ export const HeadlessCheckoutScreen = (props: any) => {
   if (appPaymentParameters.merchantName) {
     //@ts-ignore
     settings.paymentMethodOptions.applePayOptions = {
-      merchantIdentifier: 'merchant.checkout.team',
+      merchantIdentifier: 'merchant.acceptance.team',
       merchantName: appPaymentParameters.merchantName,
     };
   }

--- a/src/Components/PrimerCheckoutProvider.tsx
+++ b/src/Components/PrimerCheckoutProvider.tsx
@@ -15,6 +15,7 @@ import { ThemeContext } from './internal/theme/ThemeContext';
 import { defaultDarkTokens, defaultLightTokens } from './internal/theme/tokens';
 import { toError } from './internal/utils/errors';
 import { GOOGLE_PAY, isGooglePaySupported } from './internal/googlePay';
+import { APPLE_PAY, isApplePaySupported } from './internal/applePay';
 
 import type { PrimerSettings } from '../models/PrimerSettings';
 import type { PrimerCheckoutData } from '../models/PrimerCheckoutData';
@@ -738,6 +739,15 @@ export function PrimerCheckoutProvider({
         'google-pay-unavailable',
         'google-pay-unavailable',
         'Google Pay is not available on this device.',
+        undefined,
+        undefined
+      );
+    }
+    if (paymentMethodType === APPLE_PAY && !isApplePaySupported(stateRef.current.availablePaymentMethods)) {
+      throw new PrimerError(
+        'apple-pay-unavailable',
+        'apple-pay-unavailable',
+        'Apple Pay is not available on this device.',
         undefined,
         undefined
       );

--- a/src/Components/hooks/usePrimerPaymentMethod.ts
+++ b/src/Components/hooks/usePrimerPaymentMethod.ts
@@ -3,6 +3,7 @@ import { Platform } from 'react-native';
 
 import { usePrimerCheckout } from './usePrimerCheckout';
 import { GOOGLE_PAY, isGooglePaySupported } from '../internal/googlePay';
+import { APPLE_PAY, isApplePaySupported } from '../internal/applePay';
 import { routeMethodSelection } from '../internal/routeMethodSelection';
 
 import type { PaymentMethodAvailabilityError, UsePrimerPaymentMethodReturn } from '../types/PrimerPaymentMethodTypes';
@@ -34,7 +35,7 @@ export function usePrimerPaymentMethod(type: string): UsePrimerPaymentMethodRetu
 
   return useMemo<UsePrimerPaymentMethodReturn>(() => {
     if (kind === 'nativeUi') {
-      const isAvailable = type === GOOGLE_PAY ? isGooglePaySupported(availablePaymentMethods) : isPresent;
+      const isAvailable = isNativeUiAvailable(type, availablePaymentMethods);
       return {
         kind: 'nativeUi',
         isAvailable,
@@ -64,11 +65,27 @@ export function usePrimerPaymentMethod(type: string): UsePrimerPaymentMethodRetu
   ]);
 }
 
+/** Native-UI availability — platform-gated for Google/Apple Pay (single-platform), list-membership otherwise. */
+function isNativeUiAvailable(type: string, methods: ReadonlyArray<{ paymentMethodType: string }>): boolean {
+  if (type === GOOGLE_PAY) {
+    return isGooglePaySupported(methods);
+  }
+  if (type === APPLE_PAY) {
+    return isApplePaySupported(methods);
+  }
+  return methods.some((m) => m.paymentMethodType === type);
+}
+
 function availabilityError(type: string): PaymentMethodAvailabilityError {
   if (type === GOOGLE_PAY) {
     return Platform.OS === 'android'
       ? { code: 'NOT_READY', message: 'Google Pay is not ready on this device.' }
       : { code: 'PLATFORM_NOT_SUPPORTED', message: 'Google Pay is only available on Android.' };
+  }
+  if (type === APPLE_PAY) {
+    return Platform.OS === 'ios'
+      ? { code: 'NOT_AVAILABLE', message: 'Apple Pay is not available on this device.' }
+      : { code: 'PLATFORM_NOT_SUPPORTED', message: 'Apple Pay is only available on iOS.' };
   }
   return { code: 'NOT_AVAILABLE', message: `${type} is not available. Ensure it is configured for this session.` };
 }

--- a/src/Components/internal/applePay.ts
+++ b/src/Components/internal/applePay.ts
@@ -1,0 +1,12 @@
+import { Platform } from 'react-native';
+
+/** The Apple Pay payment-method type. */
+export const APPLE_PAY = 'APPLE_PAY';
+
+/**
+ * Whether Apple Pay can be presented. The iOS SDK already filters APPLE_PAY out of the
+ * available-methods list when the device can't present it, so list membership on iOS is
+ * sufficient; gate on Platform.OS so merchants need no platform branch in their render path.
+ */
+export const isApplePaySupported = (methods: ReadonlyArray<{ paymentMethodType: string }>): boolean =>
+  Platform.OS === 'ios' && methods.some((m) => m.paymentMethodType === APPLE_PAY);

--- a/src/__tests__/components/usePrimerPaymentMethod.test.tsx
+++ b/src/__tests__/components/usePrimerPaymentMethod.test.tsx
@@ -249,4 +249,43 @@ describe('usePrimerPaymentMethod', () => {
       expect(nativeUiManager.showPaymentMethod).not.toHaveBeenCalled();
     });
   });
+
+  describe('Apple Pay (nativeUi) on iOS', () => {
+    it('isAvailable is true when APPLE_PAY is among available methods', async () => {
+      rnMock.Platform.OS = 'ios';
+      const captures = await mountWithMethods([{ paymentMethodType: 'APPLE_PAY' }], 'APPLE_PAY');
+      const last = asNativeUi(captures[captures.length - 1]!);
+      expect(last.isAvailable).toBe(true);
+      expect(last.availabilityError).toBeNull();
+    });
+
+    it('start configures and shows APPLE_PAY when available', async () => {
+      rnMock.Platform.OS = 'ios';
+      const captures = await mountWithMethods([{ paymentMethodType: 'APPLE_PAY' }], 'APPLE_PAY');
+      const ctrl = asNativeUi(captures[captures.length - 1]!);
+      await act(async () => {
+        await ctrl.start();
+      });
+      expect(nativeUiManager.configure).toHaveBeenCalledWith('APPLE_PAY');
+      expect(nativeUiManager.showPaymentMethod).toHaveBeenCalledWith('CHECKOUT');
+    });
+  });
+
+  describe('Apple Pay (nativeUi) on Android', () => {
+    // The Android SDK can list APPLE_PAY, so the method routes to `nativeUi`, but the RN layer's
+    // own iOS-only guard reports it unavailable regardless of SDK behaviour.
+    it('reports unavailable with PLATFORM_NOT_SUPPORTED even when the SDK lists it', async () => {
+      const captures = await mountWithMethods([{ paymentMethodType: 'APPLE_PAY' }], 'APPLE_PAY');
+      const last = asNativeUi(captures[captures.length - 1]!);
+      expect(last.isAvailable).toBe(false);
+      expect(last.availabilityError?.code).toBe('PLATFORM_NOT_SUPPORTED');
+    });
+
+    it('start rejects and makes no native call on Android', async () => {
+      const captures = await mountWithMethods([{ paymentMethodType: 'APPLE_PAY' }], 'APPLE_PAY');
+      const ctrl = asNativeUi(captures[captures.length - 1]!);
+      await expect(ctrl.start()).rejects.toBeTruthy();
+      expect(nativeUiManager.showPaymentMethod).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Apple Pay flows through the generic **`usePrimerPaymentMethod('APPLE_PAY')`** — no bespoke `useApplePay` hook. It rides the same `nativeUi` path as Google Pay: the prebuilt method row (or your own button) calls `start()`, the native Headless SDK presents the sheet, and the outcome arrives on the shared `paymentOutcome`. Second step of the APM hook unification (after Google Pay, #376).

- Apple Pay is iOS-only: `isAvailable` is `false` on Android even if the SDK lists `APPLE_PAY` — the one Apple-Pay-specific rule, in `internal/applePay.ts` (mirror of `internal/googlePay.ts`).
- `startNativeUI('APPLE_PAY')` rejects when unavailable (e.g. on Android), so a custom layout that skips the `isAvailable` check still fails safely instead of making a native call.
- No native-bridge or provider re-architecture — the existing Headless `NATIVE_UI` path already drives Apple Pay. Apple Pay renders as a standard method row (no dedicated native button).

## Breaking change

`useApplePay` and the `ApplePayController` / `ApplePayAvailabilityError` types are removed — use `usePrimerPaymentMethod('APPLE_PAY')` and narrow on `kind: 'nativeUi'`.

## Base

`ov/feat/ACC-6923-google-pay-component` (#376) — the generic-hook foundation.

## Jira

[ACC-6923](https://primerapi.atlassian.net/browse/ACC-6923)

## Test plan

- [x] `yarn typecheck` / `yarn lint` — clean
- [x] `yarn jest` — green; new `usePrimerPaymentMethod` Apple Pay cases cover iOS availability + start, and the Android guard (unavailable + `start()` rejects, no native call)
- [x] Manual iOS — Apple Pay in the method list → native sheet → `onCheckoutComplete` (sandbox payment succeeded)
