### PR TITLE
feat: add PayPal to Checkout Components native-UI payments (ORC-6513)

### DIFF
--- a/src/__tests__/components/usePrimerPaymentMethod.test.tsx
+++ b/src/__tests__/components/usePrimerPaymentMethod.test.tsx
@@ -288,4 +288,36 @@ describe('usePrimerPaymentMethod', () => {
       expect(nativeUiManager.showPaymentMethod).not.toHaveBeenCalled();
     });
   });
+
+  describe('PayPal (nativeUi) — both platforms, no gate', () => {
+    it('routes a NATIVE_UI PayPal method to kind "nativeUi"', async () => {
+      const captures = await mountWithMethods([{ paymentMethodType: 'PAYPAL' }], 'PAYPAL');
+      expect(captures[captures.length - 1]!.kind).toBe('nativeUi');
+    });
+
+    it('isAvailable is true on Android when PAYPAL is listed', async () => {
+      const captures = await mountWithMethods([{ paymentMethodType: 'PAYPAL' }], 'PAYPAL');
+      const last = asNativeUi(captures[captures.length - 1]!);
+      expect(last.isAvailable).toBe(true);
+      expect(last.availabilityError).toBeNull();
+    });
+
+    it('isAvailable is also true on iOS when PAYPAL is listed (unlike Google/Apple Pay, no platform gate)', async () => {
+      rnMock.Platform.OS = 'ios';
+      const captures = await mountWithMethods([{ paymentMethodType: 'PAYPAL' }], 'PAYPAL');
+      const last = asNativeUi(captures[captures.length - 1]!);
+      expect(last.isAvailable).toBe(true);
+      expect(last.availabilityError).toBeNull();
+    });
+
+    it('start configures and shows PAYPAL when available', async () => {
+      const captures = await mountWithMethods([{ paymentMethodType: 'PAYPAL' }], 'PAYPAL');
+      const ctrl = asNativeUi(captures[captures.length - 1]!);
+      await act(async () => {
+        await ctrl.start();
+      });
+      expect(nativeUiManager.configure).toHaveBeenCalledWith('PAYPAL');
+      expect(nativeUiManager.showPaymentMethod).toHaveBeenCalledWith('CHECKOUT');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

PayPal flows through the generic **`usePrimerPaymentMethod('PAYPAL')`** — no bespoke `usePayPal` hook. Third step of the APM hook unification (after Google Pay #376, Apple Pay #374).

Because PayPal is a both-platform `NATIVE_UI` method with plain list-membership availability, it needs **zero method-specific code** — the foundation's generic hook + `startNativeUI` already drive it. So this PR is the unification paying off: the bespoke `usePayPal` is removed and PayPal rides the same path as every other native-UI method. The diff is just the test coverage proving it.

- `usePrimerPaymentMethod('PAYPAL')` → `kind: 'nativeUi'`; `start()` → `startNativeUI('PAYPAL')` → the native Headless SDK opens the PayPal approval browser; outcome arrives on the shared `paymentOutcome`.
- Available on both iOS and Android whenever PayPal is in the session — no platform guard (unlike Google/Apple Pay).
- Renders as a standard method row (no dedicated native button).

## Breaking change

`usePayPal` and the `PayPalController` / `PayPalAvailabilityError` types are removed — use `usePrimerPaymentMethod('PAYPAL')` and narrow on `kind: 'nativeUi'`.

## Base

`ov/feat/ACC-6923-apple-pay-component` (#374).

## Jira

[ORC-6513](https://primerapi.atlassian.net/browse/ORC-6513)

## Test plan

- [x] `yarn typecheck` / `yarn lint` — clean
- [x] `yarn jest` — green; new `usePrimerPaymentMethod` PayPal cases (routes to `nativeUi`; available on both platforms when listed; `start()` configures/shows `PAYPAL`)
- [x] Manual Android — PayPal → approval browser → `onCheckoutComplete` (sandbox payment succeeded)
- [x] Manual iOS — PayPal → approval browser → `onCheckoutComplete` (sandbox payment succeeded)


[ORC-6513]: https://primerapi.atlassian.net/browse/ORC-6513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ