### PR TITLE
feat(components): wire checkout analytics events and logging

### DIFF
--- a/__mocks__/react-native.js
+++ b/__mocks__/react-native.js
@@ -82,7 +82,18 @@ const reactNative = {
   NativeModules: {},
   Platform,
   StyleSheet,
-  TurboModuleRegistry: { get: () => null, getEnforcing: () => ({}) },
+  // Every TurboModule method resolves as an async no-op so a new spec method can never
+  // crash tests; suites that assert calls spy on the JS wrappers (e.g. PrimerAnalytics).
+  TurboModuleRegistry: {
+    get: () => null,
+    getEnforcing: () =>
+      new Proxy(
+        {},
+        {
+          get: (target, prop) => (prop === 'then' ? undefined : () => Promise.resolve(null)),
+        }
+      ),
+  },
   requireNativeComponent: (name) => makeComponent(name),
   useColorScheme: () => 'light',
   useWindowDimensions: () => ({ width: 375, height: 812, scale: 2, fontScale: 1 }),

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -133,9 +133,9 @@ dependencies {
   implementation 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3"
-  implementation 'io.primer:android:3.0.0-beta.3'
-  implementation 'io.primer:components-analytics:3.0.0-beta.3'
-  implementation 'io.primer:components-bridge:3.0.0-beta.3'
+  implementation 'io.primer:android:3.0.0-beta.4'
+  implementation 'io.primer:components-analytics:3.0.0-beta.4'
+  implementation 'io.primer:components-bridge:3.0.0-beta.4'
   testImplementation 'io.mockk:mockk:1.14.2'
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'

--- a/android/src/main/java/com/primerioreactnative/DefaultNativePrimerModule.kt
+++ b/android/src/main/java/com/primerioreactnative/DefaultNativePrimerModule.kt
@@ -262,10 +262,26 @@ internal open class DefaultNativePrimerModule(
     fun sendLog(
         message: String,
         event: String,
+        initDurationMs: Double?,
         promise: Promise,
     ) {
         try {
-            analyticsLoggingBridge?.sendInfoLog(message, event)
+            analyticsLoggingBridge?.sendInfoLog(message, event, initDurationMs?.toLong())
+            promise.resolve(null)
+        } catch (expected: Exception) {
+            promise.resolve(null)
+        }
+    }
+
+    fun sendErrorLog(
+        message: String,
+        event: String?,
+        errorMessage: String?,
+        stack: String?,
+        promise: Promise,
+    ) {
+        try {
+            analyticsLoggingBridge?.sendErrorLog(message, event, errorMessage, stack)
             promise.resolve(null)
         } catch (expected: Exception) {
             promise.resolve(null)

--- a/android/src/main/java/com/primerioreactnative/utils/AnalyticsEventMapper.kt
+++ b/android/src/main/java/com/primerioreactnative/utils/AnalyticsEventMapper.kt
@@ -1,5 +1,6 @@
 package com.primerioreactnative.utils
 
+import android.util.Log
 import io.primer.android.components.analytics.data.model.AnalyticsEvent
 
 @Suppress("CyclomaticComplexMethod", "ReturnCount")
@@ -9,7 +10,7 @@ internal fun toAnalyticsEvent(name: String, metadata: Map<String, String>?): Ana
         "SDK_INIT_END" -> AnalyticsEvent.SdkInitEnd
         "CHECKOUT_FLOW_STARTED" -> AnalyticsEvent.CheckoutFlowStarted
         "PAYMENT_FLOW_EXITED" -> AnalyticsEvent.PaymentFlowExited
-        "PAYMENT_REATTEMPTED" -> AnalyticsEvent.PaymentReattempted
+        "PAYMENT_REATTEMPTED" -> AnalyticsEvent.PaymentReattempted(metadata?.get("paymentMethod"))
 
         "PAYMENT_METHOD_SELECTION" -> {
             val paymentMethod = metadata?.get("paymentMethod") ?: return null
@@ -49,6 +50,9 @@ internal fun toAnalyticsEvent(name: String, metadata: Map<String, String>?): Ana
             AnalyticsEvent.PaymentRedirect(paymentMethod, redirectDestinationUrl)
         }
 
-        else -> null
+        else -> {
+            Log.d("AnalyticsEventMapper", "Dropping unknown analytics event: $name")
+            null
+        }
     }
 }

--- a/android/src/main/java/com/primerioreactnative/utils/AnalyticsEventMapper.kt
+++ b/android/src/main/java/com/primerioreactnative/utils/AnalyticsEventMapper.kt
@@ -1,6 +1,5 @@
 package com.primerioreactnative.utils
 
-import android.util.Log
 import io.primer.android.components.analytics.data.model.AnalyticsEvent
 
 @Suppress("CyclomaticComplexMethod", "ReturnCount")
@@ -50,9 +49,6 @@ internal fun toAnalyticsEvent(name: String, metadata: Map<String, String>?): Ana
             AnalyticsEvent.PaymentRedirect(paymentMethod, redirectDestinationUrl)
         }
 
-        else -> {
-            Log.d("AnalyticsEventMapper", "Dropping unknown analytics event: $name")
-            null
-        }
+        else -> null
     }
 }

--- a/android/src/newarch/java/com/primerioreactnative/NativePrimerModule.kt
+++ b/android/src/newarch/java/com/primerioreactnative/NativePrimerModule.kt
@@ -114,8 +114,24 @@ class NativePrimerModule(private val reactContext: ReactApplicationContext, priv
     implementation.trackAnalyticsEvent(eventName = eventName, metadata = metadata, promise = promise)
   }
 
-  override fun sendLog(message: String, event: String, promise: Promise) {
-    implementation.sendLog(message = message, event = event, promise = promise)
+  override fun sendLog(message: String, event: String, initDurationMs: Double?, promise: Promise) {
+    implementation.sendLog(message = message, event = event, initDurationMs = initDurationMs, promise = promise)
+  }
+
+  override fun sendErrorLog(
+    message: String,
+    event: String?,
+    errorMessage: String?,
+    stack: String?,
+    promise: Promise
+  ) {
+    implementation.sendErrorLog(
+      message = message,
+      event = event,
+      errorMessage = errorMessage,
+      stack = stack,
+      promise = promise
+    )
   }
 
   override fun setupAnalyticsLoggingBridge(clientToken: String, promise: Promise) {

--- a/android/src/oldarch/java/com/primerioreactnative/NativePrimerModule.kt
+++ b/android/src/oldarch/java/com/primerioreactnative/NativePrimerModule.kt
@@ -139,8 +139,25 @@ class NativePrimerModule(private val reactContext: ReactApplicationContext, priv
   }
 
   @ReactMethod
-  fun sendLog(message: String, event: String, promise: Promise) {
-    implementation.sendLog(message = message, event = event, promise = promise)
+  fun sendLog(message: String, event: String, initDurationMs: Double?, promise: Promise) {
+    implementation.sendLog(message = message, event = event, initDurationMs = initDurationMs, promise = promise)
+  }
+
+  @ReactMethod
+  fun sendErrorLog(
+    message: String,
+    event: String?,
+    errorMessage: String?,
+    stack: String?,
+    promise: Promise
+  ) {
+    implementation.sendErrorLog(
+      message = message,
+      event = event,
+      errorMessage = errorMessage,
+      stack = stack,
+      promise = promise
+    )
   }
 
   @ReactMethod

--- a/android/src/test/java/com/primerioreactnative/utils/AnalyticsEventMapperTest.kt
+++ b/android/src/test/java/com/primerioreactnative/utils/AnalyticsEventMapperTest.kt
@@ -31,14 +31,26 @@ internal class AnalyticsEventMapperTest {
         }
 
         @Test
-        fun `toAnalyticsEvent returns PaymentReattempted`() {
-            assertEquals(AnalyticsEvent.PaymentReattempted, toAnalyticsEvent("PAYMENT_REATTEMPTED", null))
-        }
-
-        @Test
         fun `toAnalyticsEvent ignores metadata for data object events`() {
             val metadata = mapOf("paymentMethod" to "PAYMENT_CARD")
             assertEquals(AnalyticsEvent.SdkInitStart, toAnalyticsEvent("SDK_INIT_START", metadata))
+        }
+    }
+
+    @Nested
+    inner class `PaymentReattempted event` {
+        @Test
+        fun `toAnalyticsEvent returns PaymentReattempted with paymentMethod`() {
+            val metadata = mapOf("paymentMethod" to "PAYMENT_CARD")
+            assertEquals(
+                AnalyticsEvent.PaymentReattempted("PAYMENT_CARD"),
+                toAnalyticsEvent("PAYMENT_REATTEMPTED", metadata),
+            )
+        }
+
+        @Test
+        fun `toAnalyticsEvent returns PaymentReattempted with null paymentMethod when absent`() {
+            assertEquals(AnalyticsEvent.PaymentReattempted(null), toAnalyticsEvent("PAYMENT_REATTEMPTED", null))
         }
     }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -15,7 +15,7 @@ PODS:
     - fmt
     - glog
     - hermes-engine
-    - PrimerSDK (= 3.0.0-beta.1)
+    - PrimerSDK (= 3.0.0-beta.2)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -38,37 +38,37 @@ PODS:
     - SocketRocket
     - Yoga
   - Primer3DS (2.8.0)
-  - PrimerBDCCore (3.0.0-beta.1):
-    - PrimerBDCEngine (= 3.0.0-beta.1)
-    - PrimerFoundation (= 3.0.0-beta.1)
-    - PrimerStepResolver (= 3.0.0-beta.1)
-  - PrimerBDCEngine (3.0.0-beta.1):
-    - PrimerFoundation (= 3.0.0-beta.1)
-    - PrimerStepResolver (= 3.0.0-beta.1)
-  - PrimerCore (3.0.0-beta.1):
+  - PrimerBDCCore (3.0.0-beta.2):
+    - PrimerBDCEngine (= 3.0.0-beta.2)
+    - PrimerFoundation (= 3.0.0-beta.2)
+    - PrimerStepResolver (= 3.0.0-beta.2)
+  - PrimerBDCEngine (3.0.0-beta.2):
+    - PrimerFoundation (= 3.0.0-beta.2)
+    - PrimerStepResolver (= 3.0.0-beta.2)
+  - PrimerCore (3.0.0-beta.2):
     - Primer3DS
-    - PrimerFoundation (= 3.0.0-beta.1)
-  - PrimerFoundation (3.0.0-beta.1)
+    - PrimerFoundation (= 3.0.0-beta.2)
+  - PrimerFoundation (3.0.0-beta.2)
   - PrimerIPay88MYSDK (0.1.7)
   - PrimerKlarnaSDK (1.3.1)
-  - PrimerNetworking (3.0.0-beta.1):
-    - PrimerFoundation (= 3.0.0-beta.1)
-  - PrimerResources (3.0.0-beta.1)
-  - PrimerSDK (3.0.0-beta.1):
-    - PrimerSDK/Core (= 3.0.0-beta.1)
-  - PrimerSDK/Core (3.0.0-beta.1):
-    - PrimerBDCCore (= 3.0.0-beta.1)
-    - PrimerBDCEngine (= 3.0.0-beta.1)
-    - PrimerCore (= 3.0.0-beta.1)
-    - PrimerFoundation (= 3.0.0-beta.1)
-    - PrimerNetworking (= 3.0.0-beta.1)
-    - PrimerResources (= 3.0.0-beta.1)
-    - PrimerStepResolver (= 3.0.0-beta.1)
-    - PrimerUI (= 3.0.0-beta.1)
-  - PrimerStepResolver (3.0.0-beta.1):
-    - PrimerFoundation (= 3.0.0-beta.1)
+  - PrimerNetworking (3.0.0-beta.2):
+    - PrimerFoundation (= 3.0.0-beta.2)
+  - PrimerResources (3.0.0-beta.2)
+  - PrimerSDK (3.0.0-beta.2):
+    - PrimerSDK/Core (= 3.0.0-beta.2)
+  - PrimerSDK/Core (3.0.0-beta.2):
+    - PrimerBDCCore (= 3.0.0-beta.2)
+    - PrimerBDCEngine (= 3.0.0-beta.2)
+    - PrimerCore (= 3.0.0-beta.2)
+    - PrimerFoundation (= 3.0.0-beta.2)
+    - PrimerNetworking (= 3.0.0-beta.2)
+    - PrimerResources (= 3.0.0-beta.2)
+    - PrimerStepResolver (= 3.0.0-beta.2)
+    - PrimerUI (= 3.0.0-beta.2)
+  - PrimerStepResolver (3.0.0-beta.2):
+    - PrimerFoundation (= 3.0.0-beta.2)
   - PrimerStripeSDK (1.0.0)
-  - PrimerUI (3.0.0-beta.1)
+  - PrimerUI (3.0.0-beta.2)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -2727,20 +2727,20 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  primer-io-react-native: 4f44f7a04785273960d2acc20f9e89d5b69377fc
+  primer-io-react-native: 7e42b87e182ad1e7b049ca7994bb7a365ae8f96e
   Primer3DS: b8b583ef260f703180870358bc55069de74f8f51
-  PrimerBDCCore: 069874e54362460c7e531f142dcb2a6bd7a323ea
-  PrimerBDCEngine: 12a3ef4305a2517545dbfbf5f84fdccda4a56f87
-  PrimerCore: 123e9b2691b95da631225a33a82e405aa9d3fde2
-  PrimerFoundation: ad8b64adb9b2935be936ad3ec987a02948fe32dd
+  PrimerBDCCore: efc042e93032ecb7c245c360a1516108db9b6dc4
+  PrimerBDCEngine: 87ade1f58437a2e4d8ac281729cc249585beaafb
+  PrimerCore: 09dc8d8a2ef6252338a5a207139820315e48a052
+  PrimerFoundation: 129302e83f5e90e66a5e5c5e236fac1b6383cd13
   PrimerIPay88MYSDK: 436ee0be7e2c97e4e81456ccddee20175e9e3c4d
   PrimerKlarnaSDK: 104962584ac6baad20424f73ee8493c8503fd487
-  PrimerNetworking: 2f3abd365ae16030f9d5edb3035a3f987ea73f33
-  PrimerResources: 7fc280fb7f0db39b5267fd7c090e714cefe21b09
-  PrimerSDK: aea5a2fb079b24ad59298a331f4901e6fe53b17a
-  PrimerStepResolver: 36fbe38ea43052d8960fc68c183bbb18a0c2d5ea
+  PrimerNetworking: e0b2e7eef077e47e50f189ba0af00894eccb0c1b
+  PrimerResources: 976e09729a7994cded08296f48cdf10b0f6cad4d
+  PrimerSDK: ed2b46b6593eebe1b6858235f69e0ed1e99b2215
+  PrimerStepResolver: 865afdd8e141e2e68936d7da85ccf8808232675b
   PrimerStripeSDK: c37d4e7c1b5256d67d4890c4cc4b38ddc9427489
-  PrimerUI: ea8c9e78cb78e09b4458190954b16b9fe0b1bb5a
+  PrimerUI: ca288e3f820cf1fc41b695ead663a98fdff697f0
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
   RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a

--- a/ios/Sources/NativePrimer/RCTNativePrimer.mm
+++ b/ios/Sources/NativePrimer/RCTNativePrimer.mm
@@ -137,9 +137,19 @@ RCT_EXPORT_METHOD(trackAnalyticsEvent:(NSString *)eventName
 
 RCT_EXPORT_METHOD(sendLog:(NSString *)message
                   event:(NSString *)event
+                  initDurationMs:(NSNumber * _Nullable)initDurationMs
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    [self.primer sendLog:message event:event resolver:resolve rejecter:reject];
+    [self.primer sendLog:message event:event initDurationMs:initDurationMs resolver:resolve rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(sendErrorLog:(NSString *)message
+                  event:(NSString * _Nullable)event
+                  errorMessage:(NSString * _Nullable)errorMessage
+                  stack:(NSString * _Nullable)stack
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    [self.primer sendErrorLog:message event:event errorMessage:errorMessage stack:stack resolver:resolve rejecter:reject];
 }
 
 RCT_EXPORT_METHOD(setupAnalyticsLoggingBridge:(NSString *)clientToken
@@ -210,8 +220,12 @@ RCT_EXPORT_METHOD(setupAnalyticsLoggingBridge:(NSString *)clientToken
     [self.primer trackAnalyticsEvent:eventName metadata:metadata resolver:resolve rejecter:reject];
 }
 
-- (void)sendLog:(nonnull NSString *)message event:(nonnull NSString *)event resolve:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject {
-    [self.primer sendLog:message event:event resolver:resolve rejecter:reject];
+- (void)sendLog:(nonnull NSString *)message event:(nonnull NSString *)event initDurationMs:(NSNumber *)initDurationMs resolve:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject {
+    [self.primer sendLog:message event:event initDurationMs:initDurationMs resolver:resolve rejecter:reject];
+}
+
+- (void)sendErrorLog:(nonnull NSString *)message event:(NSString *)event errorMessage:(NSString *)errorMessage stack:(NSString *)stack resolve:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject {
+    [self.primer sendErrorLog:message event:event errorMessage:errorMessage stack:stack resolver:resolve rejecter:reject];
 }
 
 - (void)setupAnalyticsLoggingBridge:(nonnull NSString *)clientToken resolve:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject {

--- a/ios/Sources/RNTPrimer.swift
+++ b/ios/Sources/RNTPrimer.swift
@@ -367,11 +367,35 @@ enum PrimerEvents: Int, CaseIterable {
     public func sendLog(
         _ message: String,
         event: String,
+        initDurationMs: NSNumber?,
         resolver: @escaping RCTPromiseResolveBlock,
         rejecter: @escaping RCTPromiseRejectBlock
     ) {
         DispatchQueue.main.async {
-            Task { await self.analyticsLoggingBridge?.logInfo(message: message, event: event) }
+            let userInfo: [String: Any]? = initDurationMs.map { ["init_duration_ms": $0.intValue] }
+            Task { await self.analyticsLoggingBridge?.logInfo(message: message, event: event, userInfo: userInfo) }
+            resolver(nil)
+        }
+    }
+
+    @objc
+    public func sendErrorLog(
+        _ message: String,
+        event: String?,
+        errorMessage: String?,
+        stack: String?,
+        resolver: @escaping RCTPromiseResolveBlock,
+        rejecter: @escaping RCTPromiseRejectBlock
+    ) {
+        DispatchQueue.main.async {
+            Task {
+                await self.analyticsLoggingBridge?.logError(
+                    message: message,
+                    event: event,
+                    errorMessage: errorMessage,
+                    stack: stack
+                )
+            }
             resolver(nil)
         }
     }

--- a/ios/Sources/RNTPrimer.swift
+++ b/ios/Sources/RNTPrimer.swift
@@ -379,6 +379,8 @@ enum PrimerEvents: Int, CaseIterable {
     }
 
     @objc
+    // resolver + rejecter are framework-mandated on RN promise bridges.
+    // swiftlint:disable:next function_parameter_count
     public func sendErrorLog(
         _ message: String,
         event: String?,

--- a/primer-io-react-native.podspec
+++ b/primer-io-react-native.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.private_header_files = ['ios/PrimerSwiftInterop.h' ]
 
   s.dependency "React-Core"
-  s.dependency "PrimerSDK", "3.0.0-beta.1"
+  s.dependency "PrimerSDK", "3.0.0-beta.2"
 
   s.pod_target_xcconfig = {
     "SWIFT_ENABLE_EXPLICIT_MODULES" => "NO"

--- a/src/Components/PrimerCheckoutProvider.tsx
+++ b/src/Components/PrimerCheckoutProvider.tsx
@@ -167,6 +167,34 @@ export function PrimerCheckoutProvider({
   const stateRef = useRef(state);
   stateRef.current = state;
 
+  // Analytics session state: dedup SELECTION per method, correlate outcomes with the attempted
+  // method, and drive REATTEMPTED / FLOW_EXITED semantics. Reset per client token.
+  const selectionSentRef = useRef<Set<string>>(new Set());
+  const lastAttemptedMethodRef = useRef<string | null>(null);
+  const hadFailureRef = useRef(false);
+  const hadSuccessRef = useRef(false);
+  const becameReadyRef = useRef(false);
+
+  const trackSelection = useCallback((paymentMethod: string) => {
+    if (selectionSentRef.current.has(paymentMethod)) return;
+    selectionSentRef.current.add(paymentMethod);
+    void PrimerAnalytics.trackEvent('PAYMENT_METHOD_SELECTION', { paymentMethod });
+  }, []);
+
+  // Fires the attempt-start events shared by every pay path: REATTEMPTED (when retrying after a
+  // failure), SUBMITTED (form/vault submits — not wallet handoffs), then PROCESSING_STARTED.
+  const trackAttemptStart = useCallback((paymentMethod: string, options: { submitted: boolean }) => {
+    lastAttemptedMethodRef.current = paymentMethod;
+    if (hadFailureRef.current) {
+      hadFailureRef.current = false;
+      void PrimerAnalytics.trackEvent('PAYMENT_REATTEMPTED', { paymentMethod });
+    }
+    if (options.submitted) {
+      void PrimerAnalytics.trackEvent('PAYMENT_SUBMITTED', { paymentMethod });
+    }
+    void PrimerAnalytics.trackEvent('PAYMENT_PROCESSING_STARTED', { paymentMethod });
+  }, []);
+
   // Native manager. Lifecycle is driven by `state.activeMethod` — the method the user
   // picked on the selection screen — so it survives the card-form view mount/unmount.
   const managerRef = useRef<PrimerHeadlessUniversalCheckoutRawDataManager | null>(null);
@@ -195,7 +223,13 @@ export function PrimerCheckoutProvider({
   // -----------------------------------------------------------------------
   useEffect(() => {
     setState(initialState);
+    selectionSentRef.current = new Set();
+    lastAttemptedMethodRef.current = null;
+    hadFailureRef.current = false;
+    hadSuccessRef.current = false;
+    becameReadyRef.current = false;
     let cancelled = false;
+    const initStartedAt = Date.now();
 
     async function init() {
       const userCallbacks = settingsRef.current?.headlessUniversalCheckoutCallbacks;
@@ -312,6 +346,22 @@ export function PrimerCheckoutProvider({
       const methods = await PrimerHeadlessUniversalCheckout.startWithClientToken(clientToken, mergedSettings);
 
       if (!cancelled) {
+        // Bridge setup must follow native init: the Android bridge resolves the SDK's DI
+        // container (null forever if created earlier) and iOS reuses the live checkout session
+        // id. Telemetry must never block checkout, so failures only warn.
+        try {
+          await PrimerAnalytics.setup(clientToken);
+          void PrimerAnalytics.trackEvent('SDK_INIT_START');
+          void PrimerAnalytics.trackEvent('SDK_INIT_END');
+          void PrimerAnalytics.sendLog(
+            'Checkout components initialized',
+            'checkout-initialized',
+            Date.now() - initStartedAt
+          );
+        } catch (analyticsErr) {
+          console.warn(`${LOG} analytics setup failed ${fmt(analyticsErr)}`);
+        }
+
         // Seed isLoadingResources atomically with isReady so consumers don't see a
         // brief "ready but no resources loading" window before the fetch effect runs.
         setState((prev) => ({
@@ -322,11 +372,26 @@ export function PrimerCheckoutProvider({
           isLoadingResources: true,
           resourcesError: null,
         }));
+        becameReadyRef.current = true;
+        void PrimerAnalytics.trackEvent('CHECKOUT_FLOW_STARTED');
       }
     }
 
     init().catch((err) => {
       console.error(`${LOG} init failed ${fmt(err)}`);
+      // Best effort: setup may not have run — on iOS the log still ships (the bridge decodes
+      // the token standalone); on Android pre-init logs are a known accepted drop.
+      const primerErr = err as PrimerError | Error;
+      void PrimerAnalytics.setup(clientToken)
+        .then(() =>
+          PrimerAnalytics.sendErrorLog(
+            'Checkout initialization failed',
+            'checkout-init-failed',
+            'description' in primerErr ? primerErr.description : primerErr.message,
+            primerErr instanceof Error ? primerErr.stack : undefined
+          )
+        )
+        .catch(() => {});
       if (!cancelled) {
         setState((prev) => ({ ...prev, error: err }));
       }
@@ -334,11 +399,46 @@ export function PrimerCheckoutProvider({
 
     return () => {
       cancelled = true;
+      // Session ends without a completed payment (unmount or token change) → funnel exit.
+      if (becameReadyRef.current && !hadSuccessRef.current) {
+        void PrimerAnalytics.trackEvent('PAYMENT_FLOW_EXITED');
+      }
       // Vault manager is tied to the native session — let the next session recreate it.
       vaultManagerRef.current = null;
       void PrimerHeadlessUniversalCheckout.cleanUp();
     };
   }, [clientToken]);
+
+  // -----------------------------------------------------------------------
+  // Analytics: single choke point for terminal outcomes. Every pay path (card
+  // submit, native-UI, vault, retry) lands in `paymentOutcome`, so SUCCESS /
+  // FAILURE emit exactly once per attempt on the null → terminal transition
+  // (each attempt clears the outcome first).
+  // -----------------------------------------------------------------------
+  useEffect(() => {
+    const outcome = state.paymentOutcome;
+    if (outcome === null) return;
+    const paymentMethod = lastAttemptedMethodRef.current ?? 'UNKNOWN';
+    if (outcome.status === 'success') {
+      hadSuccessRef.current = true;
+      void PrimerAnalytics.trackEvent('PAYMENT_SUCCESS', {
+        paymentMethod,
+        paymentId: outcome.data?.payment?.id ?? 'unknown',
+      });
+      return;
+    }
+    hadFailureRef.current = true;
+    const paymentId = outcome.data?.payment?.id;
+    void PrimerAnalytics.trackEvent('PAYMENT_FAILURE', {
+      paymentMethod,
+      ...(paymentId ? { paymentId } : null),
+    });
+    void PrimerAnalytics.sendErrorLog(
+      'Payment failed',
+      'failed-payment',
+      outcome.error?.description ?? outcome.error?.message
+    );
+  }, [state.paymentOutcome]);
 
   // -----------------------------------------------------------------------
   // Payment method resource fetch — re-runs whenever the set of available
@@ -531,8 +631,15 @@ export function PrimerCheckoutProvider({
     const manager = new PrimerHeadlessUniversalCheckoutRawDataManager();
     managerRef.current = manager;
 
+    // Once per card-form session: first invalid → valid transition.
+    let detailsEnteredFired = false;
+
     const callbacks = {
       onValidation: (isValid: boolean, errors: PrimerError[] | undefined) => {
+        if (isValid && !detailsEnteredFired) {
+          detailsEnteredFired = true;
+          void PrimerAnalytics.trackEvent('PAYMENT_DETAILS_ENTERED', { paymentMethod: method });
+        }
         const parsed = parseValidationErrors(errors);
         setState((prev) => ({
           ...prev,
@@ -611,9 +718,15 @@ export function PrimerCheckoutProvider({
   // -----------------------------------------------------------------------
   // Actions — stable identities.
   // -----------------------------------------------------------------------
-  const setActiveMethod = useCallback((method: string | null) => {
-    setState((prev) => (prev.activeMethod === method ? prev : { ...prev, activeMethod: method }));
-  }, []);
+  const setActiveMethod = useCallback(
+    (method: string | null) => {
+      if (method !== null) {
+        trackSelection(method);
+      }
+      setState((prev) => (prev.activeMethod === method ? prev : { ...prev, activeMethod: method }));
+    },
+    [trackSelection]
+  );
 
   const setRawData = useCallback(async (data: PrimerRawData) => {
     // Keep the co-badge pick sticky: merge it into every card-data payload so it
@@ -674,8 +787,9 @@ export function PrimerCheckoutProvider({
       console.warn(`${LOG} submit: no manager`);
       return;
     }
+    trackAttemptStart(stateRef.current.activeMethod ?? 'PAYMENT_CARD', { submitted: true });
     await manager.submit();
-  }, []);
+  }, [trackAttemptStart]);
 
   const retry = useCallback(async () => {
     const method = stateRef.current.activeMethod;
@@ -700,6 +814,7 @@ export function PrimerCheckoutProvider({
       }
       // Clear the previous outcome so the transitioner fires for the new attempt.
       setState((prev) => (prev.paymentOutcome === null ? prev : { ...prev, paymentOutcome: null }));
+      trackAttemptStart(method, { submitted: true });
       await manager.submit();
     } catch (err) {
       console.error(`${LOG} retry failed ${fmt(err)}`);
@@ -729,52 +844,64 @@ export function PrimerCheckoutProvider({
   // NATIVE_UI methods (Google Pay today; Apple Pay / PayPal / web-redirect APMs later) ride the
   // existing Headless NATIVE_UI path: start the native flow by type; outcomes arrive through the
   // shared onCheckoutComplete/onError. Only one native-UI flow runs at a time.
-  const startNativeUI = useCallback(async (paymentMethodType: string) => {
-    // Ignore re-entrant taps: the in-list method row isn't disabled while loading, so a fast
-    // double-tap would otherwise spawn two native flows.
-    if (stateRef.current.nativeUiInFlightType !== null) {
-      return;
-    }
-    if (paymentMethodType === GOOGLE_PAY && !isGooglePaySupported(stateRef.current.availablePaymentMethods)) {
-      throw new PrimerError(
-        'google-pay-unavailable',
-        'google-pay-unavailable',
-        'Google Pay is not available on this device.',
-        undefined,
-        undefined
-      );
-    }
-    if (paymentMethodType === APPLE_PAY && !isApplePaySupported(stateRef.current.availablePaymentMethods)) {
-      throw new PrimerError(
-        'apple-pay-unavailable',
-        'apple-pay-unavailable',
-        'Apple Pay is not available on this device.',
-        undefined,
-        undefined
-      );
-    }
-    // Clear any stale outcome so the result screen re-fires for this attempt.
-    setState((prev) => ({ ...prev, paymentOutcome: null, nativeUiInFlightType: paymentMethodType }));
-    try {
-      const manager = new PrimerHeadlessUniversalCheckoutPaymentMethodNativeUIManager();
-      await manager.configure(paymentMethodType);
-      await manager.showPaymentMethod(PrimerSessionIntent.CHECKOUT);
-      // Success / failure arrive via onCheckoutComplete / onError; shopper-cancel via
-      // onError('payment-cancelled'). nativeUiInFlightType is reset in those handlers.
-    } catch (err) {
-      console.warn(`${LOG} startNativeUI(${paymentMethodType}) failed ${fmt(err)}`);
-      const error =
-        err instanceof PrimerError
-          ? err
-          : new PrimerError('native-ui-start-failed', undefined, toError(err).message, undefined, undefined);
-      setState((prev) => ({
-        ...prev,
-        nativeUiInFlightType: null,
-        paymentOutcome: { status: 'error', error, data: null },
-      }));
-      throw error;
-    }
-  }, []);
+  const startNativeUI = useCallback(
+    async (paymentMethodType: string) => {
+      // Ignore re-entrant taps: the in-list method row isn't disabled while loading, so a fast
+      // double-tap would otherwise spawn two native flows.
+      if (stateRef.current.nativeUiInFlightType !== null) {
+        return;
+      }
+      if (paymentMethodType === GOOGLE_PAY && !isGooglePaySupported(stateRef.current.availablePaymentMethods)) {
+        throw new PrimerError(
+          'google-pay-unavailable',
+          'google-pay-unavailable',
+          'Google Pay is not available on this device.',
+          undefined,
+          undefined
+        );
+      }
+      if (paymentMethodType === APPLE_PAY && !isApplePaySupported(stateRef.current.availablePaymentMethods)) {
+        throw new PrimerError(
+          'apple-pay-unavailable',
+          'apple-pay-unavailable',
+          'Apple Pay is not available on this device.',
+          undefined,
+          undefined
+        );
+      }
+      // Clear any stale outcome so the result screen re-fires for this attempt.
+      setState((prev) => ({ ...prev, paymentOutcome: null, nativeUiInFlightType: paymentMethodType }));
+      // Wallet/APM handoff: the tap both selects the method and hands processing to the native
+      // flow (no form, so no SUBMITTED — matches the Web sequence for wallets).
+      trackSelection(paymentMethodType);
+      trackAttemptStart(paymentMethodType, { submitted: false });
+      try {
+        const manager = new PrimerHeadlessUniversalCheckoutPaymentMethodNativeUIManager();
+        await manager.configure(paymentMethodType);
+        await manager.showPaymentMethod(PrimerSessionIntent.CHECKOUT);
+        // Success / failure arrive via onCheckoutComplete / onError; shopper-cancel via
+        // onError('payment-cancelled'). nativeUiInFlightType is reset in those handlers.
+      } catch (err) {
+        console.warn(`${LOG} startNativeUI(${paymentMethodType}) failed ${fmt(err)}`);
+        const error =
+          err instanceof PrimerError
+            ? err
+            : new PrimerError('native-ui-start-failed', undefined, toError(err).message, undefined, undefined);
+        void PrimerAnalytics.sendErrorLog(
+          'Unable to present payment method',
+          'unable-to-present-payment-method',
+          `${paymentMethodType}: ${error.description ?? error.message}`
+        );
+        setState((prev) => ({
+          ...prev,
+          nativeUiInFlightType: null,
+          paymentOutcome: { status: 'error', error, data: null },
+        }));
+        throw error;
+      }
+    },
+    [trackSelection, trackAttemptStart]
+  );
 
   const cancelNativeUI = useCallback((paymentMethodType: string) => {
     // The native sheet is a system surface JS can't force-close (FR-002b), so we only clear the
@@ -834,6 +961,8 @@ export function PrimerCheckoutProvider({
       }
       // Clear any stale outcome so PaymentOutcomeTransitioner re-fires for this attempt.
       setState((prev) => (prev.paymentOutcome === null ? prev : { ...prev, paymentOutcome: null }));
+      // Vaulted pay is a card payment: same SUBMITTED → PROCESSING → outcome sequence.
+      trackAttemptStart('PAYMENT_CARD', { submitted: true });
       try {
         await vm.startPaymentFlow(vaultedPaymentMethodId, additionalData);
       } catch (err) {

--- a/src/Components/PrimerCheckoutProvider.tsx
+++ b/src/Components/PrimerCheckoutProvider.tsx
@@ -167,8 +167,7 @@ export function PrimerCheckoutProvider({
   const stateRef = useRef(state);
   stateRef.current = state;
 
-  // Analytics session state: dedup SELECTION per method, correlate outcomes with the attempted
-  // method, and drive REATTEMPTED / FLOW_EXITED semantics. Reset per client token.
+  // Analytics session state (reset per client token): SELECTION dedup + outcome correlation.
   const selectionSentRef = useRef<Set<string>>(new Set());
   const lastAttemptedMethodRef = useRef<string | null>(null);
   const hadFailureRef = useRef(false);
@@ -181,8 +180,7 @@ export function PrimerCheckoutProvider({
     void PrimerAnalytics.trackEvent('PAYMENT_METHOD_SELECTION', { paymentMethod });
   }, []);
 
-  // Fires the attempt-start events shared by every pay path: REATTEMPTED (when retrying after a
-  // failure), SUBMITTED (form/vault submits — not wallet handoffs), then PROCESSING_STARTED.
+  // Attempt-start events shared by every pay path: REATTEMPTED (after failure), optional SUBMITTED, PROCESSING.
   const trackAttemptStart = useCallback((paymentMethod: string, options: { submitted: boolean }) => {
     lastAttemptedMethodRef.current = paymentMethod;
     if (hadFailureRef.current) {
@@ -346,9 +344,7 @@ export function PrimerCheckoutProvider({
       const methods = await PrimerHeadlessUniversalCheckout.startWithClientToken(clientToken, mergedSettings);
 
       if (!cancelled) {
-        // Bridge setup must follow native init: the Android bridge resolves the SDK's DI
-        // container (null forever if created earlier) and iOS reuses the live checkout session
-        // id. Telemetry must never block checkout, so failures only warn.
+        // Setup must run after native init — Android's bridge resolves the SDK DI container here.
         try {
           await PrimerAnalytics.setup(clientToken);
           void PrimerAnalytics.trackEvent('SDK_INIT_START');
@@ -379,8 +375,7 @@ export function PrimerCheckoutProvider({
 
     init().catch((err) => {
       console.error(`${LOG} init failed ${fmt(err)}`);
-      // Best effort: setup may not have run — on iOS the log still ships (the bridge decodes
-      // the token standalone); on Android pre-init logs are a known accepted drop.
+      // Best effort: setup may not have run yet (Android drops pre-init logs; iOS still ships).
       const primerErr = err as PrimerError | Error;
       void PrimerAnalytics.setup(clientToken)
         .then(() =>
@@ -409,17 +404,14 @@ export function PrimerCheckoutProvider({
     };
   }, [clientToken]);
 
-  // -----------------------------------------------------------------------
-  // Analytics: single choke point for terminal outcomes. Every pay path (card
-  // submit, native-UI, vault, retry) lands in `paymentOutcome`, so SUCCESS /
-  // FAILURE emit exactly once per attempt on the null → terminal transition
-  // (each attempt clears the outcome first).
-  // -----------------------------------------------------------------------
+  // Single choke point: every pay path lands in `paymentOutcome`, so SUCCESS/FAILURE emit once per attempt.
   useEffect(() => {
     const outcome = state.paymentOutcome;
     if (outcome === null) return;
     const paymentMethod = lastAttemptedMethodRef.current ?? 'UNKNOWN';
     if (outcome.status === 'success') {
+      // PENDING reaches the 'success' outcome but isn't a completed payment — don't count it.
+      if (outcome.data?.payment?.status === 'PENDING') return;
       hadSuccessRef.current = true;
       void PrimerAnalytics.trackEvent('PAYMENT_SUCCESS', {
         paymentMethod,
@@ -871,8 +863,7 @@ export function PrimerCheckoutProvider({
       }
       // Clear any stale outcome so the result screen re-fires for this attempt.
       setState((prev) => ({ ...prev, paymentOutcome: null, nativeUiInFlightType: paymentMethodType }));
-      // Wallet/APM handoff: the tap both selects the method and hands processing to the native
-      // flow (no form, so no SUBMITTED — matches the Web sequence for wallets).
+      // Wallet/APM handoff: select + hand off to native, no form so no SUBMITTED (matches Web).
       trackSelection(paymentMethodType);
       trackAttemptStart(paymentMethodType, { submitted: false });
       try {

--- a/src/Components/PrimerPaymentMethodList.tsx
+++ b/src/Components/PrimerPaymentMethodList.tsx
@@ -32,7 +32,6 @@ export function PrimerPaymentMethodList({
 
   const handlePress = useCallback(
     (item: PaymentMethodItem) => {
-      // TODO: Fire PAYMENT_METHOD_SELECTION analytics event when analytics bridge is available
       onSelect(item);
     },
     [onSelect]

--- a/src/Components/analytics.ts
+++ b/src/Components/analytics.ts
@@ -9,7 +9,11 @@ export const PrimerAnalytics = {
     return RNPrimer.trackAnalyticsEvent(eventName, metadata ? JSON.stringify(metadata) : undefined);
   },
 
-  sendLog: (message: string, event: string): Promise<void> => {
-    return RNPrimer.sendLog(message, event);
+  sendLog: (message: string, event: string, initDurationMs?: number): Promise<void> => {
+    return RNPrimer.sendLog(message, event, initDurationMs);
+  },
+
+  sendErrorLog: (message: string, event?: string, errorMessage?: string, stack?: string): Promise<void> => {
+    return RNPrimer.sendErrorLog(message, event, errorMessage, stack);
   },
 };

--- a/src/RNPrimer.ts
+++ b/src/RNPrimer.ts
@@ -257,10 +257,21 @@ const RNPrimer = {
     });
   },
 
-  sendLog: (message: string, event: string): Promise<void> => {
+  sendLog: (message: string, event: string, initDurationMs?: number): Promise<void> => {
     return new Promise(async (resolve, reject) => {
       try {
-        await NativePrimer.sendLog(message, event);
+        await NativePrimer.sendLog(message, event, initDurationMs);
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+    });
+  },
+
+  sendErrorLog: (message: string, event?: string, errorMessage?: string, stack?: string): Promise<void> => {
+    return new Promise(async (resolve, reject) => {
+      try {
+        await NativePrimer.sendErrorLog(message, event, errorMessage, stack);
         resolve();
       } catch (err) {
         reject(err);

--- a/src/__tests__/components/PrimerCheckoutProvider.test.tsx
+++ b/src/__tests__/components/PrimerCheckoutProvider.test.tsx
@@ -3,7 +3,12 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 jest.mock('../../specs/NativePrimer', () => ({
   __esModule: true,
-  default: {},
+  default: {
+    setupAnalyticsLoggingBridge: jest.fn().mockResolvedValue(undefined),
+    trackAnalyticsEvent: jest.fn().mockResolvedValue(undefined),
+    sendLog: jest.fn().mockResolvedValue(undefined),
+    sendErrorLog: jest.fn().mockResolvedValue(undefined),
+  },
 }));
 
 jest.mock(

--- a/src/__tests__/components/providerAnalytics.test.tsx
+++ b/src/__tests__/components/providerAnalytics.test.tsx
@@ -1,0 +1,297 @@
+// @ts-expect-error -- React 19 concurrent act environment
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('../../specs/NativePrimer', () => ({
+  __esModule: true,
+  default: {
+    setupAnalyticsLoggingBridge: jest.fn().mockResolvedValue(undefined),
+    trackAnalyticsEvent: jest.fn().mockResolvedValue(undefined),
+    sendLog: jest.fn().mockResolvedValue(undefined),
+    sendErrorLog: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock(
+  'react-native',
+  () => {
+    const mockAddListener = jest.fn().mockImplementation(() => ({ remove: jest.fn() }));
+    return {
+      Platform: { OS: 'android', select: (o: any) => o.android ?? o.default },
+      NativeModules: {
+        PrimerHeadlessUniversalCheckout: {
+          startWithClientToken: jest.fn(),
+          cleanUp: jest.fn(),
+          setImplementedRNCallbacks: jest.fn().mockResolvedValue(undefined),
+        },
+        RNTPrimerHeadlessUniversalCheckoutRawDataManager: {
+          configure: jest.fn().mockResolvedValue(undefined),
+          listRequiredInputElementTypes: jest.fn().mockResolvedValue([]),
+          setRawData: jest.fn(),
+          submit: jest.fn().mockResolvedValue(undefined),
+          cleanUp: jest.fn().mockResolvedValue(undefined),
+        },
+        RNTPrimerHeadlessUniversalPaymentMethodNativeUIManager: {
+          configure: jest.fn().mockResolvedValue(undefined),
+          showPaymentMethod: jest.fn().mockResolvedValue(undefined),
+        },
+        RNPrimerHeadlessUniversalCheckoutVaultManager: {
+          configure: jest.fn().mockResolvedValue(undefined),
+          fetchVaultedPaymentMethods: jest.fn().mockResolvedValue({ paymentMethods: [] }),
+          deleteVaultedPaymentMethod: jest.fn(),
+          startPaymentFlow: jest.fn().mockResolvedValue(undefined),
+          startPaymentFlowWithAdditionalData: jest.fn().mockResolvedValue(undefined),
+          requiresVaultedCardCvv: jest.fn().mockResolvedValue(false),
+        },
+      },
+      NativeEventEmitter: jest.fn().mockImplementation(() => ({
+        addListener: mockAddListener,
+        removeAllListeners: jest.fn(),
+      })),
+      __mockAddListener: mockAddListener,
+    };
+  },
+  { virtual: true }
+);
+
+import { createElement } from 'react';
+// @ts-expect-error -- react-test-renderer has no types for React 19
+import renderer, { act } from 'react-test-renderer';
+import { PrimerCheckoutProvider } from '../../Components/PrimerCheckoutProvider';
+import { usePrimerCheckout } from '../../Components/hooks/usePrimerCheckout';
+import type { PrimerCheckoutContextValue } from '../../Components/types/PrimerCheckoutProviderTypes';
+
+const rnMock = require('react-native');
+const nativeModule = rnMock.NativeModules.PrimerHeadlessUniversalCheckout;
+const mockAddListener: jest.Mock = rnMock.__mockAddListener;
+
+const NativePrimer = require('../../specs/NativePrimer').default;
+const setup: jest.Mock = NativePrimer.setupAnalyticsLoggingBridge;
+const track: jest.Mock = NativePrimer.trackAnalyticsEvent;
+const sendLog: jest.Mock = NativePrimer.sendLog;
+const sendErrorLog: jest.Mock = NativePrimer.sendErrorLog;
+
+const trackedNames = () => track.mock.calls.map((c: any[]) => c[0] as string);
+const trackedMeta = (name: string): Record<string, string> | undefined => {
+  const call = track.mock.calls.find((c: any[]) => c[0] === name);
+  return call?.[1] ? JSON.parse(call[1]) : undefined;
+};
+
+function findListener(eventName: string): ((...args: any[]) => void) | undefined {
+  const call = mockAddListener.mock.calls.find((c: any[]) => c[0] === eventName);
+  return call?.[1];
+}
+
+function flushPromises() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+const CARD_METHOD = {
+  paymentMethodType: 'PAYMENT_CARD',
+  paymentMethodManagerCategories: ['RAW_DATA'],
+  supportedPrimerSessionIntents: ['CHECKOUT'],
+};
+const GOOGLE_PAY_METHOD = {
+  paymentMethodType: 'GOOGLE_PAY',
+  paymentMethodManagerCategories: ['NATIVE_UI'],
+  supportedPrimerSessionIntents: ['CHECKOUT'],
+};
+
+async function renderProvider(): Promise<{
+  root: renderer.ReactTestRenderer;
+  ctx: () => PrimerCheckoutContextValue;
+}> {
+  let latest: PrimerCheckoutContextValue | undefined;
+  let root: renderer.ReactTestRenderer;
+  function Consumer() {
+    latest = usePrimerCheckout();
+    return null;
+  }
+  await act(async () => {
+    root = renderer.create(createElement(PrimerCheckoutProvider, { clientToken: 'token-1' }, createElement(Consumer)));
+    await flushPromises();
+  });
+  return { root: root!, ctx: () => latest! };
+}
+
+describe('PrimerCheckoutProvider analytics contract', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    nativeModule.startWithClientToken.mockResolvedValue({
+      availablePaymentMethods: [CARD_METHOD, GOOGLE_PAY_METHOD],
+    });
+    nativeModule.cleanUp.mockResolvedValue(undefined);
+    nativeModule.setImplementedRNCallbacks.mockResolvedValue(undefined);
+  });
+
+  it('sets up the bridge after native init, then emits the init pair, the init log, and CHECKOUT_FLOW_STARTED', async () => {
+    await renderProvider();
+
+    expect(setup).toHaveBeenCalledTimes(1);
+    expect(setup).toHaveBeenCalledWith('token-1');
+    expect(trackedNames()).toEqual(['SDK_INIT_START', 'SDK_INIT_END', 'CHECKOUT_FLOW_STARTED']);
+    expect(sendLog).toHaveBeenCalledTimes(1);
+    const [message, event, initDurationMs] = sendLog.mock.calls[0]!;
+    expect(message).toBe('Checkout components initialized');
+    expect(event).toBe('checkout-initialized');
+    expect(typeof initDurationMs).toBe('number');
+  });
+
+  it('sends a checkout-init-failed error log and no events when init fails', async () => {
+    nativeModule.startWithClientToken.mockRejectedValue(new Error('init failed'));
+
+    await renderProvider();
+
+    expect(track).not.toHaveBeenCalled();
+    expect(sendErrorLog).toHaveBeenCalledWith(
+      'Checkout initialization failed',
+      'checkout-init-failed',
+      'init failed',
+      expect.any(String)
+    );
+  });
+
+  it('emits PAYMENT_METHOD_SELECTION once per method for the card form', async () => {
+    const { ctx } = await renderProvider();
+
+    await act(async () => {
+      ctx().setActiveMethod('PAYMENT_CARD');
+      await flushPromises();
+    });
+    await act(async () => {
+      ctx().setActiveMethod(null);
+      ctx().setActiveMethod('PAYMENT_CARD');
+      await flushPromises();
+    });
+
+    const selections = trackedNames().filter((n) => n === 'PAYMENT_METHOD_SELECTION');
+    expect(selections).toHaveLength(1);
+    expect(trackedMeta('PAYMENT_METHOD_SELECTION')).toEqual({ paymentMethod: 'PAYMENT_CARD' });
+  });
+
+  it('emits PAYMENT_DETAILS_ENTERED once on the first valid card form', async () => {
+    const { ctx } = await renderProvider();
+    await act(async () => {
+      ctx().setActiveMethod('PAYMENT_CARD');
+      await flushPromises();
+    });
+
+    const onValidation = findListener('onValidation');
+    expect(onValidation).toBeDefined();
+    await act(async () => {
+      onValidation!({ isValid: true, errors: undefined });
+      onValidation!({ isValid: true, errors: undefined });
+    });
+
+    const fired = trackedNames().filter((n) => n === 'PAYMENT_DETAILS_ENTERED');
+    expect(fired).toHaveLength(1);
+    expect(trackedMeta('PAYMENT_DETAILS_ENTERED')).toEqual({ paymentMethod: 'PAYMENT_CARD' });
+  });
+
+  it('emits SELECTION and PROCESSING_STARTED (no SUBMITTED) for a native-UI handoff', async () => {
+    const { ctx } = await renderProvider();
+
+    await act(async () => {
+      await ctx().startNativeUI('GOOGLE_PAY');
+      await flushPromises();
+    });
+
+    expect(trackedNames()).toContain('PAYMENT_METHOD_SELECTION');
+    expect(trackedNames()).toContain('PAYMENT_PROCESSING_STARTED');
+    expect(trackedNames()).not.toContain('PAYMENT_SUBMITTED');
+    expect(trackedMeta('PAYMENT_PROCESSING_STARTED')).toEqual({ paymentMethod: 'GOOGLE_PAY' });
+  });
+
+  it('logs unable-to-present and emits FAILURE when a native-UI handoff fails to present', async () => {
+    const nativeUi = rnMock.NativeModules.RNTPrimerHeadlessUniversalPaymentMethodNativeUIManager;
+    nativeUi.configure.mockRejectedValueOnce(new Error('sheet unavailable'));
+
+    const { ctx } = await renderProvider();
+    await act(async () => {
+      await ctx()
+        .startNativeUI('GOOGLE_PAY')
+        .catch(() => {});
+      await flushPromises();
+    });
+
+    const presentLog = sendErrorLog.mock.calls.find((c: any[]) => c[1] === 'unable-to-present-payment-method');
+    expect(presentLog).toBeDefined();
+    expect(presentLog![0]).toBe('Unable to present payment method');
+    expect(presentLog![2]).toContain('GOOGLE_PAY');
+    expect(trackedMeta('PAYMENT_FAILURE')).toEqual({ paymentMethod: 'GOOGLE_PAY' });
+  });
+
+  it('emits SUBMITTED + PROCESSING on card submit, then SUCCESS with the payment id', async () => {
+    const { root, ctx } = await renderProvider();
+    await act(async () => {
+      ctx().setActiveMethod('PAYMENT_CARD');
+      await flushPromises();
+    });
+
+    await act(async () => {
+      await ctx().submit();
+      await flushPromises();
+    });
+    expect(trackedMeta('PAYMENT_SUBMITTED')).toEqual({ paymentMethod: 'PAYMENT_CARD' });
+    expect(trackedMeta('PAYMENT_PROCESSING_STARTED')).toEqual({ paymentMethod: 'PAYMENT_CARD' });
+
+    const onCheckoutComplete = findListener('onCheckoutComplete');
+    await act(async () => {
+      onCheckoutComplete!({ payment: { id: 'pay_123', status: 'SUCCESS' } });
+      await flushPromises();
+    });
+    expect(trackedMeta('PAYMENT_SUCCESS')).toEqual({
+      paymentMethod: 'PAYMENT_CARD',
+      paymentId: 'pay_123',
+    });
+
+    // A completed payment is not a funnel exit.
+    await act(async () => {
+      root.unmount();
+    });
+    expect(trackedNames()).not.toContain('PAYMENT_FLOW_EXITED');
+  });
+
+  it('emits FAILURE with an error log, then REATTEMPTED on the next submit', async () => {
+    const { ctx } = await renderProvider();
+    await act(async () => {
+      ctx().setActiveMethod('PAYMENT_CARD');
+      await flushPromises();
+    });
+    await act(async () => {
+      await ctx().submit();
+      await flushPromises();
+    });
+
+    const onCheckoutComplete = findListener('onCheckoutComplete');
+    await act(async () => {
+      onCheckoutComplete!({ payment: { id: 'pay_9', status: 'FAILED' } });
+      await flushPromises();
+    });
+    expect(trackedMeta('PAYMENT_FAILURE')).toEqual({
+      paymentMethod: 'PAYMENT_CARD',
+      paymentId: 'pay_9',
+    });
+    expect(sendErrorLog).toHaveBeenCalledWith('Payment failed', 'failed-payment', expect.any(String), undefined);
+
+    await act(async () => {
+      await ctx().submit();
+      await flushPromises();
+    });
+    const names = trackedNames();
+    const reattemptIndex = names.indexOf('PAYMENT_REATTEMPTED');
+    expect(reattemptIndex).toBeGreaterThan(-1);
+    expect(names[reattemptIndex + 1]).toBe('PAYMENT_SUBMITTED');
+    expect(names[reattemptIndex + 2]).toBe('PAYMENT_PROCESSING_STARTED');
+    expect(trackedMeta('PAYMENT_REATTEMPTED')).toEqual({ paymentMethod: 'PAYMENT_CARD' });
+  });
+
+  it('emits PAYMENT_FLOW_EXITED when the session ends without a completed payment', async () => {
+    const { root } = await renderProvider();
+
+    await act(async () => {
+      root.unmount();
+    });
+
+    expect(trackedNames()).toContain('PAYMENT_FLOW_EXITED');
+  });
+});

--- a/src/__tests__/components/providerAnalytics.test.tsx
+++ b/src/__tests__/components/providerAnalytics.test.tsx
@@ -251,6 +251,32 @@ describe('PrimerCheckoutProvider analytics contract', () => {
     expect(trackedNames()).not.toContain('PAYMENT_FLOW_EXITED');
   });
 
+  it('does not emit SUCCESS or FAILURE for a PENDING payment, and still exits on unmount', async () => {
+    const { root, ctx } = await renderProvider();
+    await act(async () => {
+      ctx().setActiveMethod('PAYMENT_CARD');
+      await flushPromises();
+    });
+    await act(async () => {
+      await ctx().submit();
+      await flushPromises();
+    });
+
+    const onCheckoutComplete = findListener('onCheckoutComplete');
+    await act(async () => {
+      onCheckoutComplete!({ payment: { id: 'pay_pending', status: 'PENDING' } });
+      await flushPromises();
+    });
+    expect(trackedNames()).not.toContain('PAYMENT_SUCCESS');
+    expect(trackedNames()).not.toContain('PAYMENT_FAILURE');
+
+    // PENDING is not a completed success, so leaving now is still a funnel exit.
+    await act(async () => {
+      root.unmount();
+    });
+    expect(trackedNames()).toContain('PAYMENT_FLOW_EXITED');
+  });
+
   it('emits FAILURE with an error log, then REATTEMPTED on the next submit', async () => {
     const { ctx } = await renderProvider();
     await act(async () => {

--- a/src/__tests__/components/usePrimerPaymentMethod.test.tsx
+++ b/src/__tests__/components/usePrimerPaymentMethod.test.tsx
@@ -3,7 +3,12 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 jest.mock('../../specs/NativePrimer', () => ({
   __esModule: true,
-  default: {},
+  default: {
+    setupAnalyticsLoggingBridge: jest.fn().mockResolvedValue(undefined),
+    trackAnalyticsEvent: jest.fn().mockResolvedValue(undefined),
+    sendLog: jest.fn().mockResolvedValue(undefined),
+    sendErrorLog: jest.fn().mockResolvedValue(undefined),
+  },
 }));
 
 jest.mock(

--- a/src/specs/NativePrimer.ts
+++ b/src/specs/NativePrimer.ts
@@ -34,7 +34,8 @@ export interface Spec extends TurboModule {
   // Analytics bridge
   setupAnalyticsLoggingBridge(clientToken: string): Promise<void>;
   trackAnalyticsEvent(eventName: string, metadata?: string): Promise<void>;
-  sendLog(message: string, event: string): Promise<void>;
+  sendLog(message: string, event: string, initDurationMs?: number): Promise<void>;
+  sendErrorLog(message: string, event?: string, errorMessage?: string, stack?: string): Promise<void>;
 
   // Backward compat
   addListener(eventName?: string): void;


### PR DESCRIPTION
[ORC-6501](https://primerapi.atlassian.net/browse/ORC-6501)

Wires the core Checkout Components analytics funnel + SDK logs from the RN layer. Calls `PrimerAnalytics.setup()` once native init resolves (the bridge was never turned on before — every prior analytics call was a silent no-op), then emits the lifecycle events from the provider/hook layer through the existing `components-analytics` bridge, which enriches + sends them tagged `sdkType = RN_IOS/RN_ANDROID`.

## What fires when

- **On checkout ready:** `setup()` → `SDK_INIT_START` → `SDK_INIT_END` → `checkout-initialized` info log (with `init_duration_ms`, measured in TS) → `CHECKOUT_FLOW_STARTED`.
- **Method pick:** `PAYMENT_METHOD_SELECTION` (once per method per session).
- **Card form:** `PAYMENT_DETAILS_ENTERED` once, on the first invalid→valid transition.
- **Card / vault submit:** `PAYMENT_SUBMITTED` → `PAYMENT_PROCESSING_STARTED`.
- **Wallet / native-UI handoff:** `PAYMENT_PROCESSING_STARTED` (no `SUBMITTED` — matches Web's wallet sequence).
- **Terminal outcome (single choke point):** `PAYMENT_SUCCESS` (+`paymentId`) or `PAYMENT_FAILURE`, emitted exactly once per attempt on the null→terminal `paymentOutcome` transition.
- **Retry after failure:** `PAYMENT_REATTEMPTED` before the next submit.
- **Session ends without a completed payment:** `PAYMENT_FLOW_EXITED`.
- **Error logs:** init failure (`checkout-init-failed`), payment failure (`failed-payment`), native-UI present failure (`unable-to-present-payment-method`).

## Bridge additions (TS → Kotlin → Swift/ObjC)

- New `sendErrorLog(message, event?, errorMessage?, stack?)` across the whole chain; `sendLog` gains an optional `initDurationMs`.
- `AnalyticsEventMapper`: `PaymentReattempted` now carries `paymentMethod`; unknown event names are debug-logged instead of dropped silently.
- Jest: global `react-native` TurboModule mock hardened so new spec methods can't crash suites; new `providerAnalytics.test.tsx` contract suite (8 tests) pins the sequences above. 289 tests green, typecheck + lint clean.

## Notes for review

- **No card data in telemetry:** every event value is a payment-method type, an opaque `paymentId`/`vaultedMethodId`, or a count; every log string is a static message + an SDK-level error description/`errorId` or a JS stack. No PAN/CVV/expiry/cardholder path. Emission is fire-and-forget — it never blocks or fails checkout.
- **Native dependency:** builds locally against the sibling SDKs; the version bumps land when the native betas cut from primer-io/primer-sdk-android#1283 and primer-io/primer-sdk-ios#1825 publish. Do not merge before those.
- **Heads-up (rebase):** the open stacked PRs #393→#396 and umbrella #331 also touch `PrimerCheckoutProvider.tsx` — expect a rebase.
- **Deferred:** `PAYMENT_THREEDS` / `PAYMENT_REDIRECT_TO_THIRD_PARTY` need a native→RN flow signal that doesn't exist yet (no mobile SDK emits them). Vault event mappings are the stacked follow-up **ORC-6512** — the `VAULT_*` events already emitted in TS start flowing there, not here.
- Minor design note: native `setup()` is non-idempotent (overwrites the bridge); harmless as wired (one call per session), flagging for awareness.


[ORC-6501]: https://primerapi.atlassian.net/browse/ORC-6501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ