### PR TITLE
fix: prevent iOS host-app crash on checkout dismiss (ESC-1055)

### DIFF
--- a/example/ios/example_0_70_6Tests/RNTPrimerTests.swift
+++ b/example/ios/example_0_70_6Tests/RNTPrimerTests.swift
@@ -237,4 +237,23 @@ class RNTPrimerTests: XCTestCase {
         wait(for: [handlerExpectation, resolverExpectation], timeout: 2.0)
         XCTAssertNil(rnPrimer.primerDidFailWithErrorDecisionHandler)
     }
+
+    // MARK: - Delegate callbacks after native-module teardown (ESC-1055)
+
+    // Regression (ESC-1055): eventDelegate can be nil after RN tears down RCTNativePrimer.
+    func testPrimerDidDismissDoesNotCrashWhenEventDelegateIsNil() throws {
+        let json = "{\"onDismiss\": true}"
+        rnPrimer.implementedRNCallbacks = try JSONDecoder().decode(
+            ImplementedRNCallbacks.self,
+            from: json.data(using: .utf8)!
+        )
+        XCTAssertNil(rnPrimer.eventDelegate)
+
+        rnPrimer.primerDidDismiss()
+
+        // onDismiss emits on DispatchQueue.main.async — drain it, then assert we survived.
+        let drained = expectation(description: "main queue drained")
+        DispatchQueue.main.async { drained.fulfill() }
+        wait(for: [drained], timeout: 2.0)
+    }
 }

--- a/ios/Sources/NativePrimer/RCTNativePrimer.mm
+++ b/ios/Sources/NativePrimer/RCTNativePrimer.mm
@@ -21,9 +21,9 @@ RCT_EXPORT_MODULE(NativePrimer)
 
 - (instancetype)init {
     if (self = [super init]) {
-        _primer = [[RNTPrimer alloc] init];
-        [_primer setEventDelegate:self];
-    }
+         _primer = [RNTPrimer alloc];
+      }
+    [_primer setEventDelegate:self];
     return self;
 }
 

--- a/ios/Sources/NativePrimer/RCTNativePrimer.mm
+++ b/ios/Sources/NativePrimer/RCTNativePrimer.mm
@@ -21,9 +21,9 @@ RCT_EXPORT_MODULE(NativePrimer)
 
 - (instancetype)init {
     if (self = [super init]) {
-         _primer = [RNTPrimer alloc];
-      }
-    [_primer setEventDelegate:self];
+        _primer = [[RNTPrimer alloc] init];
+        [_primer setEventDelegate:self];
+    }
     return self;
 }
 

--- a/ios/Sources/RNTPrimer.swift
+++ b/ios/Sources/RNTPrimer.swift
@@ -367,7 +367,10 @@ extension RNTPrimer: PrimerDelegate {
                 do {
                     let checkoutData = try JSONEncoder().encode(data)
                     let checkoutJson = try JSONSerialization.jsonObject(with: checkoutData, options: .allowFragments)
-                    self.eventDelegate?.sendEvent(withName: PrimerEvents.onCheckoutComplete.stringValue, body: checkoutJson)
+                    self.eventDelegate?.sendEvent(
+                        withName: PrimerEvents.onCheckoutComplete.stringValue,
+                        body: checkoutJson
+                    )
                 } catch {
                     self.handleRNBridgeError(error, checkoutData: data, stopOnDebug: true)
                 }
@@ -522,7 +525,10 @@ extension RNTPrimer: PrimerDelegate {
             }
 
             DispatchQueue.main.async {
-              self.eventDelegate?.sendEvent(withName: PrimerEvents.onResumeSuccess.stringValue, body: ["resumeToken": resumeToken])
+              self.eventDelegate?.sendEvent(
+                  withName: PrimerEvents.onResumeSuccess.stringValue,
+                  body: ["resumeToken": resumeToken]
+              )
             }
         } else {
             // RN dev hasn't opted in on listening the tokenization callback.

--- a/ios/Sources/RNTPrimer.swift
+++ b/ios/Sources/RNTPrimer.swift
@@ -67,7 +67,7 @@ enum PrimerEvents: Int, CaseIterable {
     // MARK: - INITIALIZATION & REACT NATIVE SUPPORT
 
   // In RNTPrimer.swift, add this property
-    @objc public weak var eventDelegate: RCTNativePrimer!
+    @objc public weak var eventDelegate: RCTNativePrimer?
 
     deinit {
         print("🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
@@ -308,7 +308,7 @@ enum PrimerEvents: Int, CaseIterable {
     }
 
     private func detectImplemetedCallbacks() {
-      eventDelegate.sendEvent(withName: PrimerEvents.detectImplementedRNCallbacks.stringValue, body: nil)
+      eventDelegate?.sendEvent(withName: PrimerEvents.detectImplementedRNCallbacks.stringValue, body: nil)
     }
 
     @objc
@@ -351,7 +351,7 @@ enum PrimerEvents: Int, CaseIterable {
                let json = try? JSONSerialization.jsonObject(with: data) {
                 body["checkoutData"] = json
             }
-            self.eventDelegate.sendEvent(withName: PrimerEvents.onError.stringValue, body: body)
+            self.eventDelegate?.sendEvent(withName: PrimerEvents.onError.stringValue, body: body)
         }
     }
 }
@@ -367,7 +367,7 @@ extension RNTPrimer: PrimerDelegate {
                 do {
                     let checkoutData = try JSONEncoder().encode(data)
                     let checkoutJson = try JSONSerialization.jsonObject(with: checkoutData, options: .allowFragments)
-                    self.eventDelegate.sendEvent(withName: PrimerEvents.onCheckoutComplete.stringValue, body: checkoutJson)
+                    self.eventDelegate?.sendEvent(withName: PrimerEvents.onCheckoutComplete.stringValue, body: checkoutJson)
                 } catch {
                     self.handleRNBridgeError(error, checkoutData: data, stopOnDebug: true)
                 }
@@ -390,7 +390,7 @@ extension RNTPrimer: PrimerDelegate {
                         with: checkoutAdditionalInfo,
                         options: .allowFragments
                     )
-                    self.eventDelegate.sendEvent(
+                    self.eventDelegate?.sendEvent(
                         withName: PrimerHeadlessUniversalCheckoutEvents.onCheckoutPending.stringValue,
                         body: checkoutAdditionalInfoJson
                     )
@@ -432,7 +432,7 @@ extension RNTPrimer: PrimerDelegate {
                   let checkoutPaymentmethodJson = try data
                         .toPrimerCheckoutPaymentMethodDataRN()
                         .toJsonObject()
-                  self.eventDelegate.sendEvent(
+                  self.eventDelegate?.sendEvent(
                         withName: PrimerEvents.onBeforePaymentCreate.stringValue,
                         body: checkoutPaymentmethodJson
                       )
@@ -451,7 +451,7 @@ extension RNTPrimer: PrimerDelegate {
   public func primerClientSessionWillUpdate() {
         if self.implementedRNCallbacks?.isOnBeforeClientSessionUpdateImplemented == true {
             DispatchQueue.main.async {
-              self.eventDelegate.sendEvent(withName: PrimerEvents.onBeforeClientSessionUpdate.stringValue, body: nil)
+              self.eventDelegate?.sendEvent(withName: PrimerEvents.onBeforeClientSessionUpdate.stringValue, body: nil)
             }
         } else {
             // RN Dev hasn't implemented this callback, ignore.
@@ -464,7 +464,7 @@ extension RNTPrimer: PrimerDelegate {
                 let data = try JSONEncoder().encode(clientSession)
                 let json = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
                 DispatchQueue.main.async {
-                  self.eventDelegate.sendEvent(withName: PrimerEvents.onClientSessionUpdate.stringValue, body: json)
+                  self.eventDelegate?.sendEvent(withName: PrimerEvents.onClientSessionUpdate.stringValue, body: json)
                 }
             } catch {
                 self.handleRNBridgeError(error, checkoutData: nil, stopOnDebug: true)
@@ -495,7 +495,7 @@ extension RNTPrimer: PrimerDelegate {
                 let data = try JSONEncoder().encode(paymentMethodTokenData)
                 let json = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
                 DispatchQueue.main.async {
-                  self.eventDelegate.sendEvent(withName: PrimerEvents.onTokenizeSuccess.stringValue, body: json)
+                  self.eventDelegate?.sendEvent(withName: PrimerEvents.onTokenizeSuccess.stringValue, body: json)
                 }
             } catch {
                 self.handleRNBridgeError(error, checkoutData: nil, stopOnDebug: true)
@@ -522,7 +522,7 @@ extension RNTPrimer: PrimerDelegate {
             }
 
             DispatchQueue.main.async {
-              self.eventDelegate.sendEvent(withName: PrimerEvents.onResumeSuccess.stringValue, body: ["resumeToken": resumeToken])
+              self.eventDelegate?.sendEvent(withName: PrimerEvents.onResumeSuccess.stringValue, body: ["resumeToken": resumeToken])
             }
         } else {
             // RN dev hasn't opted in on listening the tokenization callback.
@@ -533,7 +533,7 @@ extension RNTPrimer: PrimerDelegate {
   public func primerDidDismiss() {
         if self.implementedRNCallbacks?.isOnDismissImplemented == true {
             DispatchQueue.main.async {
-              self.eventDelegate.sendEvent(withName: PrimerEvents.onDismiss.stringValue, body: nil)
+              self.eventDelegate?.sendEvent(withName: PrimerEvents.onDismiss.stringValue, body: nil)
             }
         } else {
             // RN dev hasn't opted in on listening SDK dismiss.


### PR DESCRIPTION
## Summary

- Fixes the iOS Drop-in bridge crashing the host app (SIGSEGV) right after a
  successful payment when the merchant implements `onDismiss`.
- `RNTPrimer.eventDelegate` (the back-reference to the `RCTNativePrimer` event
  emitter) was a `weak` implicitly-unwrapped optional, force-accessed from
  callbacks dispatched on the main queue. When React Native released the emitter
  before the queued block ran, ARC had zeroed the weak reference and the
  force-unwrap crashed the app. The payment always succeeded server-side — this
  was a post-payment crash only.
- Made `eventDelegate` a plain `weak` optional and optional-chained all 10
  `sendEvent` sites, so a released delegate is a safe no-op instead of a crash.
- Drop-in only — Headless modules are each their own `RCTEventEmitter` and don't
  hit this.

## Jira

[ESC-1055](https://primerapi.atlassian.net/browse/ESC-1055)

## Test plan

- [x] Added `RNTPrimerTests.testPrimerDidDismissDoesNotCrashWhenEventDelegateIsNil`
      — drives `primerDidDismiss()` with a nil `eventDelegate`; crashes pre-fix, safe no-op post-fix.
- [x] Danger / SwiftLint green.
- [ ] CI `Run iOS unit tests` green (compiles the bridge + runs the suite).


[ESC-1055]: https://primerapi.atlassian.net/browse/ESC-1055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ