### PR TITLE
feat(components): raw-data form methods + OTP bridge (ORC-6514)

### DIFF
--- a/android/src/main/java/com/primerioreactnative/components/datamodels/core/PrimerRawPaymentMethodType.kt
+++ b/android/src/main/java/com/primerioreactnative/components/datamodels/core/PrimerRawPaymentMethodType.kt
@@ -6,4 +6,5 @@ internal enum class PrimerRawPaymentMethodType {
     ADYEN_MBWAY,
     ADYEN_BANCONTACT_CARD,
     XENDIT_RETAIL_OUTLETS,
+    ADYEN_BLIK,
 }

--- a/android/src/main/java/com/primerioreactnative/components/datamodels/manager/raw/otp/PrimerRNOtpData.kt
+++ b/android/src/main/java/com/primerioreactnative/components/datamodels/manager/raw/otp/PrimerRNOtpData.kt
@@ -1,0 +1,14 @@
+package com.primerioreactnative.components.datamodels.manager.raw.otp
+
+import io.primer.android.otp.PrimerOtpData
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class PrimerRNOtpData(
+    val otp: String? = null,
+) {
+    fun toPrimerOtpData() =
+        PrimerOtpData(
+            otp.orEmpty(),
+        )
+}

--- a/android/src/main/java/com/primerioreactnative/components/manager/raw/PrimerRNHeadlessUniversalCheckoutRawManager.kt
+++ b/android/src/main/java/com/primerioreactnative/components/manager/raw/PrimerRNHeadlessUniversalCheckoutRawManager.kt
@@ -13,6 +13,7 @@ import com.primerioreactnative.components.datamodels.core.PrimerRawPaymentMethod
 import com.primerioreactnative.components.datamodels.manager.raw.billingAddress.PrimerRNAddress
 import com.primerioreactnative.components.datamodels.manager.raw.card.PrimerRNCardData
 import com.primerioreactnative.components.datamodels.manager.raw.cardRedirect.PrimerRNBancontactCardData
+import com.primerioreactnative.components.datamodels.manager.raw.otp.PrimerRNOtpData
 import com.primerioreactnative.components.datamodels.manager.raw.phoneNumber.PrimerRNPhoneNumberData
 import com.primerioreactnative.components.datamodels.manager.raw.retailOutlets.PrimerRNRetailOutletData
 import com.primerioreactnative.components.datamodels.manager.raw.retailOutlets.toRNRetailOutletsList
@@ -156,6 +157,10 @@ internal class PrimerRNHeadlessUniversalCheckoutRawManager(
                         PrimerRawPaymentMethodType.XENDIT_RETAIL_OUTLETS ->
                             json.decodeFromString<PrimerRNRetailOutletData>(rawDataStr)
                                 .toPrimerRetailOutletData()
+
+                        PrimerRawPaymentMethodType.ADYEN_BLIK ->
+                            json.decodeFromString<PrimerRNOtpData>(rawDataStr)
+                                .toPrimerOtpData()
                     }
                 rawManager.setRawData(rawData)
                 promise.resolve(null)

--- a/ios/Sources/DataModels/PrimerOTPData+Extension.swift
+++ b/ios/Sources/DataModels/PrimerOTPData+Extension.swift
@@ -1,0 +1,36 @@
+//
+//  PrimerOTPData+Extension.swift
+//  primer-io-react-native
+//
+//  Decodes the JS raw-data payload `{ "otp": "..." }` into the native PrimerSDK PrimerOTPData
+//  (BLIK). Mirrors PrimerPhoneNumberData+Extension.
+//
+
+import Foundation
+import PrimerSDK
+
+extension PrimerOTPData {
+
+  convenience init?(otpDataStr: String) {
+    do {
+      guard let data = otpDataStr.data(using: .utf8) else {
+        return nil
+      }
+
+      let json = try JSONSerialization.jsonObject(with: data)
+
+      guard let dict = json as? [String: String] else {
+        return nil
+      }
+
+      if let otp = dict["otp"] {
+        self.init(otp: otp)
+      } else {
+        return nil
+      }
+
+    } catch {
+      return nil
+    }
+  }
+}

--- a/ios/Sources/Headless Universal Checkout/Managers/Payment Method Managers/RNTRawDataManager.swift
+++ b/ios/Sources/Headless Universal Checkout/Managers/Payment Method Managers/RNTRawDataManager.swift
@@ -140,6 +140,12 @@ class RNTPrimerHeadlessUniversalCheckoutRawDataManager: RCTEventEmitter {
       return
     }
 
+    if let rawOtpData = PrimerOTPData(otpDataStr: rawDataStr) {
+      rawDataManager.rawData = rawOtpData
+      resolver(nil)
+      return
+    }
+
     let err = RNTNativeError(
       errorId: "native-ios",
       errorDescription: "Failed to decode RawData on iOS.",

--- a/src/Components/hooks/usePrimerPaymentMethod.ts
+++ b/src/Components/hooks/usePrimerPaymentMethod.ts
@@ -30,6 +30,9 @@ export function usePrimerPaymentMethod(type: string): UsePrimerPaymentMethodRetu
     filterBanks,
     selectBank,
     submitBanks,
+    cardFormState,
+    setRawData,
+    submit,
   } = usePrimerCheckout();
 
   const method = availablePaymentMethods.find((m) => m.paymentMethodType === type);
@@ -40,6 +43,9 @@ export function usePrimerPaymentMethod(type: string): UsePrimerPaymentMethodRetu
   const cancel = useCallback(() => cancelNativeUI(type), [cancelNativeUI, type]);
   const startCard = useCallback(() => setActiveMethod(type), [setActiveMethod, type]);
   const startBank = useCallback(() => startBanks(type), [startBanks, type]);
+  const startRawDataForm = useCallback(async () => {
+    setActiveMethod(type);
+  }, [setActiveMethod, type]);
 
   return useMemo<UsePrimerPaymentMethodReturn>(() => {
     if (kind === 'nativeUi') {
@@ -70,6 +76,20 @@ export function usePrimerPaymentMethod(type: string): UsePrimerPaymentMethodRetu
         clearPaymentOutcome,
       };
     }
+    if (kind === 'rawDataForm') {
+      return {
+        kind: 'rawDataForm',
+        isAvailable: isPresent,
+        requiredInputs: cardFormState.requiredFields,
+        validationErrors: Object.values(cardFormState.errors).filter((e): e is string => Boolean(e)),
+        isValid: cardFormState.isValid,
+        paymentOutcome,
+        start: startRawDataForm,
+        setData: setRawData,
+        submit,
+        clearPaymentOutcome,
+      };
+    }
     if (kind === 'card') {
       return { kind: 'card', isAvailable: isPresent, start: startCard, clearPaymentOutcome };
     }
@@ -91,6 +111,10 @@ export function usePrimerPaymentMethod(type: string): UsePrimerPaymentMethodRetu
     banks,
     selectedBankId,
     isBanksLoading,
+    cardFormState,
+    setRawData,
+    submit,
+    startRawDataForm,
     clearPaymentOutcome,
   ]);
 }

--- a/src/Components/internal/checkout-flow/CheckoutFlow.tsx
+++ b/src/Components/internal/checkout-flow/CheckoutFlow.tsx
@@ -9,6 +9,7 @@ import { LoadingScreen } from '../screens/LoadingScreen';
 import { MethodSelectionScreen } from '../screens/MethodSelectionScreen';
 import { CardFormScreen } from '../screens/CardFormScreen';
 import { BankSelectionScreen } from '../screens/BankSelectionScreen';
+import { RawDataFormScreen } from '../screens/RawDataFormScreen';
 import { CountrySelectorScreen } from '../screens/CountrySelectorScreen';
 import { ErrorScreen } from '../screens/ErrorScreen';
 import { SuccessScreen } from '../screens/SuccessScreen';
@@ -38,6 +39,7 @@ const screenMap: Partial<Record<CheckoutRouteType, React.ComponentType>> = {
   [CheckoutRoute.methodSelection]: MethodSelectionScreen,
   [CheckoutRoute.cardForm]: CardFormScreen,
   [CheckoutRoute.bankSelection]: BankSelectionScreen,
+  [CheckoutRoute.rawDataForm]: RawDataFormScreen,
   [CheckoutRoute.countrySelector]: CountrySelectorScreen,
   [CheckoutRoute.processing]: LoadingScreen,
   [CheckoutRoute.success]: CheckoutSuccessScreen,

--- a/src/Components/internal/navigation/types.ts
+++ b/src/Components/internal/navigation/types.ts
@@ -7,6 +7,7 @@ export enum CheckoutRoute {
   methodSelection = 'methodSelection',
   cardForm = 'cardForm',
   bankSelection = 'bankSelection',
+  rawDataForm = 'rawDataForm',
   processing = 'processing',
   success = 'success',
   error = 'error',
@@ -22,6 +23,7 @@ export type RouteParamMap = {
   [CheckoutRoute.methodSelection]: undefined;
   [CheckoutRoute.cardForm]: { paymentMethodType: string };
   [CheckoutRoute.bankSelection]: { paymentMethodType: string };
+  [CheckoutRoute.rawDataForm]: { paymentMethodType: string };
   [CheckoutRoute.processing]: undefined;
   [CheckoutRoute.success]: { checkoutData?: PrimerCheckoutData; title?: string; subtitle?: string } | undefined;
   [CheckoutRoute.error]: { error?: PrimerError; title?: string; subtitle?: string } | undefined;

--- a/src/Components/internal/routeMethodSelection.ts
+++ b/src/Components/internal/routeMethodSelection.ts
@@ -8,11 +8,12 @@ import type { PrimerPaymentMethodManagerCategoryName } from '../../models/Primer
  * - `nativeUi` — a native-sheet / browser-redirect method (Google/Apple Pay, PayPal), started via
  *   `startNativeUI(type)`.
  * - `bankSelection` — a `COMPONENT_WITH_REDIRECT` bank-redirect method (iDEAL; Android Dotpay).
+ * - `rawDataForm` — a non-card `RAW_DATA` method that collects a small input (Bancontact/MBWay/BLIK).
  * - `card` — the card form (`PAYMENT_CARD` only).
  * - `unsupported` — not yet wired into Components.
  *
  * Availability (e.g. Google Pay's Android-only rule) is deliberately NOT part of routing — it lives
- * with the consumer. Later PRs extend the kinds (Klarna, raw-data forms, QR).
+ * with the consumer. Later PRs extend the kinds (Klarna, QR).
  */
 // Single source of truth — derived from the hook's union so the two can't drift as variants land.
 export type PaymentMethodKind = UsePrimerPaymentMethodReturn['kind'];
@@ -32,8 +33,8 @@ export function routeMethodSelection(
   if (categories.includes('COMPONENT_WITH_REDIRECT')) {
     return 'bankSelection';
   }
-  // Non-card `RAW_DATA` (Bancontact/MBWay/BLIK) is intentionally `unsupported` here — its input
-  // form lands in #394 (ORC-6514), which turns this into `rawDataForm`. Routing it to `card` now
-  // would wrongly open the card form for a non-card method.
+  if (categories.includes('RAW_DATA')) {
+    return 'rawDataForm';
+  }
   return 'unsupported';
 }

--- a/src/Components/internal/routeMethodSelection.ts
+++ b/src/Components/internal/routeMethodSelection.ts
@@ -20,6 +20,9 @@ export type PaymentMethodKind = UsePrimerPaymentMethodReturn['kind'];
 
 const PAYMENT_CARD_TYPE = 'PAYMENT_CARD';
 
+// RAW_DATA methods with a working form here; others (e.g. XENDIT_RETAIL_OUTLETS, a list picker) stay unsupported.
+const RAW_DATA_FORM_TYPES = new Set(['ADYEN_BANCONTACT_CARD', 'ADYEN_MBWAY', 'ADYEN_BLIK']);
+
 export function routeMethodSelection(
   type: string,
   categories: readonly PrimerPaymentMethodManagerCategoryName[]
@@ -33,7 +36,7 @@ export function routeMethodSelection(
   if (categories.includes('COMPONENT_WITH_REDIRECT')) {
     return 'bankSelection';
   }
-  if (categories.includes('RAW_DATA')) {
+  if (categories.includes('RAW_DATA') && RAW_DATA_FORM_TYPES.has(type)) {
     return 'rawDataForm';
   }
   return 'unsupported';

--- a/src/Components/internal/screens/MethodSelectionScreen.tsx
+++ b/src/Components/internal/screens/MethodSelectionScreen.tsx
@@ -135,6 +135,10 @@ export function MethodSelectionScreen() {
         // Bank-redirect methods (iDEAL; Android Dotpay) — open the bank picker.
         push(CheckoutRoute.bankSelection, { paymentMethodType: method.type });
         return;
+      case 'rawDataForm':
+        // Non-card RAW_DATA methods (Bancontact / MBWay / BLIK) — open the method's input form.
+        push(CheckoutRoute.rawDataForm, { paymentMethodType: method.type });
+        return;
       case 'unsupported':
         console.warn(`${LOG} payment method ${method.type} not yet wired`);
         return;

--- a/src/Components/internal/screens/RawDataFormScreen.tsx
+++ b/src/Components/internal/screens/RawDataFormScreen.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import type { TextStyle } from 'react-native';
+
+import { usePrimerTheme } from '../theme';
+import type { PrimerTokens } from '../theme';
+import { NavigationHeader } from '../navigation/NavigationHeader';
+import { useNavigation } from '../navigation/useNavigation';
+import { useRoute } from '../navigation/useRoute';
+import { CheckoutRoute } from '../navigation/types';
+import { usePrimerLocalization } from '../localization';
+import { useCheckoutFlow } from '../checkout-flow/CheckoutFlowContext';
+import { usePrimerPaymentMethod } from '../../hooks/usePrimerPaymentMethod';
+import { useBottomSafeArea } from './useBottomSafeArea';
+import { buildRawData } from './buildRawData';
+
+// Field keys are the SDK's input-element-type strings. NOTE the platform split for BLIK's
+// one-time code: iOS reports 'OTP', Android reports 'OTP_CODE' — both are handled.
+const FIELD_LABEL: Record<string, string> = {
+  PHONE_NUMBER: 'Phone number',
+  OTP: 'One-time code',
+  OTP_CODE: 'One-time code',
+  CARD_NUMBER: 'Card number',
+  EXPIRY_DATE: 'Expiry date (MM/YY)',
+  CARDHOLDER_NAME: 'Cardholder name',
+};
+
+const NUMERIC_FIELDS = new Set<string>(['PHONE_NUMBER', 'OTP', 'OTP_CODE', 'CARD_NUMBER', 'EXPIRY_DATE']);
+
+type FieldValues = Record<string, string>;
+
+/**
+ * Prebuilt input form for non-card RAW_DATA methods — MBWay (phone), Bancontact (card-fields),
+ * BLIK (one-time code). Renders exactly the fields the method reports (never the card form). On
+ * submit the SDK tokenises; methods that redirect/poll are owned by the native flow. Dogfoods the
+ * public `usePrimerPaymentMethod` API.
+ */
+export function RawDataFormScreen() {
+  const tokens = usePrimerTheme();
+  const styles = useMemo(() => createStyles(tokens), [tokens]);
+  const { t } = usePrimerLocalization();
+  const { params } = useRoute<CheckoutRoute.rawDataForm>();
+  const { pop, replace, canGoBack } = useNavigation();
+  const { onCancel } = useCheckoutFlow();
+  const bottomInset = useBottomSafeArea();
+
+  const method = usePrimerPaymentMethod(params.paymentMethodType);
+  const form = method.kind === 'rawDataForm' ? method : null;
+  const start = form?.start;
+  const [values, setValues] = useState<FieldValues>({});
+
+  // Activate this method's raw-data manager on mount.
+  useEffect(() => {
+    void start?.();
+  }, [start]);
+
+  // Defensive: this screen is only routed to for raw-data form methods.
+  if (!form) {
+    return null;
+  }
+
+  const { requiredInputs, isValid, setData, submit } = form;
+
+  const handleChange = (field: string, text: string) => {
+    const next = { ...values, [field]: text };
+    setValues(next);
+    void setData(buildRawData(next)).catch(() => {});
+  };
+
+  const handleSubmit = () => {
+    if (!isValid) return;
+    // Jump to processing while tokenisation / any redirect runs; the outcome navigates away.
+    replace(CheckoutRoute.processing);
+    void submit();
+  };
+
+  return (
+    <View style={styles.root}>
+      <NavigationHeader
+        title={t('primer_checkout_title')}
+        showBackButton={canGoBack}
+        backLabel={t('primer_common_back')}
+        onBackPress={pop}
+        rightAction={{ label: t('primer_common_button_cancel'), onPress: onCancel }}
+      />
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        {requiredInputs.map((field) => (
+          <View key={field} style={styles.field}>
+            <Text style={styles.label}>{FIELD_LABEL[field] ?? field}</Text>
+            <TextInput
+              style={styles.input}
+              value={values[field] ?? ''}
+              onChangeText={(text) => handleChange(field, text)}
+              keyboardType={NUMERIC_FIELDS.has(field) ? 'number-pad' : 'default'}
+              autoCapitalize="none"
+              accessibilityLabel={FIELD_LABEL[field] ?? field}
+            />
+          </View>
+        ))}
+      </ScrollView>
+      <View style={[styles.footer, { paddingBottom: Math.max(bottomInset, tokens.spacing.large) }]}>
+        <TouchableOpacity
+          onPress={handleSubmit}
+          disabled={!isValid}
+          activeOpacity={0.7}
+          style={[styles.payButton, !isValid && styles.payButtonDisabled]}
+          accessibilityRole="button"
+          accessibilityState={{ disabled: !isValid }}
+        >
+          <Text style={styles.payButtonText}>{t('primer_common_button_pay')}</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+function createStyles(tokens: PrimerTokens) {
+  const { colors, radii, spacing, typography } = tokens;
+  /* eslint-disable react-native/no-unused-styles */
+  return StyleSheet.create({
+    field: {
+      gap: spacing.xsmall,
+    },
+    footer: {
+      backgroundColor: colors.background,
+      paddingHorizontal: spacing.large,
+      paddingTop: spacing.small,
+    },
+    input: {
+      borderColor: colors.border,
+      borderRadius: radii.medium,
+      borderWidth: StyleSheet.hairlineWidth,
+      color: colors.textPrimary,
+      fontSize: typography.titleLarge.fontSize,
+      minHeight: 48,
+      paddingHorizontal: spacing.medium,
+      paddingVertical: spacing.small,
+    },
+    label: {
+      color: colors.textPrimary,
+      fontFamily: typography.titleLarge.fontFamily,
+      fontSize: typography.titleLarge.fontSize,
+      fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],
+      letterSpacing: typography.titleLarge.letterSpacing,
+      lineHeight: typography.titleLarge.lineHeight,
+    },
+    payButton: {
+      alignItems: 'center',
+      backgroundColor: colors.primary,
+      borderRadius: radii.medium,
+      justifyContent: 'center',
+      minHeight: 44,
+      padding: spacing.medium,
+      width: '100%',
+    },
+    payButtonDisabled: {
+      opacity: 0.5,
+    },
+    payButtonText: {
+      color: colors.background,
+      fontFamily: typography.titleLarge.fontFamily,
+      fontSize: typography.titleLarge.fontSize,
+      fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],
+      letterSpacing: typography.titleLarge.letterSpacing,
+      lineHeight: typography.titleLarge.lineHeight,
+      textAlign: 'center',
+    },
+    root: {
+      flex: 1,
+    },
+    scrollContent: {
+      gap: spacing.medium,
+      paddingHorizontal: spacing.large,
+      paddingTop: spacing.large,
+    },
+    scrollView: {
+      flex: 1,
+    },
+  });
+  /* eslint-enable react-native/no-unused-styles */
+}

--- a/src/Components/internal/screens/RawDataFormScreen.tsx
+++ b/src/Components/internal/screens/RawDataFormScreen.tsx
@@ -96,7 +96,9 @@ export function RawDataFormScreen() {
               style={styles.input}
               value={values[field] ?? ''}
               onChangeText={(text) => handleChange(field, text)}
-              keyboardType={NUMERIC_FIELDS.has(field) ? 'number-pad' : 'default'}
+              keyboardType={
+                field === 'PHONE_NUMBER' ? 'phone-pad' : NUMERIC_FIELDS.has(field) ? 'number-pad' : 'default'
+              }
               autoCapitalize="none"
               accessibilityLabel={FIELD_LABEL[field] ?? field}
             />

--- a/src/Components/internal/screens/RawDataFormScreen.tsx
+++ b/src/Components/internal/screens/RawDataFormScreen.tsx
@@ -71,7 +71,7 @@ export function RawDataFormScreen() {
     if (!isValid) return;
     // Jump to processing while tokenisation / any redirect runs; the outcome navigates away.
     replace(CheckoutRoute.processing);
-    void submit();
+    void submit().catch(() => {});
   };
 
   return (

--- a/src/Components/internal/screens/RawDataFormScreen.tsx
+++ b/src/Components/internal/screens/RawDataFormScreen.tsx
@@ -64,7 +64,7 @@ export function RawDataFormScreen() {
   const handleChange = (field: string, text: string) => {
     const next = { ...values, [field]: text };
     setValues(next);
-    void setData(buildRawData(next)).catch(() => {});
+    void setData(buildRawData(params.paymentMethodType, next)).catch(() => {});
   };
 
   const handleSubmit = () => {

--- a/src/Components/internal/screens/buildRawData.ts
+++ b/src/Components/internal/screens/buildRawData.ts
@@ -1,0 +1,23 @@
+import type { PrimerRawData } from '../../../models/PrimerRawData';
+
+export type RawFieldValues = Record<string, string>;
+
+/**
+ * Maps the collected input values to the right `PrimerRawData` shape by which keys are present:
+ * a one-time code (BLIK — `OTP`/`OTP_CODE`), a phone number (MBWay), or Bancontact card-fields.
+ * `PrimerRawData` is an open interface, so each shape is assignable.
+ */
+export function buildRawData(values: RawFieldValues): PrimerRawData {
+  const otp = values.OTP ?? values.OTP_CODE;
+  if (otp != null) {
+    return { otp };
+  }
+  if (values.PHONE_NUMBER != null) {
+    return { phoneNumber: values.PHONE_NUMBER };
+  }
+  return {
+    cardNumber: values.CARD_NUMBER ?? '',
+    expiryDate: values.EXPIRY_DATE ?? '',
+    cardholderName: values.CARDHOLDER_NAME ?? '',
+  };
+}

--- a/src/Components/internal/screens/buildRawData.ts
+++ b/src/Components/internal/screens/buildRawData.ts
@@ -3,21 +3,23 @@ import type { PrimerRawData } from '../../../models/PrimerRawData';
 export type RawFieldValues = Record<string, string>;
 
 /**
- * Maps the collected input values to the right `PrimerRawData` shape by which keys are present:
- * a one-time code (BLIK — `OTP`/`OTP_CODE`), a phone number (MBWay), or Bancontact card-fields.
- * `PrimerRawData` is an open interface, so each shape is assignable.
+ * Builds the `PrimerRawData` payload for a method from its collected field values. The shape is
+ * chosen by payment method type — BLIK → OTP, MBWay → phone number, Bancontact → card fields — not
+ * by which keys happen to be present. `PrimerRawData` is open, so each shape is assignable.
  */
-export function buildRawData(values: RawFieldValues): PrimerRawData {
-  const otp = values.OTP ?? values.OTP_CODE;
-  if (otp != null) {
-    return { otp };
+export function buildRawData(type: string, values: RawFieldValues): PrimerRawData {
+  switch (type) {
+    case 'ADYEN_BLIK':
+      return { otp: values.OTP ?? values.OTP_CODE ?? '' };
+    case 'ADYEN_MBWAY':
+      return { phoneNumber: values.PHONE_NUMBER ?? '' };
+    case 'ADYEN_BANCONTACT_CARD':
+      return {
+        cardNumber: values.CARD_NUMBER ?? '',
+        expiryDate: values.EXPIRY_DATE ?? '',
+        cardholderName: values.CARDHOLDER_NAME ?? '',
+      };
+    default:
+      return {}; // unreachable — routing allowlists these three types
   }
-  if (values.PHONE_NUMBER != null) {
-    return { phoneNumber: values.PHONE_NUMBER };
-  }
-  return {
-    cardNumber: values.CARD_NUMBER ?? '',
-    expiryDate: values.EXPIRY_DATE ?? '',
-    cardholderName: values.CARDHOLDER_NAME ?? '',
-  };
 }

--- a/src/Components/types/PrimerPaymentMethodTypes.ts
+++ b/src/Components/types/PrimerPaymentMethodTypes.ts
@@ -1,5 +1,7 @@
 import type { PaymentOutcome } from './PrimerCheckoutProviderTypes';
 import type { IssuingBank } from '../../models/IssuingBank';
+import type { PrimerInputElementType } from '../../models/PrimerInputElementType';
+import type { PrimerRawData } from '../../models/PrimerRawData';
 
 /**
  * Why a payment method is unavailable. Coarse `{ code, message }`; the codes are method-specific
@@ -69,6 +71,31 @@ export interface BankSelectionPaymentMethod {
 }
 
 /**
+ * A non-card `RAW_DATA` form method that collects a small, method-specific input before tokenising
+ * — Bancontact (card fields), MBWay (phone), BLIK (OTP). `start()` activates the method's raw-data
+ * manager; render `requiredInputs`, push entries via `setData`, then `submit()`. The outcome arrives
+ * via `paymentOutcome`. Render nothing when `!isAvailable`.
+ */
+export interface RawDataFormPaymentMethod {
+  kind: 'rawDataForm';
+  readonly isAvailable: boolean;
+  /** The fields this method requires, from the SDK — drives the form (never the card form). */
+  readonly requiredInputs: PrimerInputElementType[];
+  /** Current validation messages (card-field methods populate these; `isValid` is the reliable gate). */
+  readonly validationErrors: string[];
+  /** Whether the entered data is valid and ready to submit. */
+  readonly isValid: boolean;
+  readonly paymentOutcome: PaymentOutcome | null;
+  /** Activate this method's raw-data manager (configure + fetch required inputs). */
+  start(): Promise<void>;
+  /** Forward the method's raw data (`PrimerPhoneNumberData` / `PrimerBancontactCardData` / `PrimerOtpData`). */
+  setData(data: PrimerRawData): Promise<void>;
+  /** Tokenise and proceed (some methods then redirect; the native SDK owns it). */
+  submit(): Promise<void>;
+  clearPaymentOutcome(): void;
+}
+
+/**
  * Can't be driven here: either a type not wired into Components yet, OR a known method that isn't
  * in the current session (its category is unknown). Either way it can't be started — render
  * nothing / disabled.
@@ -82,5 +109,6 @@ export interface UnsupportedPaymentMethod {
 export type UsePrimerPaymentMethodReturn =
   | NativeUiPaymentMethod
   | BankSelectionPaymentMethod
+  | RawDataFormPaymentMethod
   | CardPaymentMethod
   | UnsupportedPaymentMethod;

--- a/src/__tests__/components/RawDataFormScreen.test.tsx
+++ b/src/__tests__/components/RawDataFormScreen.test.tsx
@@ -1,0 +1,141 @@
+// @ts-expect-error -- React 19 concurrent act environment
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+import { createElement } from 'react';
+// @ts-expect-error -- react-test-renderer has no types for React 19
+import renderer, { act } from 'react-test-renderer';
+
+jest.mock(
+  'react-native',
+  () => ({
+    ScrollView: 'ScrollView',
+    StyleSheet: { create: (s: unknown) => s, flatten: (s: unknown) => s, hairlineWidth: 1 },
+    Text: 'Text',
+    TextInput: 'TextInput',
+    TouchableOpacity: 'TouchableOpacity',
+    View: 'View',
+  }),
+  { virtual: true }
+);
+
+// `mock`-prefixed so the hoisted jest.mock factories may reference them.
+const mockStart = jest.fn().mockResolvedValue(undefined);
+const mockSetData = jest.fn().mockResolvedValue(undefined);
+const mockSubmit = jest.fn().mockResolvedValue(undefined);
+const mockReplace = jest.fn();
+// The payment-method hook's return value — swapped per test.
+let mockMethod: any;
+
+jest.mock('../../Components/hooks/usePrimerPaymentMethod', () => ({
+  usePrimerPaymentMethod: () => mockMethod,
+}));
+
+jest.mock('../../Components/internal/theme', () => ({
+  usePrimerTheme: () => ({
+    colors: { background: '#fff', border: '#ccc', primary: '#08f', textPrimary: '#000' },
+    spacing: { xsmall: 4, small: 8, medium: 12, large: 16 },
+    radii: { medium: 8 },
+    typography: {
+      titleLarge: { fontFamily: 'system', fontSize: 16, fontWeight: '500', letterSpacing: 0, lineHeight: 20 },
+    },
+  }),
+}));
+
+jest.mock('../../Components/internal/localization', () => ({
+  usePrimerLocalization: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../../Components/internal/navigation/useRoute', () => ({
+  useRoute: () => ({ params: { paymentMethodType: 'ADYEN_MBWAY' } }),
+}));
+
+jest.mock('../../Components/internal/navigation/useNavigation', () => ({
+  useNavigation: () => ({ pop: jest.fn(), replace: mockReplace, canGoBack: false }),
+}));
+
+jest.mock('../../Components/internal/checkout-flow/CheckoutFlowContext', () => ({
+  useCheckoutFlow: () => ({ onCancel: jest.fn() }),
+}));
+
+jest.mock('../../Components/internal/screens/useBottomSafeArea', () => ({ useBottomSafeArea: () => 0 }));
+jest.mock('../../Components/internal/navigation/NavigationHeader', () => ({ NavigationHeader: () => null }));
+
+import { RawDataFormScreen } from '../../Components/internal/screens/RawDataFormScreen';
+
+function rawDataForm(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: 'rawDataForm',
+    isAvailable: true,
+    requiredInputs: ['PHONE_NUMBER'],
+    validationErrors: [],
+    isValid: false,
+    paymentOutcome: null,
+    start: mockStart,
+    setData: mockSetData,
+    submit: mockSubmit,
+    clearPaymentOutcome: jest.fn(),
+    ...overrides,
+  };
+}
+
+// Mount inside act, then read the tree after commit (accessing `.root` mid-act throws "unmounted").
+function render() {
+  let instance: any;
+  act(() => {
+    instance = renderer.create(createElement(RawDataFormScreen));
+  });
+  return instance;
+}
+
+const textInputs = (root: any) => root.findAll((n: any) => n.type === 'TextInput');
+const payButton = (root: any) => root.findAll((n: any) => n.type === 'TouchableOpacity')[0];
+
+describe('RawDataFormScreen (ORC-6514)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('activates the raw-data manager on mount and picks a keyboard per field', () => {
+    mockMethod = rawDataForm({ requiredInputs: ['PHONE_NUMBER', 'OTP', 'CARDHOLDER_NAME'] });
+    const root = render().root;
+
+    expect(mockStart).toHaveBeenCalledTimes(1);
+    const inputs = textInputs(root);
+    expect(inputs).toHaveLength(3);
+    // PHONE_NUMBER → phone-pad (so '+' works); other numeric fields → number-pad; text → default.
+    expect(inputs.map((i: any) => i.props.keyboardType)).toEqual(['phone-pad', 'number-pad', 'default']);
+  });
+
+  it('forwards typed input to the SDK in the right raw-data shape', () => {
+    mockMethod = rawDataForm({ requiredInputs: ['PHONE_NUMBER'] });
+    const root = render().root;
+
+    act(() => textInputs(root)[0].props.onChangeText('912345678'));
+    expect(mockSetData).toHaveBeenCalledWith({ phoneNumber: '912345678' });
+  });
+
+  it('blocks submit until the data is valid', () => {
+    mockMethod = rawDataForm({ isValid: false });
+    const root = render().root;
+
+    expect(payButton(root).props.disabled).toBe(true);
+    act(() => payButton(root).props.onPress());
+    expect(mockSubmit).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('submits and advances to processing once valid', () => {
+    mockMethod = rawDataForm({ isValid: true });
+    const root = render().root;
+
+    expect(payButton(root).props.disabled).toBe(false);
+    act(() => payButton(root).props.onPress());
+    expect(mockReplace).toHaveBeenCalledWith('processing');
+    expect(mockSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders nothing when the method is not a raw-data form', () => {
+    mockMethod = { kind: 'card', isAvailable: true, start: jest.fn(), clearPaymentOutcome: jest.fn() };
+
+    expect(render().toJSON()).toBeNull();
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/components/buildRawData.test.ts
+++ b/src/__tests__/components/buildRawData.test.ts
@@ -1,0 +1,35 @@
+import { buildRawData } from '../../Components/internal/screens/buildRawData';
+
+describe('buildRawData', () => {
+  it('maps a BLIK one-time code (OTP) to { otp }', () => {
+    expect(buildRawData({ OTP: '123456' })).toEqual({ otp: '123456' });
+  });
+
+  it('maps the Android OTP_CODE key to { otp } as well', () => {
+    expect(buildRawData({ OTP_CODE: '654321' })).toEqual({ otp: '654321' });
+  });
+
+  it('prefers the one-time code over a phone number when both are present', () => {
+    expect(buildRawData({ OTP: '111', PHONE_NUMBER: '+44123' })).toEqual({ otp: '111' });
+  });
+
+  it('maps a phone number (MBWay) to { phoneNumber }', () => {
+    expect(buildRawData({ PHONE_NUMBER: '+351912345678' })).toEqual({ phoneNumber: '+351912345678' });
+  });
+
+  it('maps Bancontact card-fields to the card-data shape', () => {
+    expect(buildRawData({ CARD_NUMBER: '4111', EXPIRY_DATE: '03/30', CARDHOLDER_NAME: 'John Smith' })).toEqual({
+      cardNumber: '4111',
+      expiryDate: '03/30',
+      cardholderName: 'John Smith',
+    });
+  });
+
+  it('defaults missing card-fields to empty strings', () => {
+    expect(buildRawData({ CARD_NUMBER: '4111' })).toEqual({
+      cardNumber: '4111',
+      expiryDate: '',
+      cardholderName: '',
+    });
+  });
+});

--- a/src/__tests__/components/buildRawData.test.ts
+++ b/src/__tests__/components/buildRawData.test.ts
@@ -1,35 +1,42 @@
 import { buildRawData } from '../../Components/internal/screens/buildRawData';
 
+// The payload shape is chosen by payment method type, not by which fields happen to be present.
 describe('buildRawData', () => {
-  it('maps a BLIK one-time code (OTP) to { otp }', () => {
-    expect(buildRawData({ OTP: '123456' })).toEqual({ otp: '123456' });
+  it('maps a BLIK one-time code (iOS OTP) to { otp }', () => {
+    expect(buildRawData('ADYEN_BLIK', { OTP: '123456' })).toEqual({ otp: '123456' });
   });
 
   it('maps the Android OTP_CODE key to { otp } as well', () => {
-    expect(buildRawData({ OTP_CODE: '654321' })).toEqual({ otp: '654321' });
+    expect(buildRawData('ADYEN_BLIK', { OTP_CODE: '654321' })).toEqual({ otp: '654321' });
   });
 
-  it('prefers the one-time code over a phone number when both are present', () => {
-    expect(buildRawData({ OTP: '111', PHONE_NUMBER: '+44123' })).toEqual({ otp: '111' });
+  it('picks the shape by type, ignoring unrelated fields', () => {
+    expect(buildRawData('ADYEN_BLIK', { OTP: '111', PHONE_NUMBER: '+44123' })).toEqual({ otp: '111' });
   });
 
   it('maps a phone number (MBWay) to { phoneNumber }', () => {
-    expect(buildRawData({ PHONE_NUMBER: '+351912345678' })).toEqual({ phoneNumber: '+351912345678' });
+    expect(buildRawData('ADYEN_MBWAY', { PHONE_NUMBER: '+351912345678' })).toEqual({ phoneNumber: '+351912345678' });
   });
 
   it('maps Bancontact card-fields to the card-data shape', () => {
-    expect(buildRawData({ CARD_NUMBER: '4111', EXPIRY_DATE: '03/30', CARDHOLDER_NAME: 'John Smith' })).toEqual({
-      cardNumber: '4111',
-      expiryDate: '03/30',
-      cardholderName: 'John Smith',
-    });
+    expect(
+      buildRawData('ADYEN_BANCONTACT_CARD', {
+        CARD_NUMBER: '4111',
+        EXPIRY_DATE: '03/30',
+        CARDHOLDER_NAME: 'John Smith',
+      })
+    ).toEqual({ cardNumber: '4111', expiryDate: '03/30', cardholderName: 'John Smith' });
   });
 
-  it('defaults missing card-fields to empty strings', () => {
-    expect(buildRawData({ CARD_NUMBER: '4111' })).toEqual({
+  it('defaults missing Bancontact fields to empty strings', () => {
+    expect(buildRawData('ADYEN_BANCONTACT_CARD', { CARD_NUMBER: '4111' })).toEqual({
       cardNumber: '4111',
       expiryDate: '',
       cardholderName: '',
     });
+  });
+
+  it('returns an empty payload for an unknown type — no silent card fallthrough', () => {
+    expect(buildRawData('SOMETHING_ELSE', { OTP: '123', CARD_NUMBER: '4111' })).toEqual({});
   });
 });

--- a/src/__tests__/components/routeMethodSelection.test.ts
+++ b/src/__tests__/components/routeMethodSelection.test.ts
@@ -21,8 +21,10 @@ describe('routeMethodSelection', () => {
     expect(routeMethodSelection('ADYEN_DOTPAY', ['COMPONENT_WITH_REDIRECT'])).toBe('bankSelection');
   });
 
-  it('routes a non-card RAW_DATA method to unsupported until the rawDataForm split lands in #394', () => {
-    expect(routeMethodSelection('ADYEN_BANCONTACT_CARD', ['RAW_DATA'])).toBe('unsupported');
+  it('routes non-card RAW_DATA methods (Bancontact/MBWay/BLIK) to rawDataForm', () => {
+    expect(routeMethodSelection('ADYEN_BANCONTACT_CARD', ['RAW_DATA'])).toBe('rawDataForm');
+    expect(routeMethodSelection('ADYEN_MBWAY', ['RAW_DATA'])).toBe('rawDataForm');
+    expect(routeMethodSelection('ADYEN_BLIK', ['RAW_DATA'])).toBe('rawDataForm');
   });
 
   it('returns unsupported for a category that is not yet routed', () => {

--- a/src/__tests__/components/routeMethodSelection.test.ts
+++ b/src/__tests__/components/routeMethodSelection.test.ts
@@ -27,6 +27,12 @@ describe('routeMethodSelection', () => {
     expect(routeMethodSelection('ADYEN_BLIK', ['RAW_DATA'])).toBe('rawDataForm');
   });
 
+  it('leaves other RAW_DATA methods (e.g. XENDIT_RETAIL_OUTLETS) unsupported', () => {
+    // Retail-outlets needs a list picker, not the free-text form; OVO/others aren't wired yet.
+    expect(routeMethodSelection('XENDIT_RETAIL_OUTLETS', ['RAW_DATA'])).toBe('unsupported');
+    expect(routeMethodSelection('XENDIT_OVO', ['RAW_DATA'])).toBe('unsupported');
+  });
+
   it('returns unsupported for a category that is not yet routed', () => {
     expect(routeMethodSelection('SOME_FUTURE_METHOD', ['CARD_COMPONENTS'])).toBe('unsupported');
   });

--- a/src/__tests__/components/usePrimerPaymentMethod.test.tsx
+++ b/src/__tests__/components/usePrimerPaymentMethod.test.tsx
@@ -54,6 +54,7 @@ import { PrimerError } from '../../models/PrimerError';
 import type {
   BankSelectionPaymentMethod,
   NativeUiPaymentMethod,
+  RawDataFormPaymentMethod,
   UsePrimerPaymentMethodReturn,
 } from '../../Components/types/PrimerPaymentMethodTypes';
 
@@ -80,6 +81,14 @@ function asNativeUi(c: UsePrimerPaymentMethodReturn): NativeUiPaymentMethod {
 function asBankSelection(c: UsePrimerPaymentMethodReturn): BankSelectionPaymentMethod {
   if (c.kind !== 'bankSelection') {
     throw new Error(`expected kind 'bankSelection', got '${c.kind}'`);
+  }
+  return c;
+}
+
+/** Asserts the captured controller is the `rawDataForm` variant and returns it typed. */
+function asRawDataForm(c: UsePrimerPaymentMethodReturn): RawDataFormPaymentMethod {
+  if (c.kind !== 'rawDataForm') {
+    throw new Error(`expected kind 'rawDataForm', got '${c.kind}'`);
   }
   return c;
 }
@@ -513,6 +522,27 @@ describe('usePrimerPaymentMethod', () => {
         asBankSelection(captures[captures.length - 1]!).filter('rabo');
       });
       expect(banksNative.onBankFilterChange).toHaveBeenCalledWith('rabo');
+    });
+  });
+
+  describe('raw-data form methods (Bancontact/MBWay/BLIK)', () => {
+    it('routes a non-card RAW_DATA method (MBWay) to kind "rawDataForm" with the form contract', async () => {
+      const captures = await mountWithMethods(
+        [{ paymentMethodType: 'ADYEN_MBWAY', categories: ['RAW_DATA'] }],
+        'ADYEN_MBWAY'
+      );
+      const form = asRawDataForm(captures[captures.length - 1]!);
+      expect(form.isAvailable).toBe(true);
+      expect(form.requiredInputs).toEqual([]); // populated once start() activates the raw-data manager
+      expect(form.isValid).toBe(false);
+    });
+
+    it('Bancontact also routes to rawDataForm (not the card form)', async () => {
+      const captures = await mountWithMethods(
+        [{ paymentMethodType: 'ADYEN_BANCONTACT_CARD', categories: ['RAW_DATA'] }],
+        'ADYEN_BANCONTACT_CARD'
+      );
+      expect(captures[captures.length - 1]!.kind).toBe('rawDataForm');
     });
   });
 });

--- a/src/models/PrimerRawData.ts
+++ b/src/models/PrimerRawData.ts
@@ -21,3 +21,7 @@ export interface PrimerBancontactCardData extends PrimerRawData {
 export interface PrimerRetailerData extends PrimerRawData {
   id: string;
 }
+
+export interface PrimerOtpData extends PrimerRawData {
+  otp: string;
+}


### PR DESCRIPTION
## Summary

- Adds the `rawDataForm` kind: Bancontact, MBWay, BLIK via the Headless RAW_DATA manager.
- New `RawDataFormScreen` + `buildRawData` (builds the typed raw payload per method) with unit tests.
- BLIK OTP bridged through native: iOS `PrimerOTPData+Extension.swift`, Android `PrimerRNOtpData.kt` + raw manager.

## Jira

[ORC-6514]

## Test plan

- [x] `yarn typecheck` / `yarn lint` / `yarn test` green
- [x] iOS + Android — BLIK (PL/PLN): form → OTP submit → outcome routes to the result screen with a populated `errorId` (BLIK can't reach SUCCESS in sandbox — expected)

[ORC-6514]: https://primerapi.atlassian.net/browse/ORC-6514
