### PR TITLE
feat(components): pure web-redirect APMs, Twint/Sofort (ORC-6514)

### DIFF
--- a/src/__tests__/components/routeMethodSelection.test.ts
+++ b/src/__tests__/components/routeMethodSelection.test.ts
@@ -16,6 +16,11 @@ describe('routeMethodSelection', () => {
     expect(routeMethodSelection('ADYEN_DOTPAY', ['COMPONENT_WITH_REDIRECT'])).toBe('bankSelection');
   });
 
+  it('routes pure-redirect NATIVE_UI APMs (Twint/Sofort) to nativeUi', () => {
+    expect(routeMethodSelection('ADYEN_TWINT', ['NATIVE_UI'])).toBe('nativeUi');
+    expect(routeMethodSelection('ADYEN_SOFORT', ['NATIVE_UI'])).toBe('nativeUi');
+  });
+
   it('routes a non-card RAW_DATA method to card for now (the rawDataForm split lands in #389)', () => {
     expect(routeMethodSelection('ADYEN_BANCONTACT_CARD', ['RAW_DATA'])).toBe('card');
   });

--- a/src/__tests__/components/usePrimerPaymentMethod.test.tsx
+++ b/src/__tests__/components/usePrimerPaymentMethod.test.tsx
@@ -29,6 +29,20 @@ jest.mock(
           onBankSelected: jest.fn(),
           onBankFilterChange: jest.fn(),
         },
+        // Provider init effects touch these — mock them so init resolves cleanly instead of
+        // throwing async (unhandled rejections otherwise leak across parallel test suites).
+        RNTPrimerHeadlessUniversalCheckoutAssetsManager: {
+          getPaymentMethodResources: jest.fn().mockResolvedValue({ paymentMethodResources: [] }),
+          getPaymentMethodResource: jest.fn().mockResolvedValue({ paymentMethodResource: null }),
+          getOrderedAllowedCardNetworks: jest.fn().mockResolvedValue([]),
+          getCardNetworkImage: jest.fn().mockResolvedValue({}),
+          getCardNetworkTraits: jest.fn().mockResolvedValue({}),
+        },
+        RNPrimerHeadlessUniversalCheckoutVaultManager: {
+          configure: jest.fn().mockResolvedValue(undefined),
+          fetchVaultedPaymentMethods: jest.fn().mockResolvedValue({ paymentMethods: [] }),
+          requiresVaultedCardCvv: jest.fn().mockResolvedValue(false),
+        },
       },
       NativeEventEmitter: jest.fn().mockImplementation(() => ({
         addListener: mockAddListener,
@@ -398,6 +412,40 @@ describe('usePrimerPaymentMethod', () => {
         await asBankSelection(captures[captures.length - 1]!).submit();
       });
       expect(banksNative.submit).toHaveBeenCalled();
+    });
+  });
+
+  describe('web-redirect APMs (Twint/Sofort) — both platforms, no gate', () => {
+    it('routes a NATIVE_UI web-redirect method (Twint) to kind "nativeUi"', async () => {
+      const captures = await mountWithMethods([{ paymentMethodType: 'ADYEN_TWINT' }], 'ADYEN_TWINT');
+      expect(captures[captures.length - 1]!.kind).toBe('nativeUi');
+    });
+
+    it('Twint is available on both platforms when listed (no platform gate)', async () => {
+      const android = await mountWithMethods([{ paymentMethodType: 'ADYEN_TWINT' }], 'ADYEN_TWINT');
+      expect(asNativeUi(android[android.length - 1]!).isAvailable).toBe(true);
+      rnMock.Platform.OS = 'ios';
+      const ios = await mountWithMethods([{ paymentMethodType: 'ADYEN_TWINT' }], 'ADYEN_TWINT');
+      const last = asNativeUi(ios[ios.length - 1]!);
+      expect(last.isAvailable).toBe(true);
+      expect(last.availabilityError).toBeNull();
+    });
+
+    it('start configures and shows the tapped method (Twint)', async () => {
+      const captures = await mountWithMethods([{ paymentMethodType: 'ADYEN_TWINT' }], 'ADYEN_TWINT');
+      const ctrl = asNativeUi(captures[captures.length - 1]!);
+      await act(async () => {
+        await ctrl.start();
+      });
+      expect(nativeUiManager.configure).toHaveBeenCalledWith('ADYEN_TWINT');
+      expect(nativeUiManager.showPaymentMethod).toHaveBeenCalledWith('CHECKOUT');
+    });
+
+    it('Sofort rides the same path — routes to nativeUi and is available when listed', async () => {
+      const captures = await mountWithMethods([{ paymentMethodType: 'ADYEN_SOFORT' }], 'ADYEN_SOFORT');
+      const last = asNativeUi(captures[captures.length - 1]!);
+      expect(last.kind).toBe('nativeUi');
+      expect(last.isAvailable).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

Pure web-redirect APMs (Twint, Sofort) now flow through the generic **`usePrimerPaymentMethod(type)`** — narrow on `kind: 'nativeUi'`. Sixth step of the APM hook unification (after Google Pay #376, Apple Pay #374, PayPal #385, foundational #386, banks #387).

Like PayPal, these come **for free**: Twint/Sofort are pure `NATIVE_UI` redirect methods with list-membership availability (both platforms, no device gate), which the foundation's generic `nativeUi` variant already drives. So the bespoke `usePrimerWebRedirect` hook + `WebRedirect*` types are removed and the methods ride the same path as every other native-UI method. The diff is the test coverage proving it.

- `usePrimerPaymentMethod('ADYEN_TWINT')` → `kind: 'nativeUi'`; `start()` → `startNativeUI('ADYEN_TWINT')` → the native SDK opens the redirect browser; outcome on the shared `paymentOutcome`.
- Available on both iOS and Android whenever the method is in the session — no platform guard.
- Renders as a standard method row (no dedicated button).

## Breaking change

`usePrimerWebRedirect` and the `WebRedirectController` / `WebRedirectAvailabilityError` types are removed — use `usePrimerPaymentMethod(type)` and narrow on `kind: 'nativeUi'`.

## Base

`ov/feat/ORC-6514-banks` (#387).

## Jira

[ORC-6514](https://primerapi.atlassian.net/browse/ORC-6514)

## Test plan

- [x] `yarn typecheck` / `yarn lint` — clean
- [x] `yarn jest` — green bar the known tr_TR localization flake; new web-redirect cases (Twint/Sofort route to `nativeUi`; available on both platforms when listed; `start()` configures/shows) + a `routeMethodSelection` case
- [x] Manual Twint — iOS + Android: method row → redirect browser → `onCheckoutComplete` (sandbox payment succeeded). The error path was exercised too on iOS — a user cancel and a sandbox-FAILED payment both routed to the error screen, and the retry completed successfully.
- [ ] Sofort — not device-run (the demo merchant doesn't surface it). Covered by parity (identical `NATIVE_UI` path as Twint) + the `ADYEN_SOFORT → nativeUi` unit test.

Test-only note: the hook test gained AssetsManager/VaultManager native-module mocks so the provider's init effects resolve cleanly — without them the extra provider mounts leaked async rejections into sibling suites under parallel jest.


[ORC-6514]: https://primerapi.atlassian.net/browse/ORC-6514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ