### PR TITLE
feat: raw-data form methods + BLIK OTP bridge — Bancontact/MBWay/BLIK (ORC-6514)

### DIFF
--- a/android/src/main/java/com/primerioreactnative/components/datamodels/core/PrimerRawPaymentMethodType.kt
+++ b/android/src/main/java/com/primerioreactnative/components/datamodels/core/PrimerRawPaymentMethodType.kt
@@ -6,4 +6,5 @@ internal enum class PrimerRawPaymentMethodType {
     ADYEN_MBWAY,
     ADYEN_BANCONTACT_CARD,
     XENDIT_RETAIL_OUTLETS,
+    ADYEN_BLIK,
 }

--- a/android/src/main/java/com/primerioreactnative/components/datamodels/manager/raw/otp/PrimerRNOtpData.kt
+++ b/android/src/main/java/com/primerioreactnative/components/datamodels/manager/raw/otp/PrimerRNOtpData.kt
@@ -1,0 +1,14 @@
+package com.primerioreactnative.components.datamodels.manager.raw.otp
+
+import io.primer.android.otp.PrimerOtpData
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class PrimerRNOtpData(
+    val otp: String? = null,
+) {
+    fun toPrimerOtpData() =
+        PrimerOtpData(
+            otp.orEmpty(),
+        )
+}

--- a/android/src/main/java/com/primerioreactnative/components/manager/raw/PrimerRNHeadlessUniversalCheckoutRawManager.kt
+++ b/android/src/main/java/com/primerioreactnative/components/manager/raw/PrimerRNHeadlessUniversalCheckoutRawManager.kt
@@ -13,6 +13,7 @@ import com.primerioreactnative.components.datamodels.core.PrimerRawPaymentMethod
 import com.primerioreactnative.components.datamodels.manager.raw.billingAddress.PrimerRNAddress
 import com.primerioreactnative.components.datamodels.manager.raw.card.PrimerRNCardData
 import com.primerioreactnative.components.datamodels.manager.raw.cardRedirect.PrimerRNBancontactCardData
+import com.primerioreactnative.components.datamodels.manager.raw.otp.PrimerRNOtpData
 import com.primerioreactnative.components.datamodels.manager.raw.phoneNumber.PrimerRNPhoneNumberData
 import com.primerioreactnative.components.datamodels.manager.raw.retailOutlets.PrimerRNRetailOutletData
 import com.primerioreactnative.components.datamodels.manager.raw.retailOutlets.toRNRetailOutletsList
@@ -156,6 +157,10 @@ internal class PrimerRNHeadlessUniversalCheckoutRawManager(
                         PrimerRawPaymentMethodType.XENDIT_RETAIL_OUTLETS ->
                             json.decodeFromString<PrimerRNRetailOutletData>(rawDataStr)
                                 .toPrimerRetailOutletData()
+
+                        PrimerRawPaymentMethodType.ADYEN_BLIK ->
+                            json.decodeFromString<PrimerRNOtpData>(rawDataStr)
+                                .toPrimerOtpData()
                     }
                 rawManager.setRawData(rawData)
                 promise.resolve(null)

--- a/ios/Sources/DataModels/PrimerOTPData+Extension.swift
+++ b/ios/Sources/DataModels/PrimerOTPData+Extension.swift
@@ -1,0 +1,36 @@
+//
+//  PrimerOTPData+Extension.swift
+//  primer-io-react-native
+//
+//  Decodes the JS raw-data payload `{ "otp": "..." }` into the native PrimerSDK PrimerOTPData
+//  (BLIK). Mirrors PrimerPhoneNumberData+Extension.
+//
+
+import Foundation
+import PrimerSDK
+
+extension PrimerOTPData {
+
+  convenience init?(otpDataStr: String) {
+    do {
+      guard let data = otpDataStr.data(using: .utf8) else {
+        return nil
+      }
+
+      let json = try JSONSerialization.jsonObject(with: data)
+
+      guard let dict = json as? [String: String] else {
+        return nil
+      }
+
+      if let otp = dict["otp"] {
+        self.init(otp: otp)
+      } else {
+        return nil
+      }
+
+    } catch {
+      return nil
+    }
+  }
+}

--- a/ios/Sources/Headless Universal Checkout/Managers/Payment Method Managers/RNTRawDataManager.swift
+++ b/ios/Sources/Headless Universal Checkout/Managers/Payment Method Managers/RNTRawDataManager.swift
@@ -140,6 +140,12 @@ class RNTPrimerHeadlessUniversalCheckoutRawDataManager: RCTEventEmitter {
       return
     }
 
+    if let rawOtpData = PrimerOTPData(otpDataStr: rawDataStr) {
+      rawDataManager.rawData = rawOtpData
+      resolver(nil)
+      return
+    }
+
     let err = RNTNativeError(
       errorId: "native-ios",
       errorDescription: "Failed to decode RawData on iOS.",

--- a/src/Components/hooks/usePrimerPaymentMethod.ts
+++ b/src/Components/hooks/usePrimerPaymentMethod.ts
@@ -30,6 +30,9 @@ export function usePrimerPaymentMethod(type: string): UsePrimerPaymentMethodRetu
     filterBanks,
     selectBank,
     submitBanks,
+    cardFormState,
+    setRawData,
+    submit,
   } = usePrimerCheckout();
 
   const method = availablePaymentMethods.find((m) => m.paymentMethodType === type);
@@ -40,6 +43,9 @@ export function usePrimerPaymentMethod(type: string): UsePrimerPaymentMethodRetu
   const cancel = useCallback(() => cancelNativeUI(type), [cancelNativeUI, type]);
   const startCard = useCallback(() => setActiveMethod(type), [setActiveMethod, type]);
   const startBank = useCallback(() => startBanks(type), [startBanks, type]);
+  const startRawDataForm = useCallback(async () => {
+    setActiveMethod(type);
+  }, [setActiveMethod, type]);
 
   return useMemo<UsePrimerPaymentMethodReturn>(() => {
     if (kind === 'nativeUi') {
@@ -70,6 +76,20 @@ export function usePrimerPaymentMethod(type: string): UsePrimerPaymentMethodRetu
         clearPaymentOutcome,
       };
     }
+    if (kind === 'rawDataForm') {
+      return {
+        kind: 'rawDataForm',
+        isAvailable: isPresent,
+        requiredInputs: cardFormState.requiredFields,
+        validationErrors: Object.values(cardFormState.errors).filter((e): e is string => Boolean(e)),
+        isValid: cardFormState.isValid,
+        paymentOutcome,
+        start: startRawDataForm,
+        setData: setRawData,
+        submit,
+        clearPaymentOutcome,
+      };
+    }
     if (kind === 'card') {
       return { kind: 'card', isAvailable: isPresent, start: startCard, clearPaymentOutcome };
     }
@@ -91,6 +111,10 @@ export function usePrimerPaymentMethod(type: string): UsePrimerPaymentMethodRetu
     banks,
     selectedBankId,
     isBanksLoading,
+    cardFormState,
+    setRawData,
+    submit,
+    startRawDataForm,
     clearPaymentOutcome,
   ]);
 }

--- a/src/Components/internal/checkout-flow/CheckoutFlow.tsx
+++ b/src/Components/internal/checkout-flow/CheckoutFlow.tsx
@@ -9,6 +9,7 @@ import { LoadingScreen } from '../screens/LoadingScreen';
 import { MethodSelectionScreen } from '../screens/MethodSelectionScreen';
 import { CardFormScreen } from '../screens/CardFormScreen';
 import { BankSelectionScreen } from '../screens/BankSelectionScreen';
+import { RawDataFormScreen } from '../screens/RawDataFormScreen';
 import { CountrySelectorScreen } from '../screens/CountrySelectorScreen';
 import { ErrorScreen } from '../screens/ErrorScreen';
 import { SuccessScreen } from '../screens/SuccessScreen';
@@ -38,6 +39,7 @@ const screenMap: Partial<Record<CheckoutRouteType, React.ComponentType>> = {
   [CheckoutRoute.methodSelection]: MethodSelectionScreen,
   [CheckoutRoute.cardForm]: CardFormScreen,
   [CheckoutRoute.bankSelection]: BankSelectionScreen,
+  [CheckoutRoute.rawDataForm]: RawDataFormScreen,
   [CheckoutRoute.countrySelector]: CountrySelectorScreen,
   [CheckoutRoute.processing]: LoadingScreen,
   [CheckoutRoute.success]: CheckoutSuccessScreen,

--- a/src/Components/internal/navigation/types.ts
+++ b/src/Components/internal/navigation/types.ts
@@ -7,6 +7,7 @@ export enum CheckoutRoute {
   methodSelection = 'methodSelection',
   cardForm = 'cardForm',
   bankSelection = 'bankSelection',
+  rawDataForm = 'rawDataForm',
   processing = 'processing',
   success = 'success',
   error = 'error',
@@ -22,6 +23,7 @@ export type RouteParamMap = {
   [CheckoutRoute.methodSelection]: undefined;
   [CheckoutRoute.cardForm]: { paymentMethodType: string };
   [CheckoutRoute.bankSelection]: { paymentMethodType: string };
+  [CheckoutRoute.rawDataForm]: { paymentMethodType: string };
   [CheckoutRoute.processing]: undefined;
   [CheckoutRoute.success]: { checkoutData?: PrimerCheckoutData; title?: string; subtitle?: string } | undefined;
   [CheckoutRoute.error]: { error?: PrimerError; title?: string; subtitle?: string } | undefined;

--- a/src/Components/internal/routeMethodSelection.ts
+++ b/src/Components/internal/routeMethodSelection.ts
@@ -8,11 +8,12 @@ import type { PrimerPaymentMethodManagerCategoryName } from '../../models/Primer
  * - `nativeUi` — a native-sheet / browser-redirect method (Google/Apple Pay, PayPal), started via
  *   `startNativeUI(type)`.
  * - `bankSelection` — a `COMPONENT_WITH_REDIRECT` bank-redirect method (iDEAL; Android Dotpay).
- * - `card` — the card form (`PAYMENT_CARD`, and any other `RAW_DATA` method for now).
+ * - `rawDataForm` — a non-card `RAW_DATA` method that collects a small input (Bancontact/MBWay/BLIK).
+ * - `card` — the card form (`PAYMENT_CARD` only).
  * - `unsupported` — not yet wired into Components.
  *
  * Availability (e.g. Google Pay's Android-only rule) is deliberately NOT part of routing — it lives
- * with the consumer. Later PRs extend the kinds (Klarna, raw-data forms, QR).
+ * with the consumer. Later PRs extend the kinds (Klarna, QR).
  */
 // Single source of truth — derived from the hook's union so the two can't drift as variants land.
 export type PaymentMethodKind = UsePrimerPaymentMethodReturn['kind'];
@@ -33,7 +34,7 @@ export function routeMethodSelection(
     return 'bankSelection';
   }
   if (categories.includes('RAW_DATA')) {
-    return 'card';
+    return 'rawDataForm';
   }
   return 'unsupported';
 }

--- a/src/Components/internal/screens/MethodSelectionScreen.tsx
+++ b/src/Components/internal/screens/MethodSelectionScreen.tsx
@@ -129,6 +129,10 @@ export function MethodSelectionScreen() {
         // Bank-redirect methods (iDEAL; Android Dotpay) — open the bank picker.
         push(CheckoutRoute.bankSelection, { paymentMethodType: method.type });
         return;
+      case 'rawDataForm':
+        // Non-card RAW_DATA methods (Bancontact / MBWay / BLIK) — open the method's input form.
+        push(CheckoutRoute.rawDataForm, { paymentMethodType: method.type });
+        return;
       case 'unsupported':
         console.warn(`${LOG} payment method ${method.type} not yet wired`);
         return;

--- a/src/Components/internal/screens/RawDataFormScreen.tsx
+++ b/src/Components/internal/screens/RawDataFormScreen.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import type { TextStyle } from 'react-native';
+
+import { usePrimerTheme } from '../theme';
+import type { PrimerTokens } from '../theme';
+import { NavigationHeader } from '../navigation/NavigationHeader';
+import { useNavigation } from '../navigation/useNavigation';
+import { useRoute } from '../navigation/useRoute';
+import { CheckoutRoute } from '../navigation/types';
+import { usePrimerLocalization } from '../localization';
+import { useCheckoutFlow } from '../checkout-flow/CheckoutFlowContext';
+import { usePrimerPaymentMethod } from '../../hooks/usePrimerPaymentMethod';
+import { useBottomSafeArea } from './useBottomSafeArea';
+
+import type { PrimerRawData } from '../../../models/PrimerRawData';
+
+// Field keys are the SDK's input-element-type strings. NOTE the platform split for BLIK's
+// one-time code: iOS reports 'OTP', Android reports 'OTP_CODE' — both are handled.
+const FIELD_LABEL: Record<string, string> = {
+  PHONE_NUMBER: 'Phone number',
+  OTP: 'One-time code',
+  OTP_CODE: 'One-time code',
+  CARD_NUMBER: 'Card number',
+  EXPIRY_DATE: 'Expiry date (MM/YY)',
+  CARDHOLDER_NAME: 'Cardholder name',
+};
+
+const NUMERIC_FIELDS = new Set<string>(['PHONE_NUMBER', 'OTP', 'OTP_CODE', 'CARD_NUMBER', 'EXPIRY_DATE']);
+
+type FieldValues = Record<string, string>;
+
+// The present input keys tell us which raw-data model to build (single-field phone/OTP, or
+// Bancontact card-fields). PrimerRawData is an open interface, so each shape is assignable.
+function buildRawData(values: FieldValues): PrimerRawData {
+  const otp = values.OTP ?? values.OTP_CODE;
+  if (otp != null) {
+    return { otp };
+  }
+  if (values.PHONE_NUMBER != null) {
+    return { phoneNumber: values.PHONE_NUMBER };
+  }
+  return {
+    cardNumber: values.CARD_NUMBER ?? '',
+    expiryDate: values.EXPIRY_DATE ?? '',
+    cardholderName: values.CARDHOLDER_NAME ?? '',
+  };
+}
+
+/**
+ * Prebuilt input form for non-card RAW_DATA methods — MBWay (phone), Bancontact (card-fields),
+ * BLIK (one-time code). Renders exactly the fields the method reports (never the card form). On
+ * submit the SDK tokenises; methods that redirect/poll are owned by the native flow. Dogfoods the
+ * public `usePrimerPaymentMethod` API.
+ */
+export function RawDataFormScreen() {
+  const tokens = usePrimerTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+  const { t } = usePrimerLocalization();
+  const { params } = useRoute<CheckoutRoute.rawDataForm>();
+  const { pop, replace, canGoBack } = useNavigation();
+  const { onCancel } = useCheckoutFlow();
+  const bottomInset = useBottomSafeArea();
+
+  const method = usePrimerPaymentMethod(params.paymentMethodType);
+  const form = method.kind === 'rawDataForm' ? method : null;
+  const start = form?.start;
+  const [values, setValues] = useState<FieldValues>({});
+
+  // Activate this method's raw-data manager on mount.
+  useEffect(() => {
+    void start?.();
+  }, [start]);
+
+  // Defensive: this screen is only routed to for raw-data form methods.
+  if (!form) {
+    return null;
+  }
+
+  const { requiredInputs, isValid, setData, submit } = form;
+
+  const handleChange = (field: string, text: string) => {
+    const next = { ...values, [field]: text };
+    setValues(next);
+    void setData(buildRawData(next)).catch(() => {});
+  };
+
+  const handleSubmit = () => {
+    if (!isValid) return;
+    // Jump to processing while tokenisation / any redirect runs; the outcome navigates away.
+    replace(CheckoutRoute.processing);
+    void submit();
+  };
+
+  return (
+    <View style={styles.root}>
+      <NavigationHeader
+        title={t('primer_checkout_title')}
+        showBackButton={canGoBack}
+        backLabel={t('primer_common_back')}
+        onBackPress={pop}
+        rightAction={{ label: t('primer_common_button_cancel'), onPress: onCancel }}
+      />
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        {requiredInputs.map((field) => (
+          <View key={field} style={styles.field}>
+            <Text style={styles.label}>{FIELD_LABEL[field] ?? field}</Text>
+            <TextInput
+              style={styles.input}
+              value={values[field] ?? ''}
+              onChangeText={(text) => handleChange(field, text)}
+              keyboardType={NUMERIC_FIELDS.has(field) ? 'number-pad' : 'default'}
+              autoCapitalize="none"
+              accessibilityLabel={FIELD_LABEL[field] ?? field}
+            />
+          </View>
+        ))}
+      </ScrollView>
+      <View style={[styles.footer, { paddingBottom: Math.max(bottomInset, tokens.spacing.large) }]}>
+        <TouchableOpacity
+          onPress={handleSubmit}
+          disabled={!isValid}
+          activeOpacity={0.7}
+          style={[styles.payButton, !isValid && styles.payButtonDisabled]}
+          accessibilityRole="button"
+          accessibilityState={{ disabled: !isValid }}
+        >
+          <Text style={styles.payButtonText}>{t('primer_common_button_pay')}</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+function createStyles(tokens: PrimerTokens) {
+  const { colors, radii, spacing, typography } = tokens;
+  /* eslint-disable react-native/no-unused-styles */
+  return StyleSheet.create({
+    field: {
+      gap: spacing.xsmall,
+    },
+    footer: {
+      backgroundColor: colors.background,
+      paddingHorizontal: spacing.large,
+      paddingTop: spacing.small,
+    },
+    input: {
+      borderColor: colors.border,
+      borderRadius: radii.medium,
+      borderWidth: StyleSheet.hairlineWidth,
+      color: colors.textPrimary,
+      fontSize: typography.titleLarge.fontSize,
+      minHeight: 48,
+      paddingHorizontal: spacing.medium,
+      paddingVertical: spacing.small,
+    },
+    label: {
+      color: colors.textPrimary,
+      fontFamily: typography.titleLarge.fontFamily,
+      fontSize: typography.titleLarge.fontSize,
+      fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],
+      letterSpacing: typography.titleLarge.letterSpacing,
+      lineHeight: typography.titleLarge.lineHeight,
+    },
+    payButton: {
+      alignItems: 'center',
+      backgroundColor: colors.primary,
+      borderRadius: radii.medium,
+      justifyContent: 'center',
+      minHeight: 44,
+      padding: spacing.medium,
+      width: '100%',
+    },
+    payButtonDisabled: {
+      opacity: 0.5,
+    },
+    payButtonText: {
+      color: colors.background,
+      fontFamily: typography.titleLarge.fontFamily,
+      fontSize: typography.titleLarge.fontSize,
+      fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],
+      letterSpacing: typography.titleLarge.letterSpacing,
+      lineHeight: typography.titleLarge.lineHeight,
+      textAlign: 'center',
+    },
+    root: {
+      flex: 1,
+    },
+    scrollContent: {
+      gap: spacing.medium,
+      paddingHorizontal: spacing.large,
+      paddingTop: spacing.large,
+    },
+    scrollView: {
+      flex: 1,
+    },
+  });
+  /* eslint-enable react-native/no-unused-styles */
+}

--- a/src/Components/types/PrimerPaymentMethodTypes.ts
+++ b/src/Components/types/PrimerPaymentMethodTypes.ts
@@ -1,5 +1,7 @@
 import type { PaymentOutcome } from './PrimerCheckoutProviderTypes';
 import type { IssuingBank } from '../../models/IssuingBank';
+import type { PrimerInputElementType } from '../../models/PrimerInputElementType';
+import type { PrimerRawData } from '../../models/PrimerRawData';
 
 /**
  * Why a payment method is unavailable. Coarse `{ code, message }`; the codes are method-specific
@@ -69,6 +71,31 @@ export interface BankSelectionPaymentMethod {
 }
 
 /**
+ * A non-card `RAW_DATA` form method that collects a small, method-specific input before tokenising
+ * — Bancontact (card fields), MBWay (phone), BLIK (OTP). `start()` activates the method's raw-data
+ * manager; render `requiredInputs`, push entries via `setData`, then `submit()`. The outcome arrives
+ * via `paymentOutcome`. Render nothing when `!isAvailable`.
+ */
+export interface RawDataFormPaymentMethod {
+  kind: 'rawDataForm';
+  readonly isAvailable: boolean;
+  /** The fields this method requires, from the SDK — drives the form (never the card form). */
+  readonly requiredInputs: PrimerInputElementType[];
+  /** Current validation messages (card-field methods populate these; `isValid` is the reliable gate). */
+  readonly validationErrors: string[];
+  /** Whether the entered data is valid and ready to submit. */
+  readonly isValid: boolean;
+  readonly paymentOutcome: PaymentOutcome | null;
+  /** Activate this method's raw-data manager (configure + fetch required inputs). */
+  start(): Promise<void>;
+  /** Forward the method's raw data (`PrimerPhoneNumberData` / `PrimerBancontactCardData` / `PrimerOtpData`). */
+  setData(data: PrimerRawData): Promise<void>;
+  /** Tokenise and proceed (some methods then redirect; the native SDK owns it). */
+  submit(): Promise<void>;
+  clearPaymentOutcome(): void;
+}
+
+/**
  * Can't be driven here: either a type not wired into Components yet, OR a known method that isn't
  * in the current session (its category is unknown). Either way it can't be started — render
  * nothing / disabled.
@@ -82,5 +109,6 @@ export interface UnsupportedPaymentMethod {
 export type UsePrimerPaymentMethodReturn =
   | NativeUiPaymentMethod
   | BankSelectionPaymentMethod
+  | RawDataFormPaymentMethod
   | CardPaymentMethod
   | UnsupportedPaymentMethod;

--- a/src/__tests__/components/routeMethodSelection.test.ts
+++ b/src/__tests__/components/routeMethodSelection.test.ts
@@ -21,8 +21,10 @@ describe('routeMethodSelection', () => {
     expect(routeMethodSelection('ADYEN_SOFORT', ['NATIVE_UI'])).toBe('nativeUi');
   });
 
-  it('routes a non-card RAW_DATA method to card for now (the rawDataForm split lands in #389)', () => {
-    expect(routeMethodSelection('ADYEN_BANCONTACT_CARD', ['RAW_DATA'])).toBe('card');
+  it('routes non-card RAW_DATA methods (Bancontact/MBWay/BLIK) to rawDataForm', () => {
+    expect(routeMethodSelection('ADYEN_BANCONTACT_CARD', ['RAW_DATA'])).toBe('rawDataForm');
+    expect(routeMethodSelection('ADYEN_MBWAY', ['RAW_DATA'])).toBe('rawDataForm');
+    expect(routeMethodSelection('ADYEN_BLIK', ['RAW_DATA'])).toBe('rawDataForm');
   });
 
   it('returns unsupported for a category that is not yet routed', () => {

--- a/src/__tests__/components/usePrimerPaymentMethod.test.tsx
+++ b/src/__tests__/components/usePrimerPaymentMethod.test.tsx
@@ -62,6 +62,7 @@ import { usePrimerPaymentMethod } from '../../Components/hooks/usePrimerPaymentM
 import type {
   BankSelectionPaymentMethod,
   NativeUiPaymentMethod,
+  RawDataFormPaymentMethod,
   UsePrimerPaymentMethodReturn,
 } from '../../Components/types/PrimerPaymentMethodTypes';
 
@@ -88,6 +89,14 @@ function asNativeUi(c: UsePrimerPaymentMethodReturn): NativeUiPaymentMethod {
 function asBankSelection(c: UsePrimerPaymentMethodReturn): BankSelectionPaymentMethod {
   if (c.kind !== 'bankSelection') {
     throw new Error(`expected kind 'bankSelection', got '${c.kind}'`);
+  }
+  return c;
+}
+
+/** Asserts the captured controller is the `rawDataForm` variant and returns it typed. */
+function asRawDataForm(c: UsePrimerPaymentMethodReturn): RawDataFormPaymentMethod {
+  if (c.kind !== 'rawDataForm') {
+    throw new Error(`expected kind 'rawDataForm', got '${c.kind}'`);
   }
   return c;
 }
@@ -446,6 +455,27 @@ describe('usePrimerPaymentMethod', () => {
       const last = asNativeUi(captures[captures.length - 1]!);
       expect(last.kind).toBe('nativeUi');
       expect(last.isAvailable).toBe(true);
+    });
+  });
+
+  describe('raw-data form methods (Bancontact/MBWay/BLIK)', () => {
+    it('routes a non-card RAW_DATA method (MBWay) to kind "rawDataForm" with the form contract', async () => {
+      const captures = await mountWithMethods(
+        [{ paymentMethodType: 'ADYEN_MBWAY', categories: ['RAW_DATA'] }],
+        'ADYEN_MBWAY'
+      );
+      const form = asRawDataForm(captures[captures.length - 1]!);
+      expect(form.isAvailable).toBe(true);
+      expect(form.requiredInputs).toEqual([]); // populated once start() activates the raw-data manager
+      expect(form.isValid).toBe(false);
+    });
+
+    it('Bancontact also routes to rawDataForm (not the card form)', async () => {
+      const captures = await mountWithMethods(
+        [{ paymentMethodType: 'ADYEN_BANCONTACT_CARD', categories: ['RAW_DATA'] }],
+        'ADYEN_BANCONTACT_CARD'
+      );
+      expect(captures[captures.length - 1]!.kind).toBe('rawDataForm');
     });
   });
 });

--- a/src/models/PrimerRawData.ts
+++ b/src/models/PrimerRawData.ts
@@ -21,3 +21,7 @@ export interface PrimerBancontactCardData extends PrimerRawData {
 export interface PrimerRetailerData extends PrimerRawData {
   id: string;
 }
+
+export interface PrimerOtpData extends PrimerRawData {
+  otp: string;
+}


### PR DESCRIPTION
## Summary

Non-card `RAW_DATA` form methods (Bancontact = card fields, MBWay = phone, BLIK = OTP) now flow through the generic **`usePrimerPaymentMethod(type)`** — narrow on `kind: 'rawDataForm'`. Seventh step of the APM hook unification (after Google Pay #376, Apple Pay #374, PayPal #385, foundational #386, banks #387, web-redirect #388).

A "build fresh" slice: the bespoke `usePrimerRawDataForm` hook + `RawDataFormController` type are gone; their surface folds into a `rawDataForm` variant of the one hook, and `RawDataFormScreen` dogfoods that public API. The RN side adds **no provider code** — it reuses the raw-data plumbing the card form already uses (`setActiveMethod` / `setRawData` / `submit` / `cardFormState`).

## What's here

- `usePrimerPaymentMethod('ADYEN_MBWAY')` → `kind: 'rawDataForm'` with `requiredInputs`, `validationErrors`, `isValid`, `start()` (activate the method's raw-data manager), `setData(data)`, `submit()`. Outcome on the shared `paymentOutcome`.
- **Routing split:** `routeMethodSelection` now sends non-card `RAW_DATA → 'rawDataForm'`; `PAYMENT_CARD` still → `'card'`. New `rawDataForm` nav route + `MethodSelectionScreen` case.
- `RawDataFormScreen` renders exactly the fields the method reports (phone / OTP / Bancontact card fields), rebuilt on the generic hook.
- **BLIK OTP native bridge** — `PrimerOtpData` TS type + the RN↔SDK marshalling (Kotlin `PrimerRNOtpData` + Swift `PrimerOTPData+Extension` + 3 one-line registrations), mirroring the existing phone-number bridge. The native SDKs already support BLIK; this only adds the translator. Bancontact/MBWay need no native change.

## Breaking change

`usePrimerRawDataForm` and `RawDataFormController` are removed — use `usePrimerPaymentMethod(type)` and narrow on `kind: 'rawDataForm'`.

## Base

`ov/feat/ORC-6514-web-redirect` (#388).

## Jira

[ORC-6514](https://primerapi.atlassian.net/browse/ORC-6514)

## Test plan

- [x] `yarn typecheck` / `yarn lint` — clean
- [x] `yarn jest` — green bar the known tr_TR localization flake; routing-split cases (Bancontact/MBWay/BLIK → `rawDataForm`, `PAYMENT_CARD` → `card`) + `usePrimerPaymentMethod` rawDataForm-variant cases
- [ ] Manual device — Bancontact (BE/EUR) / MBWay (PT/EUR) / BLIK (PL/PLN) are country-gated and may not surface in the demo sandbox (like Dotpay/Sofort); **not device-confirmed in this PR**. Bancontact/MBWay use already-bridged raw-data types; BLIK exercises the new OTP bridge.

Note: the 5 native files (`*.kt`/`*.swift`) are an **unchanged verbatim copy** of the original #389's BLIK-OTP bridge (already reviewed/compiled there). JS-side tooling can't compile them — they build with the example app.


[ORC-6514]: https://primerapi.atlassian.net/browse/ORC-6514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ