### PR TITLE
fix(types): replace any with precise types in RNPrimer and utils

### DIFF
--- a/src/RNPrimer.ts
+++ b/src/RNPrimer.ts
@@ -1,4 +1,5 @@
 import type { PrimerSettings } from './models/PrimerSettings';
+import type { PrimerImplementedRNCallbacks } from './models/PrimerImplementedRNCallbacks';
 import type { EventSubscription } from 'react-native';
 import NativePrimer from './specs/NativePrimer';
 
@@ -222,7 +223,7 @@ const RNPrimer = {
   },
 
   // HELPERS
-  setImplementedRNCallbacks: (implementedRNCallbacks: any): Promise<void> => {
+  setImplementedRNCallbacks: (implementedRNCallbacks: PrimerImplementedRNCallbacks): Promise<void> => {
     return new Promise(async (resolve, reject) => {
       try {
         await NativePrimer.setImplementedRNCallbacks(JSON.stringify(implementedRNCallbacks));

--- a/src/models/PrimerSettings.ts
+++ b/src/models/PrimerSettings.ts
@@ -12,6 +12,7 @@ import type {
   PrimerErrorHandler,
   PrimerHeadlessUniversalCheckoutResumeHandler,
 } from './PrimerHandlers';
+import type { IPrimerHeadlessUniversalCheckoutPaymentMethod } from './PrimerHeadlessUniversalCheckoutPaymentMethod';
 
 export type PrimerSettings = IPrimerSettings;
 
@@ -47,7 +48,7 @@ interface IPrimerSettings {
   onDismiss?: () => void;
 
   headlessUniversalCheckoutCallbacks?: {
-    onAvailablePaymentMethodsLoad?: (availablePaymentMethods: any[]) => void;
+    onAvailablePaymentMethodsLoad?: (availablePaymentMethods: IPrimerHeadlessUniversalCheckoutPaymentMethod[]) => void;
     onTokenizationStart?: (paymentMethodType: string) => void;
     onTokenizationSuccess?: (
       paymentMethodTokenData: PrimerPaymentMethodTokenData,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -26,7 +26,7 @@ export function toRgbColor(hex: string): RgbaColor | null {
   };
 }
 
-export function parseCallback<T>(data: any, callback: (val: T) => void) {
+export function parseCallback<T>(data: unknown, callback: (val: T) => void) {
   try {
     const error = JSON.parse(data) as T;
     callback(error);


### PR DESCRIPTION
## Summary

Three `any` types replaced with their correct, already-available types:

- **`RNPrimer.setImplementedRNCallbacks`** — parameter typed as `any` when `PrimerImplementedRNCallbacks` interface already exists in the models directory. Import added, type applied.
- **`PrimerSettings.headlessUniversalCheckoutCallbacks.onAvailablePaymentMethodsLoad`** — `any[]` replaced with `IPrimerHeadlessUniversalCheckoutPaymentMethod[]`, which is the type that native sends.
- **`parseCallback<T>`** in `src/utils/index.ts` — `data: any` replaced with `data: unknown`. `JSON.parse` accepts `string`, and `unknown` is the correct type when the runtime shape is verified by the cast to `T`.

## Why

All three were silently allowing callers to pass incorrect shapes. The types existed in the codebase already — this just wires them up.

No behaviour changes, types only.