### PR TITLE
feat: provide card-form state via PrimerCardFormProvider context

### DIFF
--- a/src/Components/PrimerCardForm.tsx
+++ b/src/Components/PrimerCardForm.tsx
@@ -7,16 +7,17 @@ import { PrimerExpiryDateInput } from './inputs/PrimerExpiryDateInput';
 import { PrimerCVVInput } from './inputs/PrimerCVVInput';
 import { PrimerCardholderNameInput } from './inputs/PrimerCardholderNameInput';
 import { PrimerAcceptedCardNetworks } from './PrimerAcceptedCardNetworks';
+import { usePrimerCardForm } from './hooks/usePrimerCardForm';
 import type { PrimerTextInputRef } from './types/CardInputTypes';
 import type { PrimerCardFormProps } from './types/PrimerCardFormTypes';
 
 export function PrimerCardForm({
-  cardForm,
   onSubmit,
   autoFocus = false,
   style,
   testID = 'primer-card-form',
 }: PrimerCardFormProps) {
+  const cardForm = usePrimerCardForm();
   const tokens = usePrimerTheme();
   const styles = useMemo(() => createStyles(tokens), [tokens]);
 
@@ -40,7 +41,6 @@ export function PrimerCardForm({
       <PrimerAcceptedCardNetworks testID={`${testID}-accepted-networks`} />
       <PrimerCardNumberInput
         ref={cardRef}
-        cardForm={cardForm}
         editable={!disabled}
         returnKeyType="next"
         onSubmitEditing={() => expiryRef.current?.focus()}
@@ -51,7 +51,6 @@ export function PrimerCardForm({
         <View style={styles.halfField}>
           <PrimerExpiryDateInput
             ref={expiryRef}
-            cardForm={cardForm}
             editable={!disabled}
             returnKeyType="next"
             onSubmitEditing={() => cvvRef.current?.focus()}
@@ -61,7 +60,6 @@ export function PrimerCardForm({
         <View style={styles.halfField}>
           <PrimerCVVInput
             ref={cvvRef}
-            cardForm={cardForm}
             editable={!disabled}
             returnKeyType={cardForm.isCardholderNameVisible ? 'next' : 'done'}
             onSubmitEditing={cardForm.isCardholderNameVisible ? () => nameRef.current?.focus() : onSubmit}
@@ -74,7 +72,6 @@ export function PrimerCardForm({
       {cardForm.isCardholderNameVisible && (
         <PrimerCardholderNameInput
           ref={nameRef}
-          cardForm={cardForm}
           editable={!disabled}
           returnKeyType="done"
           onSubmitEditing={onSubmit}

--- a/src/Components/PrimerCheckoutProvider.tsx
+++ b/src/Components/PrimerCheckoutProvider.tsx
@@ -59,6 +59,8 @@ interface InternalState {
   vaultedError: Error | null;
   activeVaultedMethodId: string | null;
   vaultDisplayOverride: 'expanded' | null;
+  // Shopper-picked co-badged card network. Null until the user makes a
+  // selection in the popover. Persists across re-renders / hook callers.
   selectedCardNetwork: CardNetworkId | null;
   requiresVaultedCardCvv: boolean;
   cvvInputVisible: boolean;

--- a/src/Components/hooks/usePrimerCardForm.ts
+++ b/src/Components/hooks/usePrimerCardForm.ts
@@ -4,19 +4,19 @@ import { usePrimerCheckout } from './usePrimerCheckout';
 import type { UseCardFormOptions, UsePrimerCardFormReturn } from '../types/CardFormTypes';
 
 /**
- * Card form adapter hook. Thin wrapper over `CardFormStateProvider` — the
+ * Card form adapter hook. Thin wrapper over `PrimerCardFormProvider` — the
  * provider owns the field state, focus tracking, debouncer, and submit lifecycle.
  * This hook reads the shared state and wires per-caller option callbacks
  * (`onValidationChange`, `onBinDataChange`, `onMetadataChange`).
  *
  * Must be used inside a `<PrimerCheckoutProvider>` tree that also mounts
- * `<CardFormStateProvider>` (the drop-in `CheckoutFlow` does this for you).
+ * `<PrimerCardFormProvider>` (the drop-in `CheckoutFlow` does this for you).
  */
 export function usePrimerCardForm(options: UseCardFormOptions = {}): UsePrimerCardFormReturn {
   const state = useCardFormStateContext();
   if (!state) {
     throw new Error(
-      'usePrimerCardForm must be used within a <CardFormStateProvider>. ' +
+      'usePrimerCardForm must be used within a <PrimerCardFormProvider>. ' +
         'The built-in <PrimerCheckoutSheet>/<CheckoutFlow> wires this automatically.'
     );
   }

--- a/src/Components/hooks/usePrimerCardNetworkSelection.ts
+++ b/src/Components/hooks/usePrimerCardNetworkSelection.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { usePrimerCheckout } from './usePrimerCheckout';
 import type { CardNetworkDetails, UsePrimerCardNetworkSelectionReturn } from '../types/CardNetworkSelection';
 import type { CardNetworkId } from '../internal/cardNetwork';
-import type { PrimerCardNetwork } from '../../models/PrimerBinData';
+import type { PrimerCardNetwork as PrimerBinCardNetwork } from '../../models/PrimerBinData';
 
 const LOG = '[usePrimerCardNetworkSelection]';
 
@@ -13,13 +13,13 @@ const NON_SELECTABLE_NETWORKS = new Set<string>(['EFTPOS']);
 // A card is co-badged when the BIN resolves to at least this many networks.
 const MIN_COBADGE_NETWORKS = 2;
 
-function toCardNetwork(raw: PrimerCardNetwork): CardNetworkDetails {
+function toCardNetwork(raw: PrimerBinCardNetwork): CardNetworkDetails {
   // Native emits the closed set of CardNetworkId strings; cast is faithful to that contract.
   const identifier = raw.network as CardNetworkId;
   return {
     identifier,
     displayName: raw.displayName,
-    // `allowed` is iOS-only on PrimerCardNetwork. undefined → treat as allowed.
+    // `allowed` is iOS-only on PrimerBinCardNetwork. undefined → treat as allowed.
     logoUri: null,
     allowed: raw.allowed !== false,
     allowsUserSelection: !NON_SELECTABLE_NETWORKS.has(identifier),
@@ -34,7 +34,7 @@ export function usePrimerCardNetworkSelection(): UsePrimerCardNetworkSelectionRe
     if (!binData) {
       return [];
     }
-    const all: PrimerCardNetwork[] = binData.preferred
+    const all: PrimerBinCardNetwork[] = binData.preferred
       ? [binData.preferred, ...binData.alternatives]
       : [...binData.alternatives];
     return all.map(toCardNetwork).filter((n) => n.allowed);

--- a/src/Components/index.ts
+++ b/src/Components/index.ts
@@ -45,6 +45,7 @@ export { PrimerCheckoutSheet } from './PrimerCheckoutSheet';
 export type { PrimerCheckoutSheetProps } from './PrimerCheckoutSheet';
 export { PrimerCardForm } from './PrimerCardForm';
 export type { PrimerCardFormProps } from './types/PrimerCardFormTypes';
+export { PrimerCardFormProvider } from './internal/form-state';
 export { PrimerAcceptedCardNetworks } from './PrimerAcceptedCardNetworks';
 export type { PrimerAcceptedCardNetworksProps } from './PrimerAcceptedCardNetworks';
 export { PrimerBillingAddressForm } from './PrimerBillingAddressForm';

--- a/src/Components/inputs/PrimerCVVInput.tsx
+++ b/src/Components/inputs/PrimerCVVInput.tsx
@@ -3,14 +3,16 @@ import { Image, StyleSheet } from 'react-native';
 import { PrimerTextInput } from './PrimerTextInput';
 import { TRAILING_ICON_MARGIN, TRAILING_ICON_SIZE } from './dimensions';
 import { usePrimerLocalization } from '../internal/localization';
+import { usePrimerCardForm } from '../hooks/usePrimerCardForm';
 import type { PrimerCVVInputProps, PrimerTextInputRef } from '../types/CardInputTypes';
 
 const cvvSource = require('../../assets/images/ic-cvv-hint.png');
 
 export const PrimerCVVInput = forwardRef<PrimerTextInputRef, PrimerCVVInputProps>(function PrimerCVVInput(
-  { cardForm, placeholder, label, ...rest },
+  { placeholder, label, ...rest },
   ref
 ) {
+  const cardForm = usePrimerCardForm();
   const { t } = usePrimerLocalization();
   const resolvedLabel = label ?? t('primer_card_form_label_cvv');
   const resolvedPlaceholder = placeholder ?? t('primer_card_form_placeholder_cvv');

--- a/src/Components/inputs/PrimerCardNumberInput.tsx
+++ b/src/Components/inputs/PrimerCardNumberInput.tsx
@@ -5,6 +5,7 @@ import { caretFromDigitIndex, countDigits, countDigitsBefore, targetDigitIndex }
 import { PLACEHOLDER_ICON_HEIGHT, PLACEHOLDER_ICON_WIDTH, TRAILING_ICON_MARGIN } from './dimensions';
 import { usePrimerLocalization } from '../internal/localization';
 import { usePrimerTheme } from '../internal/theme';
+import { usePrimerCardForm } from '../hooks/usePrimerCardForm';
 import { usePrimerCardNetwork } from '../hooks/usePrimerCardNetwork';
 import { usePrimerCardNetworkSelection } from '../hooks/usePrimerCardNetworkSelection';
 import { PrimerCardNetworkSelector } from '../PrimerCardNetworkSelector';
@@ -16,7 +17,8 @@ type SelectionChangeHandler = NonNullable<TextInputProps['onSelectionChange']>;
 const placeholderSource = require('../../assets/images/ic-card-placeholder.png');
 
 export const PrimerCardNumberInput = forwardRef<PrimerTextInputRef, PrimerCardNumberInputProps>(
-  function PrimerCardNumberInput({ cardForm, placeholder, label, ...rest }, ref) {
+  function PrimerCardNumberInput({ placeholder, label, ...rest }, ref) {
+    const cardForm = usePrimerCardForm();
     const { t } = usePrimerLocalization();
     const resolvedLabel = label ?? t('primer_card_form_label_number');
     const resolvedPlaceholder = placeholder ?? t('primer_card_form_placeholder_number');

--- a/src/Components/inputs/PrimerCardholderNameInput.tsx
+++ b/src/Components/inputs/PrimerCardholderNameInput.tsx
@@ -1,10 +1,12 @@
 import { forwardRef } from 'react';
 import { PrimerTextInput } from './PrimerTextInput';
 import { usePrimerLocalization } from '../internal/localization';
+import { usePrimerCardForm } from '../hooks/usePrimerCardForm';
 import type { PrimerCardholderNameInputProps, PrimerTextInputRef } from '../types/CardInputTypes';
 
 export const PrimerCardholderNameInput = forwardRef<PrimerTextInputRef, PrimerCardholderNameInputProps>(
-  function PrimerCardholderNameInput({ cardForm, placeholder, label, ...rest }, ref) {
+  function PrimerCardholderNameInput({ placeholder, label, ...rest }, ref) {
+    const cardForm = usePrimerCardForm();
     const { t } = usePrimerLocalization();
     const resolvedLabel = label ?? t('primer_card_form_label_name');
     const resolvedPlaceholder = placeholder ?? t('primer_card_form_placeholder_name');

--- a/src/Components/inputs/PrimerExpiryDateInput.tsx
+++ b/src/Components/inputs/PrimerExpiryDateInput.tsx
@@ -4,6 +4,7 @@ import { PrimerTextInput } from './PrimerTextInput';
 import { caretFromDigitIndex, countDigits, countDigitsBefore, targetDigitIndex } from './caret';
 import { TRAILING_ICON_MARGIN, TRAILING_ICON_SIZE } from './dimensions';
 import { usePrimerLocalization } from '../internal/localization';
+import { usePrimerCardForm } from '../hooks/usePrimerCardForm';
 import type { PrimerExpiryDateInputProps, PrimerTextInputRef } from '../types/CardInputTypes';
 
 type SelectionChangeHandler = NonNullable<TextInputProps['onSelectionChange']>;
@@ -11,7 +12,8 @@ type SelectionChangeHandler = NonNullable<TextInputProps['onSelectionChange']>;
 const calendarSource = require('../../assets/images/ic-expiry-calendar.png');
 
 export const PrimerExpiryDateInput = forwardRef<PrimerTextInputRef, PrimerExpiryDateInputProps>(
-  function PrimerExpiryDateInput({ cardForm, placeholder, label, ...rest }, ref) {
+  function PrimerExpiryDateInput({ placeholder, label, ...rest }, ref) {
+    const cardForm = usePrimerCardForm();
     const { t } = usePrimerLocalization();
     const resolvedLabel = label ?? t('primer_card_form_label_expiry');
     const resolvedPlaceholder = placeholder ?? t('primer_card_form_placeholder_expiry');

--- a/src/Components/internal/checkout-flow/CheckoutFlow.tsx
+++ b/src/Components/internal/checkout-flow/CheckoutFlow.tsx
@@ -12,7 +12,7 @@ import { CountrySelectorScreen } from '../screens/CountrySelectorScreen';
 import { ErrorScreen } from '../screens/ErrorScreen';
 import { SuccessScreen } from '../screens/SuccessScreen';
 import { VaultedMethodsScreen } from '../screens/VaultedMethodsScreen';
-import { CardFormStateProvider, BillingAddressFormStateProvider } from '../form-state';
+import { PrimerCardFormProvider, BillingAddressFormStateProvider } from '../form-state';
 import { CheckoutFlowContext } from './CheckoutFlowContext';
 
 const SUCCESS_AUTO_DISMISS_MS = 3000;
@@ -113,11 +113,11 @@ export function CheckoutFlow({ onCancel }: CheckoutFlowProps = {}) {
       <NavigationProvider initialRoute={CheckoutRoute.splash}>
         <ReadinessTransitioner />
         <PaymentOutcomeTransitioner />
-        <CardFormStateProvider>
+        <PrimerCardFormProvider>
           <BillingAddressFormStateProvider>
             <NavigationContainer screenMap={screenMap} />
           </BillingAddressFormStateProvider>
-        </CardFormStateProvider>
+        </PrimerCardFormProvider>
       </NavigationProvider>
     </CheckoutFlowContext.Provider>
   );

--- a/src/Components/internal/form-state/CardFormStateProvider.tsx
+++ b/src/Components/internal/form-state/CardFormStateProvider.tsx
@@ -60,7 +60,7 @@ const CardFormStateContext = createContext<UsePrimerCardFormReturn | null>(null)
  * `setRawData` / `submit` dispatch surfaces, so it must mount below
  * `PrimerCheckoutProvider`.
  */
-export function CardFormStateProvider({ children }: { children: ReactNode }) {
+export function PrimerCardFormProvider({ children }: { children: ReactNode }) {
   const {
     isReady,
     activeMethod,

--- a/src/Components/internal/form-state/index.ts
+++ b/src/Components/internal/form-state/index.ts
@@ -1,2 +1,2 @@
-export { CardFormStateProvider, useCardFormStateContext } from './CardFormStateProvider';
+export { PrimerCardFormProvider, useCardFormStateContext } from './CardFormStateProvider';
 export { BillingAddressFormStateProvider, useBillingAddressFormStateContext } from './BillingAddressFormStateProvider';

--- a/src/Components/internal/screens/CardFormScreen.tsx
+++ b/src/Components/internal/screens/CardFormScreen.tsx
@@ -104,7 +104,7 @@ export function CardFormScreen() {
         showsVerticalScrollIndicator={false}
         onContentSizeChange={(_, h) => setScrollContentHeight(h)}
       >
-        <PrimerCardForm cardForm={cardForm} autoFocus onSubmit={handlePay} />
+        <PrimerCardForm autoFocus onSubmit={handlePay} />
         {billingForm.sectionVisible && (
           <>
             <View style={styles.divider} />

--- a/src/Components/types/CardInputTypes.ts
+++ b/src/Components/types/CardInputTypes.ts
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react';
 import type { KeyboardTypeOptions, StyleProp, TextInputProps, TextStyle, ViewStyle } from 'react-native';
-import type { UsePrimerCardFormReturn } from './CardFormTypes';
 
 export interface PrimerTextInputTheme {
   primaryColor?: string;
@@ -69,7 +68,6 @@ export interface PrimerTextInputRef {
 }
 
 export interface PrimerCardInputProps {
-  cardForm: UsePrimerCardFormReturn;
   theme?: PrimerTextInputTheme;
   editable?: boolean;
   label?: string;

--- a/src/Components/types/PrimerCardFormTypes.ts
+++ b/src/Components/types/PrimerCardFormTypes.ts
@@ -1,14 +1,7 @@
 import type { StyleProp, ViewStyle } from 'react-native';
-import type { UsePrimerCardFormReturn } from './CardFormTypes';
 
 /** Merchant-facing props for the composed `<PrimerCardForm />` component. */
 export interface PrimerCardFormProps {
-  /**
-   * The card-form state returned by `usePrimerCardForm()`. Hoisted so the host screen
-   * can share it with a Pay button rendered outside the form, compose sibling
-   * sections that rely on the same state (e.g. billing address), and drive submit.
-   */
-  cardForm: UsePrimerCardFormReturn;
   /**
    * Fires when the user hits the return key on the last input. The host screen
    * typically routes this to the same handler that its Pay button uses.

--- a/src/__tests__/components/cardFormContracts.test.tsx
+++ b/src/__tests__/components/cardFormContracts.test.tsx
@@ -1,9 +1,11 @@
 /**
- * Contract test for the Checkout Components public API naming
+ * Contract tests for the card-form public API refinement
  * (specs/002-components-customization-api/contracts/public-api.md).
  *
- *   C1 — every public component / hook carries the `Primer` / `usePrimer` prefix,
- *        and the pre-rename names are gone from the public barrels.
+ *   C1 — every public card-form symbol carries the `Primer` / `usePrimer` prefix.
+ *   C4 — a card input rendered outside `PrimerCardFormProvider` throws a descriptive error.
+ *   C5 — no public Tier 1–3 path surfaces raw card field values to caller code
+ *        (inputs accept no value-emitting prop; values flow only via `usePrimerCardForm`).
  */
 import { readFileSync } from 'fs';
 import { join } from 'path';
@@ -33,14 +35,19 @@ function valueExports(source: string): string[] {
   return names;
 }
 
-describe('C1: public components and hooks are Primer-prefixed', () => {
+// ---------------------------------------------------------------------------
+// C1 — naming (FR-001 / SC-002)
+// ---------------------------------------------------------------------------
+describe('C1: card-form public exports are Primer-prefixed', () => {
   const rootBarrel = readSource('index.tsx');
   const componentsBarrel = readSource('Components/index.ts');
   const rootExports = valueExports(rootBarrel);
   const componentsExports = valueExports(componentsBarrel);
 
+  // The renamed public card-form value surface (components + hooks).
   const expectedComponentsBarrel = [
     'PrimerCardForm',
+    'PrimerCardFormProvider',
     'PrimerCardNumberInput',
     'PrimerExpiryDateInput',
     'PrimerCVVInput',
@@ -60,12 +67,7 @@ describe('C1: public components and hooks are Primer-prefixed', () => {
     expect(name).toMatch(/^(Primer|usePrimer)/);
   });
 
-  it.each(['usePrimerTheme', 'usePrimerLocalization'])('root barrel exports %s (prefixed)', (name) => {
-    expect(rootExports).toContain(name);
-    expect(name).toMatch(/^(Primer|usePrimer)/);
-  });
-
-  // Pre-rename names and unexported internals — must not survive in either barrel.
+  // Names the rename removed — must not survive in either barrel.
   const forbidden = [
     'useCardForm',
     'useCardNetwork',
@@ -75,6 +77,7 @@ describe('C1: public components and hooks are Primer-prefixed', () => {
     'ExpiryDateInput',
     'CVVInput',
     'CardholderNameInput',
+    'CardFormStateProvider',
     'usePaymentMethods',
     'useBillingAddressForm',
     'useVaultedPaymentMethods',
@@ -93,8 +96,64 @@ describe('C1: public components and hooks are Primer-prefixed', () => {
     'hasLocale',
   ];
 
-  it.each(forbidden)('no barrel re-exports %s', (name) => {
-    const hit = [...rootExports, ...componentsExports].some((e) => e === name);
+  it.each(forbidden)('no barrel re-exports the unprefixed %s', (name) => {
+    const wordBoundary = new RegExp(`\\b${name}\\b`);
+    // The renamed component value-exports must not appear unprefixed. Allow
+    // `CardFormErrors` / `CardFormField` style siblings by checking exact words.
+    const hit = [...rootExports, ...componentsExports].some((e) => wordBoundary.test(e) && e === name);
     expect(hit).toBe(false);
+  });
+
+  it.each(['usePrimerTheme', 'usePrimerLocalization'])('root barrel exports %s (prefixed)', (name) => {
+    expect(rootExports).toContain(name);
+    expect(name).toMatch(/^(Primer|usePrimer)/);
+  });
+
+  it('every card-form value export in the root barrel is prefixed', () => {
+    const cardFormish = rootExports.filter((n) =>
+      /(CardForm|CardNumberInput|ExpiryDateInput|CVVInput|CardholderNameInput|CardNetworkSelector)$/.test(n)
+    );
+    for (const name of cardFormish) {
+      expect(name).toMatch(/^(Primer|usePrimer)/);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C5 — PCI: inputs expose no value-emitting prop (FR-007 / SC-004)
+// ---------------------------------------------------------------------------
+describe('C5: card inputs surface no raw field values to callers', () => {
+  const cardInputTypes = readSource('Components/types/CardInputTypes.ts');
+
+  // The shared input prop type after the refinement.
+  const propsBody = /export interface PrimerCardInputProps \{([\s\S]*?)\n\}/.exec(cardInputTypes)?.[1] ?? '';
+
+  it('PrimerCardInputProps exists', () => {
+    expect(propsBody).not.toBe('');
+  });
+
+  // A value-emitting prop would let caller code read raw PAN/CVV/etc. None allowed.
+  it.each(['value', 'onChangeText', 'onChange', 'cardForm', 'binData'])(
+    'PrimerCardInputProps has no `%s` member',
+    (member) => {
+      expect(propsBody).not.toMatch(new RegExp(`\\b${member}\\b\\s*[?:]`));
+    }
+  );
+
+  it('the four input components receive no value/onChangeText prop', () => {
+    for (const file of [
+      'Components/inputs/PrimerCardNumberInput.tsx',
+      'Components/inputs/PrimerExpiryDateInput.tsx',
+      'Components/inputs/PrimerCVVInput.tsx',
+      'Components/inputs/PrimerCardholderNameInput.tsx',
+    ]) {
+      const src = readSource(file);
+      // Destructured props must not include a `cardForm` / `value` prop — state
+      // comes from `usePrimerCardForm()` context, not from the caller.
+      const propsDestructure = /function\s+\w+\(\s*\{([^}]*)\}/.exec(src)?.[1] ?? '';
+      expect(propsDestructure).not.toMatch(/\bcardForm\b/);
+      expect(propsDestructure).not.toMatch(/\bvalue\b/);
+      expect(src).toMatch(/usePrimerCardForm\(\)/);
+    }
   });
 });

--- a/src/__tests__/components/cardInputGuard.test.tsx
+++ b/src/__tests__/components/cardInputGuard.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * Contract test C4 (FR-006 / SC-006): a prefixed card input rendered with no
+ * `PrimerCardFormProvider` ancestor throws a descriptive error that names the
+ * provider. The guard lives in `usePrimerCardForm()`, which every input calls.
+ *
+ * `PrimerCardholderNameInput` is used because it pulls in no image assets — its
+ * module graph loads under the react-native mock without an asset transform.
+ */
+
+// @ts-expect-error -- React 19 concurrent act environment
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('../../specs/NativePrimer', () => ({ __esModule: true, default: {} }), { virtual: true });
+
+jest.mock(
+  'react-native',
+  () => ({
+    NativeModules: {},
+    NativeEventEmitter: jest.fn().mockImplementation(() => ({
+      addListener: jest.fn(() => ({ remove: jest.fn() })),
+      removeAllListeners: jest.fn(),
+    })),
+    StyleSheet: { create: (s: unknown) => s, hairlineWidth: 1 },
+    Platform: { OS: 'ios', select: (o: { ios: unknown }) => o.ios },
+    Image: 'Image',
+    View: 'View',
+    Text: 'Text',
+    TextInput: 'TextInput',
+    Pressable: 'Pressable',
+  }),
+  { virtual: true }
+);
+
+import { createElement } from 'react';
+// @ts-expect-error -- react-test-renderer has no types for React 19
+import { act, create } from 'react-test-renderer';
+import { PrimerCardholderNameInput } from '../../Components/inputs/PrimerCardholderNameInput';
+
+describe('C4: card input outside PrimerCardFormProvider', () => {
+  it('throws an error that names PrimerCardFormProvider', () => {
+    // Silence React's render-error console noise for the expected throw.
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(() => {
+        act(() => {
+          create(createElement(PrimerCardholderNameInput));
+        });
+      }).toThrow(/PrimerCardFormProvider/);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/src/__tests__/components/hooks/usePrimerCardForm.test.tsx
+++ b/src/__tests__/components/hooks/usePrimerCardForm.test.tsx
@@ -2,7 +2,7 @@ import { createElement, type ReactNode } from 'react';
 // @ts-expect-error -- react-test-renderer has no types for React 19
 import { act, create } from 'react-test-renderer';
 import { PrimerCheckoutContext } from '../../../Components/internal/PrimerCheckoutContext';
-import { CardFormStateProvider } from '../../../Components/internal/form-state/CardFormStateProvider';
+import { PrimerCardFormProvider } from '../../../Components/internal/form-state/CardFormStateProvider';
 import { usePrimerCardForm } from '../../../Components/hooks/usePrimerCardForm';
 import type { CardNetworkDescriptor } from '../../../Components/internal/cardNetwork';
 import type { PrimerCheckoutContextValue } from '../../../Components/types/PrimerCheckoutProviderTypes';
@@ -73,7 +73,7 @@ function withErrors(errors: CardFormErrors): PrimerCheckoutContextValue {
 
 function contextWrapper(value: PrimerCheckoutContextValue) {
   return ({ children }: { children: ReactNode }) =>
-    createElement(PrimerCheckoutContext.Provider, { value }, createElement(CardFormStateProvider, null, children));
+    createElement(PrimerCheckoutContext.Provider, { value }, createElement(PrimerCardFormProvider, null, children));
 }
 
 function renderHook<T>(hook: () => T, Wrapper: (props: { children: ReactNode }) => ReactNode) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -133,6 +133,8 @@ export type { NamedComponentValidatableData };
 export { PrimerCheckoutProvider } from './Components';
 export { usePrimerCheckout } from './Components';
 export { usePrimerPaymentMethods } from './Components';
+export { usePrimerVaultManager } from './Components';
+export type { VaultedPaymentMethodItem, UsePrimerVaultManagerReturn } from './Components';
 export type {
   PrimerCheckoutProviderProps,
   PrimerCheckoutContextValue,
@@ -146,15 +148,13 @@ export type {
   UsePrimerPaymentMethodsReturn,
 } from './Components';
 export { usePrimerCardForm } from './Components';
+export type { UseCardFormOptions, UsePrimerCardFormReturn, CardFormErrors, CardFormField } from './Components';
 export { usePrimerCardNetwork } from './Components';
 export type { UseCardNetworkReturn } from './Components';
 export { usePrimerCardNetworkSelection } from './Components';
 export type { CardNetworkDetails, CardNetworkId, UsePrimerCardNetworkSelectionReturn } from './Components';
 export { PrimerCardNetworkSelector } from './Components';
 export type { PrimerCardNetworkSelectorProps } from './Components';
-export { usePrimerVaultManager } from './Components';
-export type { VaultedPaymentMethodItem, UsePrimerVaultManagerReturn } from './Components';
-export type { UseCardFormOptions, UsePrimerCardFormReturn, CardFormErrors, CardFormField } from './Components';
 export { usePrimerBillingAddressForm } from './Components';
 export type {
   UsePrimerBillingAddressFormOptions,
@@ -169,6 +169,7 @@ export { PrimerCheckoutSheet } from './Components';
 export type { PrimerCheckoutSheetProps } from './Components';
 export { PrimerCardForm } from './Components';
 export type { PrimerCardFormProps } from './Components';
+export { PrimerCardFormProvider } from './Components';
 export { PrimerAcceptedCardNetworks } from './Components';
 export type { PrimerAcceptedCardNetworksProps } from './Components';
 export { PrimerBillingAddressForm } from './Components';


### PR DESCRIPTION
## Summary
Replaces card-form prop-drilling with context. `PrimerCardFormProvider` creates and owns the form instance (field state, formatting, validation lifecycle, submit); the four inputs read it from context and no longer take a `cardForm` prop (`PrimerCardInputProps` drops the field). `usePrimerCardForm()` reads the same context for custom pay buttons / custom UI. The prebuilt `PrimerCardForm` becomes the provider plus the default input arrangement.

Rendering an input outside the provider throws a descriptive error naming `PrimerCardFormProvider` (tested). Inputs stay opaque — no value-emitting props — preserving the future secure-mode option.

## Merge gate
ADR (in review): https://app.notion.com/p/377ca65dc30e81de958bdc3bb2b887b8 — merge only after approval.

## Stacked on
#381 (naming). Followed by the example gallery PR.

## Jira
https://primerapi.atlassian.net/browse/ORC-6924

## Test plan
- `tsc` clean; `jest src/__tests__/components` green
- C4 (outside-provider guard) and C5 (no raw-value props on inputs) contract tests
