### PR TITLE
feat(components): route web-redirect categories + shared provider plumbing (ORC-6514)

### DIFF
--- a/src/Components/internal/routeMethodSelection.ts
+++ b/src/Components/internal/routeMethodSelection.ts
@@ -1,4 +1,5 @@
 import type { UsePrimerPaymentMethodReturn } from '../types/PrimerPaymentMethodTypes';
+import type { PrimerPaymentMethodManagerCategoryName } from '../../models/PrimerHeadlessUniversalCheckoutPaymentMethod';
 
 /**
  * How a payment method is driven, decided by **manager category** (mirrors RN Headless), not by
@@ -17,7 +18,10 @@ export type PaymentMethodKind = UsePrimerPaymentMethodReturn['kind'];
 
 const PAYMENT_CARD_TYPE = 'PAYMENT_CARD';
 
-export function routeMethodSelection(type: string, categories: readonly string[]): PaymentMethodKind {
+export function routeMethodSelection(
+  type: string,
+  categories: readonly PrimerPaymentMethodManagerCategoryName[]
+): PaymentMethodKind {
   if (type === PAYMENT_CARD_TYPE) {
     return 'card';
   }

--- a/src/Components/internal/screens/MethodSelectionScreen.tsx
+++ b/src/Components/internal/screens/MethodSelectionScreen.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
+import { PrimerError } from '../../../models/PrimerError';
 import { PrimerAnalytics } from '../../analytics';
 import { usePrimerPaymentMethods } from '../../hooks/usePrimerPaymentMethods';
 import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
@@ -12,6 +13,7 @@ import { usePrimerLocalization } from '../localization';
 import { NavigationHeader } from '../navigation/NavigationHeader';
 import { CheckoutRoute } from '../navigation/types';
 import { useNavigation } from '../navigation/useNavigation';
+import { routeMethodSelection } from '../routeMethodSelection';
 import { usePrimerTheme } from '../theme';
 import { CheckoutButton } from '../ui/CheckoutButton';
 import { PAYMENT_METHOD_BUTTON_HEIGHT } from '../ui/PaymentMethodButton';
@@ -104,21 +106,34 @@ export function MethodSelectionScreen() {
   useStatusScreenHeight(sheetHeight);
 
   const handleSelect = (method: PaymentMethodItem) => {
-    // Route by manager category (mirrors RN Headless), not by payment-method type.
-    if (method.categories.includes('NATIVE_UI')) {
-      // Jump to processing (same as the card form's Pay) so the shopper sees a spinner — not the
-      // method list — when the native sheet closes; PaymentOutcomeTransitioner navigates away once
-      // the outcome arrives.
-      replace(CheckoutRoute.processing);
-      void startNativeUI(method.type).catch(() => {});
-      return;
+    // Route through the shared classifier (the same map the hook uses), so a new kind can't be
+    // wired into one path and silently missed in the other.
+    const kind = routeMethodSelection(method.type, method.categories);
+    switch (kind) {
+      case 'nativeUi':
+        // Jump to processing (same as the card form's Pay) so the shopper sees a spinner — not the
+        // method list — while the native sheet animates; PaymentOutcomeTransitioner navigates away
+        // once the outcome arrives. If start() rejects (e.g. an unavailable method the SDK still
+        // lists, like Google Pay on iOS), show the error screen instead of stranding the shopper on
+        // the spinner.
+        replace(CheckoutRoute.processing);
+        void startNativeUI(method.type).catch((e) => {
+          replace(CheckoutRoute.error, { error: e instanceof PrimerError ? e : undefined });
+        });
+        return;
+      case 'card':
+        setActiveMethod(method.type);
+        push(CheckoutRoute.cardForm, { paymentMethodType: method.type });
+        return;
+      case 'unsupported':
+        console.warn(`${LOG} payment method ${method.type} not yet wired`);
+        return;
+      default: {
+        // A new union kind must add a case above, or this fails to compile.
+        const _exhaustive: never = kind;
+        void _exhaustive;
+      }
     }
-    if (method.categories.includes('RAW_DATA')) {
-      setActiveMethod(method.type);
-      push(CheckoutRoute.cardForm, { paymentMethodType: method.type });
-      return;
-    }
-    console.warn(`${LOG} payment method ${method.type} not yet wired`);
   };
 
   const handleShowAll = useCallback(() => {

--- a/src/__tests__/components/routeMethodSelection.test.ts
+++ b/src/__tests__/components/routeMethodSelection.test.ts
@@ -1,0 +1,25 @@
+import { routeMethodSelection } from '../../Components/internal/routeMethodSelection';
+
+// The classifier is load-bearing for both `usePrimerPaymentMethod` and `MethodSelectionScreen`,
+// so the two route a method the same way. Categories mirror RN Headless manager categories.
+describe('routeMethodSelection', () => {
+  it('routes PAYMENT_CARD to card (by type, regardless of category)', () => {
+    expect(routeMethodSelection('PAYMENT_CARD', ['RAW_DATA'])).toBe('card');
+  });
+
+  it('routes a NATIVE_UI method to nativeUi', () => {
+    expect(routeMethodSelection('GOOGLE_PAY', ['NATIVE_UI'])).toBe('nativeUi');
+  });
+
+  it('routes a non-card RAW_DATA method to card for now (the rawDataForm split lands in #389)', () => {
+    expect(routeMethodSelection('ADYEN_BANCONTACT_CARD', ['RAW_DATA'])).toBe('card');
+  });
+
+  it('returns unsupported for a category that is not yet routed', () => {
+    expect(routeMethodSelection('SOME_FUTURE_METHOD', ['CARD_COMPONENTS'])).toBe('unsupported');
+  });
+
+  it('returns unsupported when the method is absent from the session (no categories)', () => {
+    expect(routeMethodSelection('GOOGLE_PAY', [])).toBe('unsupported');
+  });
+});


### PR DESCRIPTION
## Summary

Foundational cleanup of the deferred #376-review items — no new payment methods. This is the "verify" PR in the APM-unification stack (after Google Pay #376, Apple Pay #374, PayPal #385). It hardens how the prebuilt method list routes a tapped method and stops a native-UI failure from stranding the shopper.

The original ORC-6514 bank/QR/raw-data provider plumbing is **not** here — it moves into the PRs that actually consume it (#387 banks, #389 forms, #390 QR). On the reset stack those screens don't exist yet, so building the plumbing now would be dead code routing nowhere.

## What changed

- **Stuck native-UI screen** — when a native-UI `start()` rejects (e.g. an unavailable method the SDK still lists), `MethodSelectionScreen` used to swallow the error and leave the shopper on the processing spinner with no way back. It now navigates to the error screen.
- **One routing classifier** — `MethodSelectionScreen` routes through the shared `routeMethodSelection` (the same map `usePrimerPaymentMethod` uses), with an exhaustiveness check. A new `kind` can no longer be wired into the hook and silently missed by the screen.
- **Typed category param** — `routeMethodSelection(type, categories)` takes `PrimerPaymentMethodManagerCategoryName[]` instead of `string[]`.
- **Union stays flat** — the `usePrimerPaymentMethod` return union keeps three distinct variants with no shared base. They genuinely diverge (`unsupported` is `isAvailable` only; `card` has no outcome/cancel; `nativeUi` has both plus `cancel`), so a base would force optional fields and weaken the discriminated union. Revisit only if it fragments at 6+ variants.

Routing behavior is otherwise unchanged — PAYMENT_CARD and other RAW_DATA methods still open the card form (the non-card RAW_DATA split lands in #389).

## Not a breaking change

Internal only — no public hook, component, or type is added, removed, or changed.

## Base

`ov/feat/ORC-6513-native-ui-payments` (#385).

## Jira

[ORC-6514](https://primerapi.atlassian.net/browse/ORC-6514)

## Test plan

- [x] `yarn typecheck` / `yarn lint` — clean
- [x] `yarn jest` — green bar the known tr_TR localization flake; new `routeMethodSelection.test.ts`
- [x] Manual iOS — PayPal (native-UI) and card both route and complete as before (routing-consolidation is behavior-preserving)
- [x] Stuck-screen fix is a defensive catch on the start()-reject path; not reproducible in the sandbox (no unavailable native-UI method is listed there)


[ORC-6514]: https://primerapi.atlassian.net/browse/ORC-6514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ