### PR TITLE
feat: add standalone Primer status screen components (ORC-6924)

### DIFF
--- a/example/src/screens/NavigationDemoScreen.tsx
+++ b/example/src/screens/NavigationDemoScreen.tsx
@@ -11,9 +11,9 @@ import {
   useNavigation,
   useRoute,
   useTheme,
-  LoadingScreen as RealLoadingScreen,
-  SuccessScreen as RealSuccessScreen,
-  ErrorScreen as RealErrorScreen,
+  PrimerLoadingScreen as RealLoadingScreen,
+  PrimerSuccessScreen as RealSuccessScreen,
+  PrimerErrorScreen as RealErrorScreen,
 } from '@primer-io/react-native';
 
 // --- Sample Screens ---

--- a/src/Components/internal/screens/ErrorScreen.tsx
+++ b/src/Components/internal/screens/ErrorScreen.tsx
@@ -1,20 +1,15 @@
-import { useMemo } from 'react';
-import { Image, View, StyleSheet } from 'react-native';
+import { View } from 'react-native';
 import { useTheme } from '../theme';
 import { useLocalization } from '../localization';
 import { CheckoutRoute, useNavigation, useRoute } from '../navigation';
-import type { PrimerTokens } from '../theme';
-import { StatusScreenLayout } from './StatusScreenLayout';
+import { PrimerErrorScreen } from '../../status';
 import { useStatusScreenHeight } from './useStatusScreenHeight';
-import { STATUS_SCREEN_ICON_SIZE } from './constants';
 import { useBottomSafeArea } from './useBottomSafeArea';
-import { CheckoutButton } from '../ui';
 import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
 import { fmt } from '../debug';
 import { PrimerError } from '../../../models/PrimerError';
 
 const LOG = '[ErrorScreen]';
-const errorIcon = require('./assets/error-large.png');
 const CONTENT_HEIGHT = 282;
 const TOP_PADDING = 34;
 
@@ -28,7 +23,6 @@ export function ErrorScreen() {
   const bottomInset = Math.max(rawBottomInset, tokens.spacing.large);
   const sheetHeight = TOP_PADDING + CONTENT_HEIGHT + bottomInset;
   useStatusScreenHeight(sheetHeight);
-  const styles = useMemo(() => createStyles(tokens), [tokens]);
 
   const title = params?.title ?? t('primer_checkout_error_title');
   const subtitle = params?.subtitle ?? params?.error?.description ?? t('primer_checkout_error_subtitle');
@@ -57,33 +51,7 @@ export function ErrorScreen() {
 
   return (
     <View style={{ height: sheetHeight, paddingTop: TOP_PADDING, paddingBottom: bottomInset }}>
-      <StatusScreenLayout
-        icon={<Image source={errorIcon} style={{ width: STATUS_SCREEN_ICON_SIZE, height: STATUS_SCREEN_ICON_SIZE }} />}
-        title={title}
-        subtitle={subtitle}
-      >
-        <View style={styles.buttonGroup}>
-          <CheckoutButton title={t('primer_common_button_retry')} variant="primary" onPress={onRetry} />
-          <CheckoutButton
-            title={t('primer_checkout_error_button_other_methods')}
-            variant="outlined"
-            onPress={onChooseOther}
-          />
-        </View>
-      </StatusScreenLayout>
+      <PrimerErrorScreen title={title} subtitle={subtitle} onRetry={onRetry} onChooseOtherMethod={onChooseOther} />
     </View>
   );
-}
-
-function createStyles(tokens: PrimerTokens) {
-  const { spacing } = tokens;
-
-  /* eslint-disable react-native/no-unused-styles */
-  return StyleSheet.create({
-    buttonGroup: {
-      gap: spacing.small,
-      width: '100%',
-    },
-  });
-  /* eslint-enable react-native/no-unused-styles */
 }

--- a/src/Components/internal/screens/LoadingScreen.tsx
+++ b/src/Components/internal/screens/LoadingScreen.tsx
@@ -1,14 +1,12 @@
-import { ActivityIndicator, View } from 'react-native';
+import { View } from 'react-native';
 
 import { useTheme } from '../theme';
 import { useLocalization } from '../localization';
 import { CheckoutRoute, useRoute } from '../navigation';
-import { StatusScreenLayout } from './StatusScreenLayout';
+import { PrimerLoadingScreen } from '../../status';
 import { useStatusScreenHeight } from './useStatusScreenHeight';
-import { STATUS_SCREEN_ICON_SIZE } from './constants';
 import { useBottomSafeArea } from './useBottomSafeArea';
 
-const SPINNER_SCALE = 1.1;
 const CONTENT_HEIGHT = 246;
 
 export function LoadingScreen() {
@@ -37,29 +35,9 @@ export function LoadingScreen() {
   const subtitle = params?.subtitle ?? t(defaultSubtitleKey);
 
   return (
-    /* eslint-disable react-native/no-inline-styles -- screen-level layout with fixed height and icon sizing */
+    /* eslint-disable-next-line react-native/no-inline-styles -- screen-level layout with fixed height */
     <View style={{ height: sheetHeight, justifyContent: 'center', paddingBottom: bottomInset }}>
-      <StatusScreenLayout
-        icon={
-          <View
-            style={{
-              width: STATUS_SCREEN_ICON_SIZE,
-              height: STATUS_SCREEN_ICON_SIZE,
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <ActivityIndicator
-              size="large"
-              color={tokens.colors.primary}
-              style={{ transform: [{ scale: SPINNER_SCALE }] }}
-            />
-          </View>
-        }
-        title={title}
-        subtitle={subtitle}
-      />
+      <PrimerLoadingScreen title={title} subtitle={subtitle} />
     </View>
-    /* eslint-enable react-native/no-inline-styles */
   );
 }

--- a/src/Components/internal/screens/SuccessScreen.tsx
+++ b/src/Components/internal/screens/SuccessScreen.tsx
@@ -1,15 +1,12 @@
-import { useEffect } from 'react';
-import { Image, View } from 'react-native';
+import { View } from 'react-native';
 import { useTheme } from '../theme';
 import { useLocalization } from '../localization';
 import { CheckoutRoute, useRoute } from '../navigation';
-import { StatusScreenLayout } from './StatusScreenLayout';
+import { PrimerSuccessScreen } from '../../status';
 import { useStatusScreenHeight } from './useStatusScreenHeight';
-import { STATUS_SCREEN_ICON_SIZE } from './constants';
 import { useBottomSafeArea } from './useBottomSafeArea';
 import { useCheckoutFlow } from '../checkout-flow/CheckoutFlowContext';
 
-const checkCircleIcon = require('./assets/check-circle-large.png');
 const CONTENT_HEIGHT = 246;
 const AUTO_DISMISS_MS = 3000;
 
@@ -23,24 +20,13 @@ export function SuccessScreen() {
   const sheetHeight = CONTENT_HEIGHT + bottomInset;
   useStatusScreenHeight(sheetHeight);
 
-  useEffect(() => {
-    const id = setTimeout(onCancel, AUTO_DISMISS_MS);
-    return () => clearTimeout(id);
-  }, [onCancel]);
-
   const title = params?.title ?? t('primer_checkout_success_title');
   const subtitle = params?.subtitle ?? t('primer_checkout_success_subtitle');
 
   return (
     // eslint-disable-next-line react-native/no-inline-styles -- screen-level layout with fixed height
     <View style={{ height: sheetHeight, justifyContent: 'center', paddingBottom: bottomInset }}>
-      <StatusScreenLayout
-        icon={
-          <Image source={checkCircleIcon} style={{ width: STATUS_SCREEN_ICON_SIZE, height: STATUS_SCREEN_ICON_SIZE }} />
-        }
-        title={title}
-        subtitle={subtitle}
-      />
+      <PrimerSuccessScreen title={title} subtitle={subtitle} onDismiss={onCancel} autoDismissMs={AUTO_DISMISS_MS} />
     </View>
   );
 }

--- a/src/Components/internal/screens/index.ts
+++ b/src/Components/internal/screens/index.ts
@@ -1,5 +1,3 @@
-export { StatusScreenLayout } from './StatusScreenLayout';
-export type { StatusScreenLayoutProps } from './StatusScreenLayout';
 export { LoadingScreen } from './LoadingScreen';
 export { SuccessScreen } from './SuccessScreen';
 export { ErrorScreen } from './ErrorScreen';

--- a/src/Components/status/PrimerErrorScreen.tsx
+++ b/src/Components/status/PrimerErrorScreen.tsx
@@ -1,0 +1,77 @@
+import React, { useMemo } from 'react';
+import { Image, View, StyleSheet } from 'react-native';
+
+import { useTheme } from '../internal/theme';
+import type { PrimerTokens } from '../internal/theme';
+import { useLocalization } from '../internal/localization';
+import { STATUS_SCREEN_ICON_SIZE } from '../internal/screens/constants';
+import { CheckoutButton } from '../internal/ui';
+import { PrimerStatusScreenLayout } from './PrimerStatusScreenLayout';
+
+const errorIcon = require('../internal/screens/assets/error-large.png');
+
+export interface PrimerErrorScreenProps {
+  title?: string;
+  subtitle?: string;
+  icon?: React.ReactNode;
+  onRetry?: () => void;
+  onChooseOtherMethod?: () => void;
+  retryLabel?: string;
+  otherMethodLabel?: string;
+}
+
+export function PrimerErrorScreen({
+  title,
+  subtitle,
+  icon,
+  onRetry,
+  onChooseOtherMethod,
+  retryLabel,
+  otherMethodLabel,
+}: PrimerErrorScreenProps) {
+  const tokens = useTheme();
+  const { t } = useLocalization();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+
+  const resolvedTitle = title ?? t('primer_checkout_error_title');
+  const resolvedSubtitle = subtitle ?? t('primer_checkout_error_subtitle');
+  const resolvedIcon = icon ?? <Image source={errorIcon} style={styles.icon} />;
+
+  const hasButtons = onRetry != null || onChooseOtherMethod != null;
+
+  return (
+    <PrimerStatusScreenLayout icon={resolvedIcon} title={resolvedTitle} subtitle={resolvedSubtitle}>
+      {hasButtons && (
+        <View style={styles.buttonGroup}>
+          {onRetry != null && (
+            <CheckoutButton title={retryLabel ?? t('primer_common_button_retry')} variant="primary" onPress={onRetry} />
+          )}
+          {onChooseOtherMethod != null && (
+            <CheckoutButton
+              title={otherMethodLabel ?? t('primer_checkout_error_button_other_methods')}
+              variant="outlined"
+              onPress={onChooseOtherMethod}
+            />
+          )}
+        </View>
+      )}
+    </PrimerStatusScreenLayout>
+  );
+}
+
+function createStyles(tokens: PrimerTokens) {
+  const { spacing } = tokens;
+
+  /* eslint-disable react-native/no-unused-styles */
+  return StyleSheet.create({
+    buttonGroup: {
+      gap: spacing.small,
+      width: '100%',
+    },
+    icon: {
+      height: STATUS_SCREEN_ICON_SIZE,
+      width: STATUS_SCREEN_ICON_SIZE,
+    },
+  });
+  /* eslint-enable react-native/no-unused-styles */
+}

--- a/src/Components/status/PrimerLoadingScreen.tsx
+++ b/src/Components/status/PrimerLoadingScreen.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from 'react';
+import { ActivityIndicator, View, StyleSheet } from 'react-native';
+
+import { useTheme } from '../internal/theme';
+import { useLocalization } from '../internal/localization';
+import { STATUS_SCREEN_ICON_SIZE } from '../internal/screens/constants';
+import { PrimerStatusScreenLayout } from './PrimerStatusScreenLayout';
+
+const SPINNER_SCALE = 1.1;
+
+export interface PrimerLoadingScreenProps {
+  title?: string;
+  subtitle?: string;
+  /** Custom loading visual rendered in the centered slot. Defaults to the SDK spinner. */
+  icon?: ReactNode;
+}
+
+export function PrimerLoadingScreen({ title, subtitle, icon }: PrimerLoadingScreenProps) {
+  const tokens = useTheme();
+  const { t } = useLocalization();
+
+  const resolvedTitle = title ?? t('primer_checkout_loading_indicator');
+  const resolvedSubtitle = subtitle ?? t('primer_checkout_loading_subtitle');
+  const resolvedIcon = icon ?? (
+    <View style={styles.iconWrapper}>
+      <ActivityIndicator size="large" color={tokens.colors.primary} style={styles.spinner} />
+    </View>
+  );
+
+  return <PrimerStatusScreenLayout icon={resolvedIcon} title={resolvedTitle} subtitle={resolvedSubtitle} />;
+}
+
+const styles = StyleSheet.create({
+  iconWrapper: {
+    alignItems: 'center',
+    height: STATUS_SCREEN_ICON_SIZE,
+    justifyContent: 'center',
+    width: STATUS_SCREEN_ICON_SIZE,
+  },
+  spinner: {
+    transform: [{ scale: SPINNER_SCALE }],
+  },
+});

--- a/src/Components/status/PrimerStatusScreenLayout.tsx
+++ b/src/Components/status/PrimerStatusScreenLayout.tsx
@@ -1,17 +1,17 @@
 import React, { useMemo } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import type { TextStyle } from 'react-native';
-import { useTheme } from '../theme';
-import type { PrimerTokens } from '../theme';
+import { useTheme } from '../internal/theme';
+import type { PrimerTokens } from '../internal/theme';
 
-export interface StatusScreenLayoutProps {
+export interface PrimerStatusScreenLayoutProps {
   icon: React.ReactNode;
   title: string;
   subtitle: string;
   children?: React.ReactNode;
 }
 
-export function StatusScreenLayout({ icon, title, subtitle, children }: StatusScreenLayoutProps) {
+export function PrimerStatusScreenLayout({ icon, title, subtitle, children }: PrimerStatusScreenLayoutProps) {
   const tokens = useTheme();
   const styles = useMemo(() => createStyles(tokens), [tokens]);
 

--- a/src/Components/status/PrimerSuccessScreen.tsx
+++ b/src/Components/status/PrimerSuccessScreen.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect } from 'react';
+import { Image, StyleSheet } from 'react-native';
+
+import { useLocalization } from '../internal/localization';
+import { STATUS_SCREEN_ICON_SIZE } from '../internal/screens/constants';
+import { PrimerStatusScreenLayout } from './PrimerStatusScreenLayout';
+
+const checkCircleIcon = require('../internal/screens/assets/check-circle-large.png');
+
+export interface PrimerSuccessScreenProps {
+  title?: string;
+  subtitle?: string;
+  icon?: React.ReactNode;
+  onDismiss?: () => void;
+  autoDismissMs?: number;
+}
+
+export function PrimerSuccessScreen({ title, subtitle, icon, onDismiss, autoDismissMs }: PrimerSuccessScreenProps) {
+  const { t } = useLocalization();
+
+  useEffect(() => {
+    if (!onDismiss || autoDismissMs == null) return;
+    const id = setTimeout(onDismiss, autoDismissMs);
+    return () => clearTimeout(id);
+  }, [onDismiss, autoDismissMs]);
+
+  const resolvedTitle = title ?? t('primer_checkout_success_title');
+  const resolvedSubtitle = subtitle ?? t('primer_checkout_success_subtitle');
+  const resolvedIcon = icon ?? <Image source={checkCircleIcon} style={styles.icon} />;
+
+  return <PrimerStatusScreenLayout icon={resolvedIcon} title={resolvedTitle} subtitle={resolvedSubtitle} />;
+}
+
+const styles = StyleSheet.create({
+  icon: {
+    height: STATUS_SCREEN_ICON_SIZE,
+    width: STATUS_SCREEN_ICON_SIZE,
+  },
+});

--- a/src/Components/status/index.ts
+++ b/src/Components/status/index.ts
@@ -1,0 +1,8 @@
+export { PrimerStatusScreenLayout } from './PrimerStatusScreenLayout';
+export type { PrimerStatusScreenLayoutProps } from './PrimerStatusScreenLayout';
+export { PrimerLoadingScreen } from './PrimerLoadingScreen';
+export type { PrimerLoadingScreenProps } from './PrimerLoadingScreen';
+export { PrimerSuccessScreen } from './PrimerSuccessScreen';
+export type { PrimerSuccessScreenProps } from './PrimerSuccessScreen';
+export { PrimerErrorScreen } from './PrimerErrorScreen';
+export type { PrimerErrorScreenProps } from './PrimerErrorScreen';

--- a/src/__tests__/components/status/primerStatusScreens.test.tsx
+++ b/src/__tests__/components/status/primerStatusScreens.test.tsx
@@ -1,0 +1,150 @@
+// @ts-expect-error -- React 19 concurrent act environment
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+import { createElement } from 'react';
+// @ts-expect-error -- react-test-renderer has no types for React 19
+import { act, create } from 'react-test-renderer';
+
+// react-native is not transformed in this project's jest setup (transformIgnorePatterns
+// excludes node_modules, test env is node), so every test mocks it. We render real
+// primitives here, so the mock provides lightweight host-ish components + StyleSheet.
+let mockColorScheme: 'light' | 'dark' | null = 'light';
+
+jest.mock('react-native', () => {
+  // Inlined here because jest hoists jest.mock above imports; the factory may only
+  // reference mock-prefixed outer vars, so it can't close over a top-level helper.
+  const { createElement: ce } = require('react');
+  const makeComponent = (name: string) => {
+    const Mock = (props: { children?: unknown }) => ce(name, props, props?.children);
+    Mock.displayName = name;
+    return Mock;
+  };
+  return {
+    useColorScheme: () => mockColorScheme,
+    View: makeComponent('View'),
+    Text: makeComponent('Text'),
+    Image: makeComponent('Image'),
+    ActivityIndicator: makeComponent('ActivityIndicator'),
+    TouchableOpacity: makeComponent('TouchableOpacity'),
+    StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+  };
+});
+
+// PNG assets can't be loaded by jest (no asset transformer / moduleNameMapper).
+jest.mock('../../../Components/internal/screens/assets/check-circle-large.png', () => 1, { virtual: true });
+jest.mock('../../../Components/internal/screens/assets/error-large.png', () => 2, { virtual: true });
+
+import {
+  PrimerStatusScreenLayout,
+  PrimerLoadingScreen,
+  PrimerSuccessScreen,
+  PrimerErrorScreen,
+} from '../../../Components/status';
+import { CheckoutButton } from '../../../Components/internal/ui';
+
+function render(element: ReturnType<typeof createElement>) {
+  let testRenderer: ReturnType<typeof create>;
+  act(() => {
+    testRenderer = create(element);
+  });
+  return testRenderer;
+}
+
+beforeEach(() => {
+  mockColorScheme = 'light';
+});
+
+describe('public status components (standalone, no checkout/navigation provider)', () => {
+  it('PrimerStatusScreenLayout renders title, subtitle, icon and children without throwing', () => {
+    const r = render(
+      createElement(
+        PrimerStatusScreenLayout,
+        { icon: createElement('Icon'), title: 'Hello', subtitle: 'World' },
+        createElement('Child')
+      )
+    );
+    expect(r.toJSON()).not.toBeNull();
+  });
+
+  it('PrimerLoadingScreen renders with default copy', () => {
+    const r = render(createElement(PrimerLoadingScreen, {}));
+    expect(r.toJSON()).not.toBeNull();
+  });
+
+  it('PrimerLoadingScreen renders with overridden copy', () => {
+    const r = render(createElement(PrimerLoadingScreen, { title: 'Wait', subtitle: 'Almost there' }));
+    expect(r.toJSON()).not.toBeNull();
+  });
+
+  it('PrimerSuccessScreen renders without throwing', () => {
+    const r = render(createElement(PrimerSuccessScreen, { title: 'Done', subtitle: 'Paid' }));
+    expect(r.toJSON()).not.toBeNull();
+  });
+
+  it('PrimerSuccessScreen fires onDismiss after autoDismissMs and clears on unmount', () => {
+    jest.useFakeTimers();
+    try {
+      const onDismiss = jest.fn();
+      const r = render(createElement(PrimerSuccessScreen, { onDismiss, autoDismissMs: 3000 }));
+      expect(onDismiss).not.toHaveBeenCalled();
+      act(() => {
+        jest.advanceTimersByTime(3000);
+      });
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+      act(() => {
+        r.unmount();
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('PrimerSuccessScreen does not schedule dismiss when autoDismissMs is omitted', () => {
+    jest.useFakeTimers();
+    try {
+      const onDismiss = jest.fn();
+      render(createElement(PrimerSuccessScreen, { onDismiss }));
+      act(() => {
+        jest.advanceTimersByTime(10000);
+      });
+      expect(onDismiss).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('PrimerErrorScreen renders without throwing', () => {
+    const r = render(createElement(PrimerErrorScreen, { title: 'Failed', subtitle: 'Oops' }));
+    expect(r.toJSON()).not.toBeNull();
+  });
+
+  it('PrimerErrorScreen renders no buttons when no callbacks are passed', () => {
+    const r = render(createElement(PrimerErrorScreen, {}));
+    expect(r.root.findAllByType(CheckoutButton)).toHaveLength(0);
+  });
+
+  it('PrimerErrorScreen renders only the retry button when only onRetry is passed', () => {
+    const onRetry = jest.fn();
+    const r = render(createElement(PrimerErrorScreen, { onRetry }));
+    const buttons = r.root.findAllByType(CheckoutButton);
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0].props.variant).toBe('primary');
+    act(() => {
+      buttons[0].props.onPress();
+    });
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('PrimerErrorScreen renders only the other-method button when only onChooseOtherMethod is passed', () => {
+    const onChooseOtherMethod = jest.fn();
+    const r = render(createElement(PrimerErrorScreen, { onChooseOtherMethod }));
+    const buttons = r.root.findAllByType(CheckoutButton);
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0].props.variant).toBe('outlined');
+  });
+
+  it('PrimerErrorScreen renders both buttons when both callbacks are passed', () => {
+    const r = render(createElement(PrimerErrorScreen, { onRetry: jest.fn(), onChooseOtherMethod: jest.fn() }));
+    expect(r.root.findAllByType(CheckoutButton)).toHaveLength(2);
+  });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -220,8 +220,18 @@ export type {
   RouteParamMap,
 } from './Components/internal/navigation';
 
-export { LoadingScreen, SuccessScreen, ErrorScreen, StatusScreenLayout } from './Components/internal/screens';
-export type { StatusScreenLayoutProps } from './Components/internal/screens';
+export {
+  PrimerLoadingScreen,
+  PrimerSuccessScreen,
+  PrimerErrorScreen,
+  PrimerStatusScreenLayout,
+} from './Components/status';
+export type {
+  PrimerLoadingScreenProps,
+  PrimerSuccessScreenProps,
+  PrimerErrorScreenProps,
+  PrimerStatusScreenLayoutProps,
+} from './Components/status';
 
 // must be exported in order to support the old architecture
 const nativeModule = require('./specs/NativePrimer').default;


### PR DESCRIPTION
## Summary

- Decouples the checkout status screens (loading / success / error) into reusable, prop-driven **public** components, so a custom (Tier-3) layout can reuse them in a merchant-owned flow instead of them being locked inside the drop-in sheet.
- New public components in `src/Components/status/`: `PrimerStatusScreenLayout`, `PrimerLoadingScreen`, `PrimerSuccessScreen`, `PrimerErrorScreen`. Each takes `title` / `subtitle` / `icon` (success/error also `onRetry` / `onChooseOtherMethod` / `onDismiss` + labels), defaulting to the SDK's localized copy + icons.
- Internal sheet screens (`LoadingScreen` / `SuccessScreen` / `ErrorScreen`) become thin wrappers that read route/flow context and render the public components — **drop-in flow behavior unchanged**.
- Moves `StatusScreenLayout` → public `status/` dir (renamed `PrimerStatusScreenLayout`); barrels updated.

## Stacked on

`ov/feat/ACC-6922-cobadge`. Part of the Checkout Components customization work; the public-API addition is captured in the Checkout Components customization ADR.

## Jira

[ORC-6924](https://primerapi.atlassian.net/browse/ORC-6924) — M11: Customization (Slots)

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn lint` — clean
- [x] `yarn test` — standalone render test added for all four components (no checkout/navigation provider); suite green (1 pre-existing, unrelated `useLocalization` locale flake)
- [x] iOS example app — loading/success/error render via the drop-in flow, unchanged
- [ ] Android example app — pending rebuild

[ORC-6924]: https://primerapi.atlassian.net/browse/ORC-6924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ