### PR TITLE
feat: add allowedCardTypes to Apple Pay and Google Pay options (ORC-7504)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -133,7 +133,7 @@ dependencies {
   implementation 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3"
-  implementation 'io.primer:android:2.51.0'
+  implementation 'io.primer:android:2.52.0'
   testImplementation 'io.mockk:mockk:1.14.2'
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'

--- a/android/src/main/java/com/primerioreactnative/datamodels/PrimerSettingsRN.kt
+++ b/android/src/main/java/com/primerioreactnative/datamodels/PrimerSettingsRN.kt
@@ -156,8 +156,7 @@ data class PrimerThreeDsAndroidOptionsRN(val threeDsAppRequestorUrl: String? = n
 @Serializable
 data class PrimerGooglePayOptionsRN(
     var merchantName: String? = null,
-    var allowedCardNetworks: List<String> =
-        listOf("AMEX", "DISCOVER", "JCB", "MASTERCARD", "VISA"),
+    var allowedCardTypes: List<String>? = null,
     var buttonStyle: GooglePayButtonStyle = GooglePayButtonStyle.BLACK,
     @SerialName("isCaptureBillingAddressEnabled")
     var captureBillingAddress: Boolean = false,

--- a/android/src/main/java/com/primerioreactnative/extensions/PrimerPaymentMethodOptionsRN.kt
+++ b/android/src/main/java/com/primerioreactnative/extensions/PrimerPaymentMethodOptionsRN.kt
@@ -29,10 +29,16 @@ fun PrimerPaymentMethodOptionsRN.toPrimerPaymentMethodOptions(context: Context) 
         stripeOptions.toPrimerStripeOptions(context),
     )
 
-fun PrimerGooglePayOptionsRN.toPrimerGooglePayOptions() =
-    PrimerGooglePayOptions(
+fun PrimerGooglePayOptionsRN.toPrimerGooglePayOptions(): PrimerGooglePayOptions {
+    val knownCardTypes = setOf("credit", "debit", "prepaid")
+    val cardTypes =
+        allowedCardTypes
+            ?.filter { it in knownCardTypes }
+            ?.takeIf { it.isNotEmpty() }
+    return PrimerGooglePayOptions(
         merchantName = merchantName,
-        allowedCardNetworks = allowedCardNetworks,
+        allowCreditCards = cardTypes?.contains("credit") ?: true,
+        allowPrepaidCards = cardTypes?.contains("prepaid") ?: true,
         buttonStyle = buttonStyle,
         captureBillingAddress = captureBillingAddress,
         existingPaymentMethodRequired = existingPaymentMethodRequired,
@@ -41,6 +47,7 @@ fun PrimerGooglePayOptionsRN.toPrimerGooglePayOptions() =
         emailAddressRequired = emailAddressRequired,
         buttonOptions = buttonOptions?.toPrimerGooglePayButtonOptions() ?: GooglePayButtonOptions(),
     )
+}
 
 fun PrimerGoogleShippingAddressParametersRN.toPrimerGoogleShippingAddressParameters() =
     PrimerGoogleShippingAddressParameters(phoneNumberRequired)

--- a/android/src/test/java/com/primerioreactnative/extensions/PrimerGooglePayOptionsRNTest.kt
+++ b/android/src/test/java/com/primerioreactnative/extensions/PrimerGooglePayOptionsRNTest.kt
@@ -1,0 +1,68 @@
+package com.primerioreactnative.extensions
+
+import com.primerioreactnative.datamodels.PrimerGooglePayOptionsRN
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class PrimerGooglePayOptionsRNTest {
+    @Test
+    fun `null allowedCardTypes allows all card types`() {
+        val options = PrimerGooglePayOptionsRN(allowedCardTypes = null).toPrimerGooglePayOptions()
+
+        assertTrue(options.allowCreditCards)
+        assertTrue(options.allowPrepaidCards)
+    }
+
+    @Test
+    fun `empty allowedCardTypes allows all card types`() {
+        val options = PrimerGooglePayOptionsRN(allowedCardTypes = emptyList()).toPrimerGooglePayOptions()
+
+        assertTrue(options.allowCreditCards)
+        assertTrue(options.allowPrepaidCards)
+    }
+
+    @Test
+    fun `debit only disables credit and prepaid`() {
+        val options = PrimerGooglePayOptionsRN(allowedCardTypes = listOf("debit")).toPrimerGooglePayOptions()
+
+        assertFalse(options.allowCreditCards)
+        assertFalse(options.allowPrepaidCards)
+    }
+
+    @Test
+    fun `credit only keeps credit and disables prepaid`() {
+        val options = PrimerGooglePayOptionsRN(allowedCardTypes = listOf("credit")).toPrimerGooglePayOptions()
+
+        assertTrue(options.allowCreditCards)
+        assertFalse(options.allowPrepaidCards)
+    }
+
+    @Test
+    fun `prepaid only disables credit and keeps prepaid`() {
+        val options = PrimerGooglePayOptionsRN(allowedCardTypes = listOf("prepaid")).toPrimerGooglePayOptions()
+
+        assertFalse(options.allowCreditCards)
+        assertTrue(options.allowPrepaidCards)
+    }
+
+    @Test
+    fun `unknown values are dropped and fail open`() {
+        val options =
+            PrimerGooglePayOptionsRN(allowedCardTypes = listOf("CREDIT", "unknown"))
+                .toPrimerGooglePayOptions()
+
+        assertTrue(options.allowCreditCards)
+        assertTrue(options.allowPrepaidCards)
+    }
+
+    @Test
+    fun `all card types keep both flags enabled`() {
+        val options =
+            PrimerGooglePayOptionsRN(allowedCardTypes = listOf("credit", "debit", "prepaid"))
+                .toPrimerGooglePayOptions()
+
+        assertTrue(options.allowCreditCards)
+        assertTrue(options.allowPrepaidCards)
+    }
+}

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -15,7 +15,7 @@ PODS:
     - fmt
     - glog
     - hermes-engine
-    - PrimerSDK (= 2.49.0)
+    - PrimerSDK (= 2.51.1)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -38,30 +38,37 @@ PODS:
     - SocketRocket
     - Yoga
   - Primer3DS (2.8.0)
-  - PrimerBDCCore (2.49.0):
-    - PrimerBDCEngine (= 2.49.0)
-    - PrimerFoundation (= 2.49.0)
-    - PrimerStepResolver (= 2.49.0)
-  - PrimerBDCEngine (2.49.0):
-    - PrimerFoundation (= 2.49.0)
-    - PrimerStepResolver (= 2.49.0)
-  - PrimerCore (2.49.0):
+  - PrimerBDCCore (2.51.1):
+    - PrimerBDCEngine (= 2.51.1)
+    - PrimerFoundation (= 2.51.1)
+    - PrimerStepResolver (= 2.51.1)
+  - PrimerBDCEngine (2.51.1):
+    - PrimerFoundation (= 2.51.1)
+    - PrimerStepResolver (= 2.51.1)
+  - PrimerCore (2.51.1):
     - Primer3DS
-    - PrimerFoundation (= 2.49.0)
-  - PrimerFoundation (2.49.0)
+    - PrimerFoundation (= 2.51.1)
+  - PrimerFoundation (2.51.1)
   - PrimerIPay88MYSDK (0.1.7)
   - PrimerKlarnaSDK (1.3.1)
-  - PrimerSDK (2.49.0):
-    - PrimerSDK/Core (= 2.49.0)
-  - PrimerSDK/Core (2.49.0):
-    - PrimerBDCCore (= 2.49.0)
-    - PrimerBDCEngine (= 2.49.0)
-    - PrimerCore (= 2.49.0)
-    - PrimerFoundation (= 2.49.0)
-    - PrimerStepResolver (= 2.49.0)
-  - PrimerStepResolver (2.49.0):
-    - PrimerFoundation (= 2.49.0)
+  - PrimerNetworking (2.51.1):
+    - PrimerFoundation (= 2.51.1)
+  - PrimerResources (2.51.1)
+  - PrimerSDK (2.51.1):
+    - PrimerSDK/Core (= 2.51.1)
+  - PrimerSDK/Core (2.51.1):
+    - PrimerBDCCore (= 2.51.1)
+    - PrimerBDCEngine (= 2.51.1)
+    - PrimerCore (= 2.51.1)
+    - PrimerFoundation (= 2.51.1)
+    - PrimerNetworking (= 2.51.1)
+    - PrimerResources (= 2.51.1)
+    - PrimerStepResolver (= 2.51.1)
+    - PrimerUI (= 2.51.1)
+  - PrimerStepResolver (2.51.1):
+    - PrimerFoundation (= 2.51.1)
   - PrimerStripeSDK (1.0.0)
+  - PrimerUI (2.51.1)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -2551,9 +2558,12 @@ SPEC REPOS:
     - PrimerFoundation
     - PrimerIPay88MYSDK
     - PrimerKlarnaSDK
+    - PrimerNetworking
+    - PrimerResources
     - PrimerSDK
     - PrimerStepResolver
     - PrimerStripeSDK
+    - PrimerUI
     - SocketRocket
 
 EXTERNAL SOURCES:
@@ -2717,17 +2727,20 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  primer-io-react-native: e78748b21612ae8ae6aebbfb7370ffc701e04890
+  primer-io-react-native: 51816f1d7259c680159e22654a2021e1727f5de2
   Primer3DS: b8b583ef260f703180870358bc55069de74f8f51
-  PrimerBDCCore: c12a1c92a45895a0e628beb2ae380f0b17fd4117
-  PrimerBDCEngine: 326fa95c79ee94706619bebeb257fdbb8f3918bf
-  PrimerCore: 73e86d2620183b65b40b5681a86ffd8e6313d2c1
-  PrimerFoundation: 879930406228bfc7dbc60e3449ba0b5295e834d3
+  PrimerBDCCore: 7f5344b88a2123bda018e8aad84eab97554f640a
+  PrimerBDCEngine: df493c9d3e4712aaea45bbd9c3f1e58a8232b66a
+  PrimerCore: a7281a00d18dee78e63f2e8110b89029554a9476
+  PrimerFoundation: 78c4a2437577ad06caea15f5d2a619b3b113be48
   PrimerIPay88MYSDK: 436ee0be7e2c97e4e81456ccddee20175e9e3c4d
   PrimerKlarnaSDK: 104962584ac6baad20424f73ee8493c8503fd487
-  PrimerSDK: 822743acdbaa008cfb500349a0af8b2331c16067
-  PrimerStepResolver: f1a49765775fa945d20fb868b0f750a7dd5bb53b
+  PrimerNetworking: 8b80bcca22bea3b0781241c6e7b3f2983a3d0a7d
+  PrimerResources: 3588c545e393a0e6942aa5b50ff00d7dc0881403
+  PrimerSDK: ed1627c6e576fd60688394ee1da08dfce6a2798e
+  PrimerStepResolver: 27bb5225697aaaf1c0159fb7c2114f9dc1a131ba
   PrimerStripeSDK: c37d4e7c1b5256d67d4890c4cc4b38ddc9427489
+  PrimerUI: f1fbd445fc83d56abba38154089f4d7f8510ac10
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
   RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a

--- a/ios/Sources/DataModels/PrimerSettings+Extensions.swift
+++ b/ios/Sources/DataModels/PrimerSettings+Extensions.swift
@@ -1,3 +1,4 @@
+import PrimerFoundation
 import PrimerSDK
 
 extension PrimerSettings {
@@ -115,6 +116,17 @@ extension PrimerSettings {
           )
         }
 
+        var allowedCardTypes: [CardType]?
+        if let rnAllowedCardTypes = rnApplePayOptions["allowedCardTypes"] as? [String] {
+          let parsedCardTypes = rnAllowedCardTypes.compactMap { CardType(rawValue: $0) }
+          if parsedCardTypes.count != rnAllowedCardTypes.count {
+            PrimerLogging.shared.logger.warn(
+              message: "Some allowedCardTypes values cannot be filtered on Apple Pay and were ignored")
+          }
+          // empty maps to nil so Apple Pay falls open to all types
+          allowedCardTypes = parsedCardTypes.isEmpty ? nil : parsedCardTypes
+        }
+
         applePayOptions = PrimerApplePayOptions(
           merchantIdentifier: rnApplePayMerchantIdentifier,
           merchantName: rnApplePayMerchantName,
@@ -122,7 +134,8 @@ extension PrimerSettings {
           showApplePayForUnsupportedDevice: rnApplePayShowApplePayForUnsupportedDevice,
           checkProvidedNetworks: rnApplePayCheckProvidedNetworks,
           shippingOptions: shippingOptions,
-          billingOptions: billingOptions
+          billingOptions: billingOptions,
+          allowedCardTypes: allowedCardTypes
         )
       }
 
@@ -149,7 +162,8 @@ extension PrimerSettings {
         var cardFormUIOptions: PrimerCardFormUIOptions?
         if let rnCardFormUIOptions = rnUIOptions["cardFormUIOptions"] as? [String: Any] {
             let rnCardFormUIOptionsData = try (JSONSerialization.data(withJSONObject: rnCardFormUIOptions))
-            let rnCardFormUIOptions = try JSONDecoder().decode(PrimerCardFormUIOptionsRN.self, from: rnCardFormUIOptionsData)
+            let rnCardFormUIOptions = try JSONDecoder().decode(
+              PrimerCardFormUIOptionsRN.self, from: rnCardFormUIOptionsData)
             cardFormUIOptions = rnCardFormUIOptions.asPrimerCardFormUIOptions()
         }
 

--- a/primer-io-react-native.podspec
+++ b/primer-io-react-native.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.private_header_files = ['ios/PrimerSwiftInterop.h' ]
 
   s.dependency "React-Core"
-  s.dependency "PrimerSDK", "2.49.0"
+  s.dependency "PrimerSDK", "2.51.1"
 
   s.pod_target_xcconfig = {
     "SWIFT_ENABLE_EXPLICIT_MODULES" => "NO"

--- a/src/models/PrimerSettings.ts
+++ b/src/models/PrimerSettings.ts
@@ -132,6 +132,7 @@ interface IPrimerApplePayOptions {
   checkProvidedNetworks?: boolean;
   shippingOptions?: IShippingOptions;
   billingOptions?: IBillingOptions;
+  allowedCardTypes?: PrimerWalletCardType[];
 }
 interface IShippingOptions {
   shippingContactFields?: RequiredContactField[];
@@ -142,6 +143,8 @@ interface IBillingOptions {
 }
 
 type RequiredContactField = 'name' | 'emailAddress' | 'phoneNumber' | 'postalAddress';
+
+type PrimerWalletCardType = 'credit' | 'debit' | 'prepaid';
 
 interface IPrimerCardPaymentOptions {
   is3DSOnVaultingEnabled: boolean;
@@ -154,7 +157,7 @@ interface IPrimerGoCardlessOptions {
 
 interface IPrimerGooglePayOptions {
   merchantName?: string;
-  allowedCardNetworks?: string[];
+  allowedCardTypes?: PrimerWalletCardType[];
   isCaptureBillingAddressEnabled?: boolean;
   isExistingPaymentMethodRequired?: boolean;
   shippingAddressParameters?: IPrimerGoogleShippingAddressParameters;


### PR DESCRIPTION
[ORC-7504](https://primerapi.atlassian.net/browse/ORC-7504)

Adds `allowedCardTypes` (`credit | debit | prepaid`) to the Apple Pay and Google Pay init options so merchants can restrict which card types the wallet sheet offers. Removes the inert `googlePayOptions.allowedCardNetworks` — wallet networks come from the client session's `orderedAllowedCardNetworks`.

| `allowedCardTypes` | Apple Pay | Google Pay |
|---|---|---|
| absent / `[]` | all types | all types |
| `['debit']` | credit hidden | debit only |
| `['credit']` | credit only | credit + debit |
| `['prepaid']` | all types (not filterable) | prepaid only |

Best-effort by platform: prepaid can't be filtered on Apple Pay, debit can't be hidden on Google Pay. Removing `allowedCardNetworks` is type-level only — it mapped to a deprecated no-op and old JS passing it is ignored at runtime (`ignoreUnknownKeys`).

Requires PrimerSDK 2.51.1 (iOS) and io.primer:android 2.52.0.


[ORC-7504]: https://primerapi.atlassian.net/browse/ORC-7504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ