### PR TITLE
chore: enable @typescript-eslint/no-floating-promises

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,7 @@ export default tseslint.config(
     },
     files: ['**/src/**/*.ts', '**/src/**/*.tsx'],
     rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/no-shadow': 'error',
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
       'no-undef': 'off',

--- a/src/Components/PrimerCheckoutProvider.tsx
+++ b/src/Components/PrimerCheckoutProvider.tsx
@@ -319,7 +319,7 @@ export function PrimerCheckoutProvider({
       cancelled = true;
       // Vault manager is tied to the native session — let the next session recreate it.
       vaultManagerRef.current = null;
-      void PrimerHeadlessUniversalCheckout.cleanUp().catch((err) => console.warn(`${LOG} cleanUp failed ${fmt(err)}`));
+      void PrimerHeadlessUniversalCheckout.cleanUp();
     };
   }, [clientToken]);
 

--- a/src/Components/PrimerCheckoutProvider.tsx
+++ b/src/Components/PrimerCheckoutProvider.tsx
@@ -319,7 +319,7 @@ export function PrimerCheckoutProvider({
       cancelled = true;
       // Vault manager is tied to the native session — let the next session recreate it.
       vaultManagerRef.current = null;
-      PrimerHeadlessUniversalCheckout.cleanUp();
+      void PrimerHeadlessUniversalCheckout.cleanUp().catch((err) => console.warn(`${LOG} cleanUp failed ${fmt(err)}`));
     };
   }, [clientToken]);
 
@@ -424,7 +424,7 @@ export function PrimerCheckoutProvider({
         : { ...prev, isLoadingVaulted: true, vaultedError: null }
     );
 
-    (async () => {
+    void (async () => {
       try {
         const { methods, iconMap } = await refreshVaultedMethods();
         if (cancelled) return;
@@ -548,7 +548,7 @@ export function PrimerCheckoutProvider({
     };
     lastManagerCallbacksRef.current = callbacks;
 
-    (async () => {
+    void (async () => {
       try {
         await manager.configure({ paymentMethodType: method, ...callbacks });
         if (cancelled) return;

--- a/src/Components/hooks/useCardNetwork.ts
+++ b/src/Components/hooks/useCardNetwork.ts
@@ -37,7 +37,7 @@ export function useCardNetwork(): UseCardNetworkReturn {
     setDescriptor(DEFAULT_DESCRIPTOR);
     if (!network) return;
     let cancelled = false;
-    fetchCardNetworkDescriptor(network).then((d) => {
+    void fetchCardNetworkDescriptor(network).then((d) => {
       if (cancelled) return;
       console.log(`${LOG} descriptor resolved ${JSON.stringify({ network, id: d.id })}`);
       setDescriptor(d);

--- a/src/Components/internal/screens/CardFormScreen.tsx
+++ b/src/Components/internal/screens/CardFormScreen.tsx
@@ -83,7 +83,7 @@ export function CardFormScreen() {
       await billingForm.flush();
     }
     replace(CheckoutRoute.processing);
-    void cardForm.submit().catch((err) => console.warn(`[CardFormScreen] submit failed: ${String(err)}`));
+    void cardForm.submit();
   }, [canSubmit, cardForm, billingForm, replace]);
 
   return (

--- a/src/Components/internal/screens/CardFormScreen.tsx
+++ b/src/Components/internal/screens/CardFormScreen.tsx
@@ -83,7 +83,7 @@ export function CardFormScreen() {
       await billingForm.flush();
     }
     replace(CheckoutRoute.processing);
-    cardForm.submit();
+    void cardForm.submit().catch((err) => console.warn(`[CardFormScreen] submit failed: ${String(err)}`));
   }, [canSubmit, cardForm, billingForm, replace]);
 
   return (

--- a/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/AchManager.ts
+++ b/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/AchManager.ts
@@ -98,37 +98,37 @@ export class PrimerHeadlessUniversalCheckoutAchManager {
 
   private async configureListeners(props: AchManagerProps): Promise<void> {
     if (props?.onStep) {
-      this.addListener('onStep', (data) => {
+      void this.addListener('onStep', (data) => {
         props.onStep?.(data);
       });
     }
 
     if (props?.onInvalid) {
-      this.addListener('onInvalid', (data) => {
+      void this.addListener('onInvalid', (data) => {
         props.onInvalid?.(data);
       });
     }
 
     if (props?.onError) {
-      this.addListener('onError', (data) => {
+      void this.addListener('onError', (data) => {
         props.onError?.(data);
       });
     }
 
     if (props?.onValid) {
-      this.addListener('onValid', (data) => {
+      void this.addListener('onValid', (data) => {
         props.onValid?.(data);
       });
     }
 
     if (props?.onValidating) {
-      this.addListener('onValidating', (data) => {
+      void this.addListener('onValidating', (data) => {
         props.onValidating?.(data);
       });
     }
 
     if (props?.onValidationError) {
-      this.addListener('onValidationError', (data) => {
+      void this.addListener('onValidationError', (data) => {
         props.onValidationError?.(data);
       });
     }

--- a/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/ComponentWithRedirectManager.ts
+++ b/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/ComponentWithRedirectManager.ts
@@ -119,37 +119,37 @@ export class PrimerHeadlessUniversalCheckoutComponentWithRedirectManager {
 
   private async configureListeners(props: ComponentWithRedirectManagerProps): Promise<void> {
     if (props?.onStep) {
-      this.addListener('onStep', (data) => {
+      void this.addListener('onStep', (data) => {
         props.onStep?.(data);
       });
     }
 
     if (props?.onInvalid) {
-      this.addListener('onInvalid', (data) => {
+      void this.addListener('onInvalid', (data) => {
         props.onInvalid?.(data);
       });
     }
 
     if (props?.onError) {
-      this.addListener('onError', (data) => {
+      void this.addListener('onError', (data) => {
         props.onError?.(data);
       });
     }
 
     if (props?.onValid) {
-      this.addListener('onValid', (data) => {
+      void this.addListener('onValid', (data) => {
         props.onValid?.(data);
       });
     }
 
     if (props?.onValidating) {
-      this.addListener('onValidating', (data) => {
+      void this.addListener('onValidating', (data) => {
         props.onValidating?.(data);
       });
     }
 
     if (props?.onValidationError) {
-      this.addListener('onValidationError', (data) => {
+      void this.addListener('onValidationError', (data) => {
         props.onValidationError?.(data);
       });
     }

--- a/src/HeadlessUniversalCheckout/PrimerHeadlessUniversalCheckout.ts
+++ b/src/HeadlessUniversalCheckout/PrimerHeadlessUniversalCheckout.ts
@@ -23,14 +23,14 @@ import type {
 const tokenizationHandler: PrimerHeadlessUniversalCheckoutResumeHandler = {
   continueWithNewClientToken: async (newClientToken: string) => {
     try {
-      RNPrimerHeadlessUniversalCheckout.handleTokenizationNewClientToken(newClientToken);
+      await RNPrimerHeadlessUniversalCheckout.handleTokenizationNewClientToken(newClientToken);
     } catch (err) {
       console.error(err);
     }
   },
 
   complete: () => {
-    RNPrimerHeadlessUniversalCheckout.handleCompleteFlow();
+    void RNPrimerHeadlessUniversalCheckout.handleCompleteFlow();
   },
 };
 
@@ -39,14 +39,14 @@ const tokenizationHandler: PrimerHeadlessUniversalCheckoutResumeHandler = {
 const resumeHandler: PrimerHeadlessUniversalCheckoutResumeHandler = {
   continueWithNewClientToken: async (newClientToken: string) => {
     try {
-      RNPrimerHeadlessUniversalCheckout.handleResumeWithNewClientToken(newClientToken);
+      await RNPrimerHeadlessUniversalCheckout.handleResumeWithNewClientToken(newClientToken);
     } catch (err) {
       console.error(err);
     }
   },
 
   complete: () => {
-    RNPrimerHeadlessUniversalCheckout.handleCompleteFlow();
+    void RNPrimerHeadlessUniversalCheckout.handleCompleteFlow();
   },
 };
 
@@ -55,7 +55,7 @@ const resumeHandler: PrimerHeadlessUniversalCheckoutResumeHandler = {
 const paymentCreationHandler: PrimerPaymentCreationHandler = {
   abortPaymentCreation: async (errorMessage: string) => {
     try {
-      RNPrimerHeadlessUniversalCheckout.handlePaymentCreationAbort(errorMessage);
+      await RNPrimerHeadlessUniversalCheckout.handlePaymentCreationAbort(errorMessage);
     } catch (err) {
       console.error(err);
     }
@@ -63,7 +63,7 @@ const paymentCreationHandler: PrimerPaymentCreationHandler = {
 
   continuePaymentCreation: async () => {
     try {
-      RNPrimerHeadlessUniversalCheckout.handlePaymentCreationContinue();
+      await RNPrimerHeadlessUniversalCheckout.handlePaymentCreationContinue();
     } catch (err) {
       console.error(err);
     }

--- a/src/Primer.ts
+++ b/src/Primer.ts
@@ -25,7 +25,7 @@ import type { PrimerImplementedRNCallbacks } from './models/PrimerImplementedRNC
 const tokenizationHandler: PrimerTokenizationHandler = {
   handleFailure: async (errorMessage: string) => {
     try {
-      RNPrimer.handleTokenizationFailure(errorMessage);
+      await RNPrimer.handleTokenizationFailure(errorMessage);
     } catch (err) {
       console.error(err);
     }
@@ -33,7 +33,7 @@ const tokenizationHandler: PrimerTokenizationHandler = {
 
   handleSuccess: async () => {
     try {
-      RNPrimer.handleTokenizationSuccess();
+      await RNPrimer.handleTokenizationSuccess();
     } catch (err) {
       console.error(err);
     }
@@ -41,7 +41,7 @@ const tokenizationHandler: PrimerTokenizationHandler = {
 
   continueWithNewClientToken: async (newClientToken: string) => {
     try {
-      RNPrimer.handleTokenizationNewClientToken(newClientToken);
+      await RNPrimer.handleTokenizationNewClientToken(newClientToken);
     } catch (err) {
       console.error(err);
     }
@@ -53,7 +53,7 @@ const tokenizationHandler: PrimerTokenizationHandler = {
 const resumeHandler: PrimerResumeHandler = {
   handleFailure: async (errorMessage: string) => {
     try {
-      RNPrimer.handleResumeFailure(errorMessage);
+      await RNPrimer.handleResumeFailure(errorMessage);
     } catch (err) {
       console.error(err);
     }
@@ -61,7 +61,7 @@ const resumeHandler: PrimerResumeHandler = {
 
   handleSuccess: async () => {
     try {
-      RNPrimer.handleResumeSuccess();
+      await RNPrimer.handleResumeSuccess();
     } catch (err) {
       console.error(err);
     }
@@ -69,7 +69,7 @@ const resumeHandler: PrimerResumeHandler = {
 
   continueWithNewClientToken: async (newClientToken: string) => {
     try {
-      RNPrimer.handleResumeWithNewClientToken(newClientToken);
+      await RNPrimer.handleResumeWithNewClientToken(newClientToken);
     } catch (err) {
       console.error(err);
     }
@@ -81,7 +81,7 @@ const resumeHandler: PrimerResumeHandler = {
 const paymentCreationHandler: PrimerPaymentCreationHandler = {
   abortPaymentCreation: async (errorMessage: string) => {
     try {
-      RNPrimer.handlePaymentCreationAbort(errorMessage);
+      await RNPrimer.handlePaymentCreationAbort(errorMessage);
     } catch (err) {
       console.error(err);
     }
@@ -89,7 +89,7 @@ const paymentCreationHandler: PrimerPaymentCreationHandler = {
 
   continuePaymentCreation: async () => {
     try {
-      RNPrimer.handlePaymentCreationContinue();
+      await RNPrimer.handlePaymentCreationContinue();
     } catch (err) {
       console.error(err);
     }
@@ -101,7 +101,7 @@ const paymentCreationHandler: PrimerPaymentCreationHandler = {
 const errorHandler: PrimerErrorHandler = {
   showErrorMessage: async (errorMessage: string) => {
     try {
-      RNPrimer.showErrorMessage(errorMessage || '');
+      await RNPrimer.showErrorMessage(errorMessage || '');
     } catch (err) {
       console.error(err);
     }
@@ -309,13 +309,13 @@ export const Primer: IPrimer = {
     RNPrimerHeadlessUniversalCheckout.removeAllListeners();
     RNPrimer.removeAllListeners();
     primerSettings = undefined;
-    RNPrimer.dismiss();
+    void RNPrimer.dismiss();
   },
 
   dismiss(): void {
     RNPrimerHeadlessUniversalCheckout.removeAllListeners();
     RNPrimer.removeAllListeners();
     primerSettings = undefined;
-    RNPrimer.dismiss();
+    void RNPrimer.dismiss();
   },
 };


### PR DESCRIPTION
## Summary

- Enables [`@typescript-eslint/no-floating-promises`](https://typescript-eslint.io/rules/no-floating-promises/) repo-wide and fixes all 40 violations — follow-up to [#375 (comment)](https://github.com/primer-io/primer-sdk-react-native/pull/375#discussion_r3358633665).
- Fix picked per site: `await` where an existing try/catch was wrapping an un-awaited native call (dead catch blocks in the `Primer.ts` / `PrimerHeadlessUniversalCheckout.ts` decision handlers); `void` for intentional fire-and-forget (discarded `addListener` subscriptions, async IIFEs with internal try/catch); `.catch` + warn where a real rejection was floating silently (`cardForm.submit()`, `cleanUp()` in the provider teardown).

## Jira

N/A — follow-up to a review comment on #375.

## Test plan

- [x] `yarn typecheck` / `yarn lint` clean
- [x] `yarn test` — no new failures