### PR TITLE
fix(components): make Bancontact expiry enterable and MM/YYYY (ORC-7697)

### DIFF
--- a/src/Components/internal/cardFormat.ts
+++ b/src/Components/internal/cardFormat.ts
@@ -25,6 +25,34 @@ export function maxFormattedCardNumberLength(descriptor: CardNetworkDescriptor):
 }
 
 /**
+ * Format keystrokes into a displayed `MM/YY` expiry, inserting the separator once the month is
+ * complete. `previous` detects a delete so the separator isn't re-added under the caret.
+ */
+export function formatExpiryDate(value: string, previous: string): string {
+  const digits = value.replace(/\D/g, '').slice(0, 4);
+  if (value.length < previous.length) {
+    return digits;
+  }
+  if (digits.length >= 2) {
+    return digits.slice(0, 2) + '/' + digits.slice(2);
+  }
+  return digits;
+}
+
+/** Longest displayed expiry — `MM/YY`. Use as the input's `maxLength`. */
+export const MAX_EXPIRY_DATE_LENGTH = 5;
+
+/**
+ * Display is MM/YY but Android's validator requires MM/YYYY; iOS accepts both.
+ * Expand only once the year is fully typed (4-char "MM/YY"); partial edits
+ * pass through unchanged so native can keep reporting "cannot be blank".
+ */
+export function expandExpiryYearForNative(formatted: string): string {
+  const match = /^(\d{2})\/(\d{2})$/.exec(formatted);
+  return match ? `${match[1]}/20${match[2]}` : formatted;
+}
+
+/**
  * Insert spaces into a raw digit string according to a gap pattern.
  * Example: `formatDigitsWithGaps("4242424242424242", [4,8,12])` → `"4242 4242 4242 4242"`.
  */

--- a/src/Components/internal/form-state/CardFormStateProvider.tsx
+++ b/src/Components/internal/form-state/CardFormStateProvider.tsx
@@ -3,7 +3,13 @@ import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
 import { usePrimerCardNetwork } from '../../hooks/usePrimerCardNetwork';
 import { debounce, type DebouncedFunction } from '../../../utils/debounce';
 import { PrimerError } from '../../../models/PrimerError';
-import { formatDigitsWithGaps, maxFormattedCardNumberLength, maxPanDigits } from '../cardFormat';
+import {
+  expandExpiryYearForNative,
+  formatDigitsWithGaps,
+  formatExpiryDate,
+  maxFormattedCardNumberLength,
+  maxPanDigits,
+} from '../cardFormat';
 import type { CardFormField, CardFormErrors, UsePrimerCardFormReturn } from '../../types/CardFormTypes';
 
 const LOG = '[CardFormState]';
@@ -15,31 +21,12 @@ function formatCardNumber(value: string, gapPattern: readonly number[], maxDigit
   return formatDigitsWithGaps(digits, gapPattern);
 }
 
-function formatExpiryDate(value: string, previous: string): string {
-  const digits = value.replace(/\D/g, '').slice(0, 4);
-  if (value.length < previous.length) {
-    return digits;
-  }
-  if (digits.length >= 2) {
-    return digits.slice(0, 2) + '/' + digits.slice(2);
-  }
-  return digits;
-}
-
 function formatCVV(value: string, maxDigits: 3 | 4): string {
   return value.replace(/\D/g, '').slice(0, maxDigits);
 }
 
 function stripCardNumberForNative(formatted: string): string {
   return formatted.replace(/\s/g, '');
-}
-
-// Display is MM/YY but Android's validator requires MM/YYYY; iOS accepts both.
-// Expand only once the year is fully typed (4-char "MM/YY"); partial edits
-// pass through unchanged so native can keep reporting "cannot be blank".
-function expandExpiryYearForNative(formatted: string): string {
-  const match = /^(\d{2})\/(\d{2})$/.exec(formatted);
-  return match ? `${match[1]}/20${match[2]}` : formatted;
 }
 
 const INITIAL_FOCUS: Record<CardFormField, boolean> = {

--- a/src/Components/internal/screens/RawDataFormScreen.tsx
+++ b/src/Components/internal/screens/RawDataFormScreen.tsx
@@ -13,6 +13,7 @@ import { useCheckoutFlow } from '../checkout-flow/CheckoutFlowContext';
 import { usePrimerPaymentMethod } from '../../hooks/usePrimerPaymentMethod';
 import { useBottomSafeArea } from './useBottomSafeArea';
 import { buildRawData } from './buildRawData';
+import { formatExpiryDate, MAX_EXPIRY_DATE_LENGTH } from '../cardFormat';
 
 // Field keys are the SDK's input-element-type strings. NOTE the platform split for BLIK's
 // one-time code: iOS reports 'OTP', Android reports 'OTP_CODE' — both are handled.
@@ -62,7 +63,9 @@ export function RawDataFormScreen() {
   const { requiredInputs, isValid, setData, submit } = form;
 
   const handleChange = (field: string, text: string) => {
-    const next = { ...values, [field]: text };
+    // 'number-pad' has no '/' key on either platform, so the separator has to be inserted for them.
+    const formatted = field === 'EXPIRY_DATE' ? formatExpiryDate(text, values[field] ?? '') : text;
+    const next = { ...values, [field]: formatted };
     setValues(next);
     void setData(buildRawData(params.paymentMethodType, next)).catch(() => {});
   };
@@ -99,6 +102,7 @@ export function RawDataFormScreen() {
               keyboardType={
                 field === 'PHONE_NUMBER' ? 'phone-pad' : NUMERIC_FIELDS.has(field) ? 'number-pad' : 'default'
               }
+              maxLength={field === 'EXPIRY_DATE' ? MAX_EXPIRY_DATE_LENGTH : undefined}
               autoCapitalize="none"
               accessibilityLabel={FIELD_LABEL[field] ?? field}
             />

--- a/src/Components/internal/screens/buildRawData.ts
+++ b/src/Components/internal/screens/buildRawData.ts
@@ -1,4 +1,5 @@
 import type { PrimerRawData } from '../../../models/PrimerRawData';
+import { expandExpiryYearForNative } from '../cardFormat';
 
 export type RawFieldValues = Record<string, string>;
 
@@ -16,7 +17,7 @@ export function buildRawData(type: string, values: RawFieldValues): PrimerRawDat
     case 'ADYEN_BANCONTACT_CARD':
       return {
         cardNumber: values.CARD_NUMBER ?? '',
-        expiryDate: values.EXPIRY_DATE ?? '',
+        expiryDate: expandExpiryYearForNative(values.EXPIRY_DATE ?? ''),
         cardholderName: values.CARDHOLDER_NAME ?? '',
       };
     default:

--- a/src/__tests__/components/RawDataFormScreen.test.tsx
+++ b/src/__tests__/components/RawDataFormScreen.test.tsx
@@ -45,8 +45,10 @@ jest.mock('../../Components/internal/localization', () => ({
   usePrimerLocalization: () => ({ t: (key: string) => key }),
 }));
 
+let mockPaymentMethodType = 'ADYEN_MBWAY';
+
 jest.mock('../../Components/internal/navigation/useRoute', () => ({
-  useRoute: () => ({ params: { paymentMethodType: 'ADYEN_MBWAY' } }),
+  useRoute: () => ({ params: { paymentMethodType: mockPaymentMethodType } }),
 }));
 
 jest.mock('../../Components/internal/navigation/useNavigation', () => ({
@@ -91,7 +93,10 @@ const textInputs = (root: any) => root.findAll((n: any) => n.type === 'TextInput
 const payButton = (root: any) => root.findAll((n: any) => n.type === 'TouchableOpacity')[0];
 
 describe('RawDataFormScreen (ORC-6514)', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPaymentMethodType = 'ADYEN_MBWAY';
+  });
 
   it('activates the raw-data manager on mount and picks a keyboard per field', () => {
     mockMethod = rawDataForm({ requiredInputs: ['PHONE_NUMBER', 'OTP', 'CARDHOLDER_NAME'] });
@@ -137,5 +142,59 @@ describe('RawDataFormScreen (ORC-6514)', () => {
 
     expect(render().toJSON()).toBeNull();
     expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  // ORC-7697: 'number-pad' has no '/' key, so without auto-insert a valid expiry is untypeable.
+  describe('Bancontact expiry (ORC-7697)', () => {
+    const bancontactForm = (overrides: Record<string, unknown> = {}) => {
+      mockPaymentMethodType = 'ADYEN_BANCONTACT_CARD';
+      mockMethod = rawDataForm({
+        requiredInputs: ['CARD_NUMBER', 'EXPIRY_DATE', 'CARDHOLDER_NAME'],
+        ...overrides,
+      });
+      return render().root;
+    };
+    const expiryInput = (root: any) => textInputs(root)[1];
+
+    it('inserts the separator as digits are typed', () => {
+      const root = bancontactForm();
+
+      act(() => expiryInput(root).props.onChangeText('0'));
+      expect(expiryInput(root).props.value).toBe('0');
+
+      act(() => expiryInput(root).props.onChangeText('03'));
+      expect(expiryInput(root).props.value).toBe('03/');
+
+      act(() => expiryInput(root).props.onChangeText('03/30'));
+      expect(expiryInput(root).props.value).toBe('03/30');
+    });
+
+    it('sends MM/YYYY to native while displaying MM/YY', () => {
+      const root = bancontactForm();
+
+      act(() => expiryInput(root).props.onChangeText('03/30'));
+
+      expect(expiryInput(root).props.value).toBe('03/30');
+      expect(mockSetData).toHaveBeenLastCalledWith({
+        cardNumber: '',
+        expiryDate: '03/2030',
+        cardholderName: '',
+      });
+    });
+
+    it('lets a delete cross the separator', () => {
+      const root = bancontactForm();
+
+      act(() => expiryInput(root).props.onChangeText('03/30'));
+      act(() => expiryInput(root).props.onChangeText('03/3'));
+      expect(expiryInput(root).props.value).toBe('033');
+    });
+
+    it('caps the expiry at the displayed MM/YY length', () => {
+      const root = bancontactForm();
+
+      expect(expiryInput(root).props.maxLength).toBe(5);
+      expect(textInputs(root)[0].props.maxLength).toBeUndefined();
+    });
   });
 });

--- a/src/__tests__/components/buildRawData.test.ts
+++ b/src/__tests__/components/buildRawData.test.ts
@@ -18,14 +18,35 @@ describe('buildRawData', () => {
     expect(buildRawData('ADYEN_MBWAY', { PHONE_NUMBER: '+351912345678' })).toEqual({ phoneNumber: '+351912345678' });
   });
 
-  it('maps Bancontact card-fields to the card-data shape', () => {
+  // Android's validator accepts MM/YYYY only; the field displays MM/YY, so the year is expanded here.
+  it('maps Bancontact card-fields to the card-data shape, expanding the year', () => {
     expect(
       buildRawData('ADYEN_BANCONTACT_CARD', {
         CARD_NUMBER: '4111',
         EXPIRY_DATE: '03/30',
         CARDHOLDER_NAME: 'John Smith',
       })
-    ).toEqual({ cardNumber: '4111', expiryDate: '03/30', cardholderName: 'John Smith' });
+    ).toEqual({ cardNumber: '4111', expiryDate: '03/2030', cardholderName: 'John Smith' });
+  });
+
+  it('leaves an already four-digit Bancontact year untouched', () => {
+    expect(
+      buildRawData('ADYEN_BANCONTACT_CARD', {
+        CARD_NUMBER: '4111',
+        EXPIRY_DATE: '03/2030',
+        CARDHOLDER_NAME: 'John Smith',
+      })
+    ).toEqual({ cardNumber: '4111', expiryDate: '03/2030', cardholderName: 'John Smith' });
+  });
+
+  it('passes a partially typed Bancontact expiry through so native still reports it invalid', () => {
+    expect(
+      buildRawData('ADYEN_BANCONTACT_CARD', {
+        CARD_NUMBER: '4111',
+        EXPIRY_DATE: '03/',
+        CARDHOLDER_NAME: 'John Smith',
+      })
+    ).toEqual({ cardNumber: '4111', expiryDate: '03/', cardholderName: 'John Smith' });
   });
 
   it('defaults missing Bancontact fields to empty strings', () => {

--- a/src/__tests__/components/cardFormat.test.ts
+++ b/src/__tests__/components/cardFormat.test.ts
@@ -1,0 +1,39 @@
+import { expandExpiryYearForNative, formatExpiryDate } from '../../Components/internal/cardFormat';
+
+// Shared by the card form and the Bancontact raw-data form — the expiry inputs on both use a
+// numeric keyboard, so the separator has to be synthesised and the year expanded before native.
+describe('formatExpiryDate', () => {
+  it('inserts the separator once the month is complete', () => {
+    expect(formatExpiryDate('0', '')).toBe('0');
+    expect(formatExpiryDate('03', '0')).toBe('03/');
+    expect(formatExpiryDate('03/3', '03/')).toBe('03/3');
+    expect(formatExpiryDate('03/30', '03/3')).toBe('03/30');
+  });
+
+  it('drops the separator on delete so the month stays editable', () => {
+    expect(formatExpiryDate('03/3', '03/30')).toBe('033');
+    expect(formatExpiryDate('03', '03/')).toBe('03');
+  });
+
+  it('ignores non-digits and caps at four digits', () => {
+    expect(formatExpiryDate('0a3', '')).toBe('03/');
+    expect(formatExpiryDate('0330999', '')).toBe('03/30');
+  });
+});
+
+describe('expandExpiryYearForNative', () => {
+  it('expands a complete two-digit year', () => {
+    expect(expandExpiryYearForNative('03/30')).toBe('03/2030');
+  });
+
+  it('leaves a four-digit year alone', () => {
+    expect(expandExpiryYearForNative('03/2030')).toBe('03/2030');
+  });
+
+  it('passes partial input through so native still reports it invalid', () => {
+    expect(expandExpiryYearForNative('')).toBe('');
+    expect(expandExpiryYearForNative('03')).toBe('03');
+    expect(expandExpiryYearForNative('03/')).toBe('03/');
+    expect(expandExpiryYearForNative('03/3')).toBe('03/3');
+  });
+});


### PR DESCRIPTION
ORC-7697 — RN half. iOS native half: primer-io/primer-sdk-ios#1853.

The Bancontact expiry field uses `number-pad`, which has no `/` key, so the value can't be typed. Android's validator wants `MM/YYYY`, so Pay never enables.

- `RawDataFormScreen` auto-inserts the `/` and caps the field at 5 chars
- `buildRawData` expands `MM/YY` → `MM/YYYY` for Bancontact

Helpers moved out of `CardFormStateProvider` into `cardFormat.ts` so both forms share them.

Fixes Android on its own. iOS also needs #1853.
