### PR TITLE
fix(components): translate raw-data form labels and apply theme changes (ORC-8116)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "example": "yarn workspace @primer-io/react-native-example",
     "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build lib",
     "bootstrap": "yarn example pods",
-    "test": "jest src/__tests__ --coverage",
+    "test": "jest src --coverage",
     "test:unit:coverage:lcov": "yarn test && node scripts/aggregate-coverage.js && nyc report --reporter lcov"
   },
   "keywords": [

--- a/src/Components/PrimerCheckoutProvider.tsx
+++ b/src/Components/PrimerCheckoutProvider.tsx
@@ -245,8 +245,9 @@ export function PrimerCheckoutProvider({
 }: PrimerCheckoutProviderProps) {
   const [state, setState] = useState<InternalState>(initialState);
 
-  const [lightTokens] = useState(() => mergeTokens(defaultLightTokens, theme?.light));
-  const [darkTokens] = useState(() => mergeTokens(defaultDarkTokens, theme?.dark));
+  const lightTokens = useMemo(() => mergeTokens(defaultLightTokens, theme?.light), [theme?.light]);
+  const darkTokens = useMemo(() => mergeTokens(defaultDarkTokens, theme?.dark), [theme?.dark]);
+  const themeContextValue = useMemo(() => ({ lightTokens, darkTokens }), [lightTokens, darkTokens]);
 
   // Refs keep init useEffect deps to [clientToken] only.
   const settingsRef = useRef(settings);
@@ -1837,7 +1838,7 @@ export function PrimerCheckoutProvider({
   ]);
 
   return (
-    <ThemeContext.Provider value={{ lightTokens, darkTokens }}>
+    <ThemeContext.Provider value={themeContextValue}>
       <PrimerCheckoutContext.Provider value={contextValue}>{children}</PrimerCheckoutContext.Provider>
     </ThemeContext.Provider>
   );

--- a/src/Components/inputs/PrimerCVVInput.tsx
+++ b/src/Components/inputs/PrimerCVVInput.tsx
@@ -3,6 +3,7 @@ import { Image, StyleSheet } from 'react-native';
 import { PrimerTextInput } from './PrimerTextInput';
 import { TRAILING_ICON_MARGIN, TRAILING_ICON_SIZE } from './dimensions';
 import { usePrimerLocalization } from '../internal/localization';
+import { usePrimerTheme } from '../internal/theme';
 import { usePrimerCardForm } from '../hooks/usePrimerCardForm';
 import type { PrimerCVVInputProps, PrimerTextInputRef } from '../types/CardInputTypes';
 
@@ -14,6 +15,7 @@ export const PrimerCVVInput = forwardRef<PrimerTextInputRef, PrimerCVVInputProps
 ) {
   const cardForm = usePrimerCardForm();
   const { t } = usePrimerLocalization();
+  const tokens = usePrimerTheme();
   const resolvedLabel = label ?? t('primer_card_form_label_cvv');
   const resolvedPlaceholder = placeholder ?? t('primer_card_form_placeholder_cvv');
 
@@ -34,7 +36,7 @@ export const PrimerCVVInput = forwardRef<PrimerTextInputRef, PrimerCVVInputProps
       trailingContent={
         <Image
           source={cvvSource}
-          style={styles.icon}
+          style={[styles.icon, { tintColor: tokens.colors.iconPrimary }]}
           resizeMode="contain"
           testID={rest.testID ? `${rest.testID}-hint-icon` : undefined}
         />

--- a/src/Components/inputs/PrimerExpiryDateInput.tsx
+++ b/src/Components/inputs/PrimerExpiryDateInput.tsx
@@ -4,6 +4,7 @@ import { PrimerTextInput } from './PrimerTextInput';
 import { caretFromDigitIndex, countDigits, countDigitsBefore, targetDigitIndex } from './caret';
 import { TRAILING_ICON_MARGIN, TRAILING_ICON_SIZE } from './dimensions';
 import { usePrimerLocalization } from '../internal/localization';
+import { usePrimerTheme } from '../internal/theme';
 import { usePrimerCardForm } from '../hooks/usePrimerCardForm';
 import type { PrimerExpiryDateInputProps, PrimerTextInputRef } from '../types/CardInputTypes';
 
@@ -15,6 +16,7 @@ export const PrimerExpiryDateInput = forwardRef<PrimerTextInputRef, PrimerExpiry
   function PrimerExpiryDateInput({ placeholder, label, ...rest }, ref) {
     const cardForm = usePrimerCardForm();
     const { t } = usePrimerLocalization();
+    const tokens = usePrimerTheme();
     const resolvedLabel = label ?? t('primer_card_form_label_expiry');
     const resolvedPlaceholder = placeholder ?? t('primer_card_form_placeholder_expiry');
     const innerRef = useRef<PrimerTextInputRef>(null);
@@ -81,7 +83,7 @@ export const PrimerExpiryDateInput = forwardRef<PrimerTextInputRef, PrimerExpiry
         trailingContent={
           <Image
             source={calendarSource}
-            style={styles.icon}
+            style={[styles.icon, { tintColor: tokens.colors.iconPrimary }]}
             resizeMode="contain"
             testID={rest.testID ? `${rest.testID}-calendar-icon` : undefined}
           />

--- a/src/Components/internal/screens/BankSelectionScreen.tsx
+++ b/src/Components/internal/screens/BankSelectionScreen.tsx
@@ -171,7 +171,7 @@ function createStyles(tokens: PrimerTokens) {
       opacity: 0.5,
     },
     payButtonText: {
-      color: colors.background,
+      color: colors.onPrimary,
       fontFamily: typography.titleLarge.fontFamily,
       fontSize: typography.titleLarge.fontSize,
       fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],

--- a/src/Components/internal/screens/CardFormScreen.tsx
+++ b/src/Components/internal/screens/CardFormScreen.tsx
@@ -146,7 +146,7 @@ export function CardFormScreen() {
           testID="primer-card-form-submit"
         >
           {cardForm.isSubmitting ? (
-            <ActivityIndicator color={tokens.colors.background} />
+            <ActivityIndicator color={tokens.colors.onPrimary} />
           ) : (
             <Text style={styles.payButtonText}>{t('primer_common_button_pay')}</Text>
           )}
@@ -193,7 +193,7 @@ function createStyles(tokens: PrimerTokens) {
       opacity: 1,
     },
     payButtonText: {
-      color: colors.background,
+      color: colors.onPrimary,
       fontFamily: typography.titleLarge.fontFamily,
       fontSize: typography.titleLarge.fontSize,
       fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],

--- a/src/Components/internal/screens/MethodSelectionScreen.tsx
+++ b/src/Components/internal/screens/MethodSelectionScreen.tsx
@@ -264,6 +264,7 @@ function createStyles(tokens: PrimerTokens) {
     },
     showAllIcon: {
       height: CHEVRON_ICON_SIZE,
+      tintColor: colors.iconPrimary,
       width: CHEVRON_ICON_SIZE,
     },
     showAllLabel: {

--- a/src/Components/internal/screens/RawDataFormScreen.tsx
+++ b/src/Components/internal/screens/RawDataFormScreen.tsx
@@ -16,13 +16,22 @@ import { buildRawData } from './buildRawData';
 
 // Field keys are the SDK's input-element-type strings. NOTE the platform split for BLIK's
 // one-time code: iOS reports 'OTP', Android reports 'OTP_CODE' — both are handled.
-const FIELD_LABEL: Record<string, string> = {
-  PHONE_NUMBER: 'Phone number',
-  OTP: 'One-time code',
-  OTP_CODE: 'One-time code',
-  CARD_NUMBER: 'Card number',
-  EXPIRY_DATE: 'Expiry date (MM/YY)',
-  CARDHOLDER_NAME: 'Cardholder name',
+const FIELD_LABEL_KEY: Record<string, string> = {
+  PHONE_NUMBER: 'primer_card_form_label_phone',
+  OTP: 'primer_card_form_label_otp',
+  OTP_CODE: 'primer_card_form_label_otp',
+  CARD_NUMBER: 'primer_card_form_label_number',
+  EXPIRY_DATE: 'primer_card_form_label_expiry',
+  CARDHOLDER_NAME: 'primer_card_form_label_name',
+};
+
+const FIELD_PLACEHOLDER_KEY: Record<string, string> = {
+  PHONE_NUMBER: 'primer_card_form_placeholder_phone',
+  OTP: 'primer_card_form_placeholder_otp',
+  OTP_CODE: 'primer_card_form_placeholder_otp',
+  CARD_NUMBER: 'primer_card_form_placeholder_number',
+  EXPIRY_DATE: 'primer_card_form_placeholder_expiry',
+  CARDHOLDER_NAME: 'primer_card_form_placeholder_name',
 };
 
 const NUMERIC_FIELDS = new Set<string>(['PHONE_NUMBER', 'OTP', 'OTP_CODE', 'CARD_NUMBER', 'EXPIRY_DATE']);
@@ -89,21 +98,31 @@ export function RawDataFormScreen() {
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        {requiredInputs.map((field) => (
-          <View key={field} style={styles.field}>
-            <Text style={styles.label}>{FIELD_LABEL[field] ?? field}</Text>
-            <TextInput
-              style={styles.input}
-              value={values[field] ?? ''}
-              onChangeText={(text) => handleChange(field, text)}
-              keyboardType={
-                field === 'PHONE_NUMBER' ? 'phone-pad' : NUMERIC_FIELDS.has(field) ? 'number-pad' : 'default'
-              }
-              autoCapitalize="none"
-              accessibilityLabel={FIELD_LABEL[field] ?? field}
-            />
-          </View>
-        ))}
+        {requiredInputs.map((field) => {
+          const labelKey = FIELD_LABEL_KEY[field];
+          const placeholderKey = FIELD_PLACEHOLDER_KEY[field];
+          const placeholder = placeholderKey ? t(placeholderKey) : undefined;
+          const fieldLabel = labelKey ? t(labelKey) : field;
+          // the expiry field has no input mask, so the format has to stay visible while typing
+          const label = field === 'EXPIRY_DATE' && placeholder ? `${fieldLabel} (${placeholder})` : fieldLabel;
+          return (
+            <View key={field} style={styles.field}>
+              <Text style={styles.label}>{label}</Text>
+              <TextInput
+                style={styles.input}
+                value={values[field] ?? ''}
+                placeholder={placeholder}
+                placeholderTextColor={tokens.colors.textPlaceholder}
+                onChangeText={(text) => handleChange(field, text)}
+                keyboardType={
+                  field === 'PHONE_NUMBER' ? 'phone-pad' : NUMERIC_FIELDS.has(field) ? 'number-pad' : 'default'
+                }
+                autoCapitalize="none"
+                accessibilityLabel={label}
+              />
+            </View>
+          );
+        })}
       </ScrollView>
       <View style={[styles.footer, { paddingBottom: Math.max(bottomInset, tokens.spacing.large) }]}>
         <TouchableOpacity

--- a/src/Components/internal/screens/RawDataFormScreen.tsx
+++ b/src/Components/internal/screens/RawDataFormScreen.tsx
@@ -183,7 +183,7 @@ function createStyles(tokens: PrimerTokens) {
       opacity: 0.5,
     },
     payButtonText: {
-      color: colors.background,
+      color: colors.onPrimary,
       fontFamily: typography.titleLarge.fontFamily,
       fontSize: typography.titleLarge.fontSize,
       fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],

--- a/src/Components/internal/screens/RawDataFormScreen.tsx
+++ b/src/Components/internal/screens/RawDataFormScreen.tsx
@@ -25,15 +25,6 @@ const FIELD_LABEL_KEY: Record<string, string> = {
   CARDHOLDER_NAME: 'primer_card_form_label_name',
 };
 
-const FIELD_PLACEHOLDER_KEY: Record<string, string> = {
-  PHONE_NUMBER: 'primer_card_form_placeholder_phone',
-  OTP: 'primer_card_form_placeholder_otp',
-  OTP_CODE: 'primer_card_form_placeholder_otp',
-  CARD_NUMBER: 'primer_card_form_placeholder_number',
-  EXPIRY_DATE: 'primer_card_form_placeholder_expiry',
-  CARDHOLDER_NAME: 'primer_card_form_placeholder_name',
-};
-
 const NUMERIC_FIELDS = new Set<string>(['PHONE_NUMBER', 'OTP', 'OTP_CODE', 'CARD_NUMBER', 'EXPIRY_DATE']);
 
 type FieldValues = Record<string, string>;
@@ -100,19 +91,13 @@ export function RawDataFormScreen() {
       >
         {requiredInputs.map((field) => {
           const labelKey = FIELD_LABEL_KEY[field];
-          const placeholderKey = FIELD_PLACEHOLDER_KEY[field];
-          const placeholder = placeholderKey ? t(placeholderKey) : undefined;
-          const fieldLabel = labelKey ? t(labelKey) : field;
-          // the expiry field has no input mask, so the format has to stay visible while typing
-          const label = field === 'EXPIRY_DATE' && placeholder ? `${fieldLabel} (${placeholder})` : fieldLabel;
+          const label = labelKey ? t(labelKey) : field;
           return (
             <View key={field} style={styles.field}>
               <Text style={styles.label}>{label}</Text>
               <TextInput
                 style={styles.input}
                 value={values[field] ?? ''}
-                placeholder={placeholder}
-                placeholderTextColor={tokens.colors.textPlaceholder}
                 onChangeText={(text) => handleChange(field, text)}
                 keyboardType={
                   field === 'PHONE_NUMBER' ? 'phone-pad' : NUMERIC_FIELDS.has(field) ? 'number-pad' : 'default'

--- a/src/Components/internal/screens/RawDataFormScreen.tsx
+++ b/src/Components/internal/screens/RawDataFormScreen.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
-import type { TextStyle } from 'react-native';
+import type { TextInputProps, TextStyle } from 'react-native';
 
 import { usePrimerTheme } from '../theme';
 import type { PrimerTokens } from '../theme';
@@ -26,6 +26,19 @@ const FIELD_LABEL_KEY: Record<string, string> = {
 };
 
 const NUMERIC_FIELDS = new Set<string>(['PHONE_NUMBER', 'OTP', 'OTP_CODE', 'CARD_NUMBER', 'EXPIRY_DATE']);
+
+// Autofill hints and capitalisation, per field. `autoComplete` drives Android, `textContentType`
+// drives iOS, and only the cardholder name wants capitalisation.
+type FieldInputProps = Pick<TextInputProps, 'autoComplete' | 'textContentType' | 'autoCapitalize'>;
+
+const FIELD_INPUT_PROPS: Record<string, FieldInputProps> = {
+  PHONE_NUMBER: { autoComplete: 'tel', textContentType: 'telephoneNumber' },
+  OTP: { autoComplete: 'one-time-code', textContentType: 'oneTimeCode' },
+  OTP_CODE: { autoComplete: 'one-time-code', textContentType: 'oneTimeCode' },
+  CARD_NUMBER: { autoComplete: 'cc-number', textContentType: 'creditCardNumber' },
+  EXPIRY_DATE: { autoComplete: 'cc-exp', textContentType: 'creditCardExpiration' },
+  CARDHOLDER_NAME: { autoComplete: 'cc-name', textContentType: 'creditCardName', autoCapitalize: 'words' },
+};
 
 type FieldValues = Record<string, string>;
 
@@ -103,6 +116,7 @@ export function RawDataFormScreen() {
                   field === 'PHONE_NUMBER' ? 'phone-pad' : NUMERIC_FIELDS.has(field) ? 'number-pad' : 'default'
                 }
                 autoCapitalize="none"
+                {...FIELD_INPUT_PROPS[field]}
                 accessibilityLabel={label}
               />
             </View>

--- a/src/Components/internal/screens/StripeAchMandateScreen.tsx
+++ b/src/Components/internal/screens/StripeAchMandateScreen.tsx
@@ -56,7 +56,7 @@ export function StripeAchMandateScreen() {
           accessibilityHint={t('accessibility_ach_mandate_accept_hint')}
         >
           {answering ? (
-            <ActivityIndicator color={tokens.colors.background} />
+            <ActivityIndicator color={tokens.colors.onPrimary} />
           ) : (
             <Text style={styles.acceptButtonText}>{t('primer_ach_mandate_button_accept')}</Text>
           )}
@@ -91,7 +91,7 @@ function createStyles(tokens: PrimerTokens) {
       width: '100%',
     },
     acceptButtonText: {
-      color: colors.background,
+      color: colors.onPrimary,
       fontFamily: typography.titleLarge.fontFamily,
       fontSize: typography.titleLarge.fontSize,
       fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],

--- a/src/Components/internal/screens/StripeAchUserDetailsScreen.tsx
+++ b/src/Components/internal/screens/StripeAchUserDetailsScreen.tsx
@@ -184,7 +184,7 @@ export function StripeAchUserDetailsScreen() {
           accessibilityHint={t('accessibility_ach_continue_hint')}
         >
           {isWaiting ? (
-            <ActivityIndicator color={tokens.colors.background} />
+            <ActivityIndicator color={tokens.colors.onPrimary} />
           ) : (
             <Text style={styles.continueButtonText}>{t('primer_ach_button_continue')}</Text>
           )}
@@ -211,7 +211,7 @@ function createStyles(tokens: PrimerTokens) {
       opacity: 0.5,
     },
     continueButtonText: {
-      color: colors.background,
+      color: colors.onPrimary,
       fontFamily: typography.titleLarge.fontFamily,
       fontSize: typography.titleLarge.fontSize,
       fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],

--- a/src/Components/internal/screens/VaultedMethodsScreen.tsx
+++ b/src/Components/internal/screens/VaultedMethodsScreen.tsx
@@ -397,6 +397,7 @@ function createStyles(tokens: PrimerTokens) {
     },
     headerIcon: {
       height: HEADER_ICON_SIZE,
+      tintColor: colors.iconPrimary,
       width: HEADER_ICON_SIZE,
     },
     listContent: {
@@ -449,6 +450,7 @@ function createRowStyles(tokens: PrimerTokens, isActive: boolean) {
     },
     deleteIcon: {
       height: DELETE_ICON_SIZE,
+      tintColor: colors.iconPrimary,
       width: DELETE_ICON_SIZE,
     },
     leftCol: {

--- a/src/Components/internal/screens/VaultedMethodsScreen.tsx
+++ b/src/Components/internal/screens/VaultedMethodsScreen.tsx
@@ -434,6 +434,7 @@ function createRowStyles(tokens: PrimerTokens, isActive: boolean) {
     },
     checkIcon: {
       height: CHECK_ICON_SIZE,
+      tintColor: colors.primary,
       width: CHECK_ICON_SIZE,
     },
     checkIconBox: {

--- a/src/Components/internal/theme/__tests__/merge.test.ts
+++ b/src/Components/internal/theme/__tests__/merge.test.ts
@@ -1,6 +1,6 @@
-import { mergeTokens } from '../../../Components/internal/theme/merge';
-import { defaultLightTokens } from '../../../Components/internal/theme/tokens';
-import type { PrimerTypographyStyle } from '../../../Components/internal/theme/types';
+import { mergeTokens } from '../merge';
+import { defaultLightTokens } from '../tokens';
+import type { PrimerTypographyStyle } from '../types';
 
 const base = defaultLightTokens;
 

--- a/src/Components/internal/theme/__tests__/useTheme.test.ts
+++ b/src/Components/internal/theme/__tests__/useTheme.test.ts
@@ -1,10 +1,10 @@
 import { createElement, type ReactNode } from 'react';
 // @ts-expect-error -- react-test-renderer has no types for React 19
 import { act, create } from 'react-test-renderer';
-import { ThemeContext } from '../../../Components/internal/theme/ThemeContext';
-import { defaultDarkTokens, defaultLightTokens } from '../../../Components/internal/theme/tokens';
-import { usePrimerTheme } from '../../../Components/internal/theme/usePrimerTheme';
-import type { PrimerTokens } from '../../../Components/internal/theme/types';
+import { ThemeContext } from '../ThemeContext';
+import { defaultDarkTokens, defaultLightTokens } from '../tokens';
+import { usePrimerTheme } from '../usePrimerTheme';
+import type { PrimerTokens } from '../types';
 
 let mockColorScheme: 'light' | 'dark' | null = 'light';
 

--- a/src/Components/internal/theme/tokens/dark.ts
+++ b/src/Components/internal/theme/tokens/dark.ts
@@ -6,6 +6,7 @@ import type { PrimerTokens } from '../types';
 export const defaultDarkTokens: PrimerTokens = {
   colors: {
     primary: '#2f98ff', // primerColorBrand — unchanged in dark (0.184, 0.596, 1.0)
+    onPrimary: '#efefef', // dark gray900 — matches Android's onColoredSurface in dark
     background: '#171619', // dark primerColorGray000 (0.090, 0.086, 0.098)
     surface: '#292929', // dark primerColorGray100 (0.161, 0.161, 0.161)
     overlay: 'rgba(0,0,0,0.7)',

--- a/src/Components/internal/theme/tokens/dark.ts
+++ b/src/Components/internal/theme/tokens/dark.ts
@@ -16,10 +16,10 @@ export const defaultDarkTokens: PrimerTokens = {
     textDisabled: '#858585', // dark primerColorGray400 (0.522, 0.522, 0.522)
     textNegative: '#f6bfbf', // dark primerColorRed900 (0.965, 0.749, 0.749)
     textLink: '#4aaeff', // dark primerColorBlue900 (0.290, 0.682, 1.0)
-    border: '#424242', // dark primerColorGray200 (0.259, 0.259, 0.259)
+    border: '#575757', // dark primerColorGray300 (0.341, 0.341, 0.341)
     borderFocused: '#2f98ff', // dark primerColorBrand — unchanged
     borderError: '#e46d70', // dark primerColorRed500 (0.894, 0.427, 0.439)
-    borderDisabled: '#292929', // dark primerColorGray100 (0.161, 0.161, 0.161)
+    borderDisabled: '#424242', // dark primerColorGray200 (0.259, 0.259, 0.259)
     iconPrimary: '#efefef', // dark primerColorGray900
     iconDisabled: '#858585', // dark primerColorGray400
     iconNegative: '#e46d70', // dark primerColorRed500

--- a/src/Components/internal/theme/tokens/light.ts
+++ b/src/Components/internal/theme/tokens/light.ts
@@ -5,6 +5,7 @@ import type { PrimerTokens } from '../types';
 export const defaultLightTokens: PrimerTokens = {
   colors: {
     primary: '#2f98ff', // primerColorBrand (0.184, 0.596, 1.0)
+    onPrimary: '#ffffff', // gray000 — matches Android's onColoredSurface in light
     background: '#ffffff', // primerColorBackground (1.0, 1.0, 1.0)
     surface: '#f5f5f5', // primerColorGray100 (0.961, 0.961, 0.961)
     overlay: 'rgba(0,0,0,0.5)',

--- a/src/Components/internal/theme/types.ts
+++ b/src/Components/internal/theme/types.ts
@@ -1,5 +1,6 @@
 export interface PrimerColorTokens {
   primary: string;
+  onPrimary: string;
   background: string;
   surface: string;
   overlay: string;

--- a/src/Components/internal/ui/CheckoutButton.tsx
+++ b/src/Components/internal/ui/CheckoutButton.tsx
@@ -28,7 +28,7 @@ export function CheckoutButton({
 
   const buttonStyle = variant === 'primary' ? styles.primaryButton : styles.outlinedButton;
   const textStyle = variant === 'primary' ? styles.primaryText : styles.outlinedText;
-  const spinnerColor = variant === 'primary' ? tokens.colors.background : tokens.colors.textPrimary;
+  const spinnerColor = variant === 'primary' ? tokens.colors.onPrimary : tokens.colors.textPrimary;
   const isInteractive = !disabled && !loading;
   const showDisabledTint = disabled && !loading;
 
@@ -92,7 +92,7 @@ function createStyles(tokens: PrimerTokens) {
     },
     primaryText: {
       ...baseText,
-      color: colors.background,
+      color: colors.onPrimary,
     },
   });
   /* eslint-enable react-native/no-unused-styles */

--- a/src/Components/internal/ui/PaymentMethodButton.tsx
+++ b/src/Components/internal/ui/PaymentMethodButton.tsx
@@ -119,7 +119,7 @@ function createStyles(tokens: PrimerTokens) {
       right: spacing.small,
     },
     surchargeLight: {
-      color: colors.background,
+      color: colors.onPrimary,
       fontFamily: typography.bodySmall.fontFamily,
       fontSize: typography.bodySmall.fontSize,
       fontWeight: typography.bodySmall.fontWeight as TextStyle['fontWeight'],

--- a/src/Components/internal/ui/PaymentMethodButton.tsx
+++ b/src/Components/internal/ui/PaymentMethodButton.tsx
@@ -9,6 +9,9 @@ import type { PaymentMethodButtonProps } from '../../types/PrimerPaymentMethodLi
 
 export const PAYMENT_METHOD_BUTTON_HEIGHT = 44;
 const BUTTON_HEIGHT = PAYMENT_METHOD_BUTTON_HEIGHT;
+// the surcharge badge sits on the payment method's own brand colour, which merchant theming
+// doesn't control, so it stays a fixed light value
+const ON_BRAND_SURFACE_TEXT = '#ffffff';
 
 export function PaymentMethodButton({ item, onPress }: PaymentMethodButtonProps) {
   const tokens = usePrimerTheme();
@@ -119,7 +122,7 @@ function createStyles(tokens: PrimerTokens) {
       right: spacing.small,
     },
     surchargeLight: {
-      color: colors.onPrimary,
+      color: ON_BRAND_SURFACE_TEXT,
       fontFamily: typography.bodySmall.fontFamily,
       fontSize: typography.bodySmall.fontSize,
       fontWeight: typography.bodySmall.fontWeight as TextStyle['fontWeight'],

--- a/src/Components/status/PrimerErrorScreen.tsx
+++ b/src/Components/status/PrimerErrorScreen.tsx
@@ -60,7 +60,7 @@ export function PrimerErrorScreen({
 }
 
 function createStyles(tokens: PrimerTokens) {
-  const { spacing } = tokens;
+  const { colors, spacing } = tokens;
 
   /* eslint-disable react-native/no-unused-styles */
   return StyleSheet.create({
@@ -70,6 +70,7 @@ function createStyles(tokens: PrimerTokens) {
     },
     icon: {
       height: STATUS_SCREEN_ICON_SIZE,
+      tintColor: colors.iconNegative,
       width: STATUS_SCREEN_ICON_SIZE,
     },
   });

--- a/src/Components/status/PrimerSuccessScreen.tsx
+++ b/src/Components/status/PrimerSuccessScreen.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { Image, StyleSheet } from 'react-native';
 
 import { usePrimerLocalization } from '../internal/localization';
+import { usePrimerTheme } from '../internal/theme';
 import { STATUS_SCREEN_ICON_SIZE } from '../internal/screens/constants';
 import { PrimerStatusScreenLayout } from './PrimerStatusScreenLayout';
 
@@ -24,9 +25,12 @@ export function PrimerSuccessScreen({ title, subtitle, icon, onDismiss, autoDism
     return () => clearTimeout(id);
   }, [onDismiss, autoDismissMs]);
 
+  const tokens = usePrimerTheme();
   const resolvedTitle = title ?? t('primer_checkout_success_title');
   const resolvedSubtitle = subtitle ?? t('primer_checkout_success_subtitle');
-  const resolvedIcon = icon ?? <Image source={checkCircleIcon} style={styles.icon} />;
+  const resolvedIcon = icon ?? (
+    <Image source={checkCircleIcon} style={[styles.icon, { tintColor: tokens.colors.iconPositive }]} />
+  );
 
   return <PrimerStatusScreenLayout icon={resolvedIcon} title={resolvedTitle} subtitle={resolvedSubtitle} />;
 }

--- a/src/__tests__/components/RawDataFormScreen.test.tsx
+++ b/src/__tests__/components/RawDataFormScreen.test.tsx
@@ -104,6 +104,26 @@ describe('RawDataFormScreen (ORC-6514)', () => {
     expect(inputs.map((i: any) => i.props.keyboardType)).toEqual(['phone-pad', 'number-pad', 'default']);
   });
 
+  it('offers the right autofill hint per field', () => {
+    mockMethod = rawDataForm({ requiredInputs: ['PHONE_NUMBER', 'OTP', 'CARD_NUMBER', 'CARDHOLDER_NAME'] });
+    const inputs = textInputs(render().root);
+
+    expect(inputs.map((i: any) => i.props.autoComplete)).toEqual(['tel', 'one-time-code', 'cc-number', 'cc-name']);
+    expect(inputs.map((i: any) => i.props.textContentType)).toEqual([
+      'telephoneNumber',
+      'oneTimeCode',
+      'creditCardNumber',
+      'creditCardName',
+    ]);
+  });
+
+  it('capitalises the cardholder name and nothing else', () => {
+    mockMethod = rawDataForm({ requiredInputs: ['PHONE_NUMBER', 'CARDHOLDER_NAME'] });
+    const inputs = textInputs(render().root);
+
+    expect(inputs.map((i: any) => i.props.autoCapitalize)).toEqual(['none', 'words']);
+  });
+
   it('forwards typed input to the SDK in the right raw-data shape', () => {
     mockMethod = rawDataForm({ requiredInputs: ['PHONE_NUMBER'] });
     const root = render().root;

--- a/src/__tests__/components/theme/merge.test.ts
+++ b/src/__tests__/components/theme/merge.test.ts
@@ -1,6 +1,6 @@
-import { mergeTokens } from '../merge';
-import { defaultLightTokens } from '../tokens';
-import type { PrimerTypographyStyle } from '../types';
+import { mergeTokens } from '../../../Components/internal/theme/merge';
+import { defaultLightTokens } from '../../../Components/internal/theme/tokens';
+import type { PrimerTypographyStyle } from '../../../Components/internal/theme/types';
 
 const base = defaultLightTokens;
 

--- a/src/__tests__/components/theme/useTheme.test.ts
+++ b/src/__tests__/components/theme/useTheme.test.ts
@@ -1,10 +1,10 @@
 import { createElement, type ReactNode } from 'react';
 // @ts-expect-error -- react-test-renderer has no types for React 19
 import { act, create } from 'react-test-renderer';
-import { ThemeContext } from '../ThemeContext';
-import { defaultDarkTokens, defaultLightTokens } from '../tokens';
-import { usePrimerTheme } from '../usePrimerTheme';
-import type { PrimerTokens } from '../types';
+import { ThemeContext } from '../../../Components/internal/theme/ThemeContext';
+import { defaultDarkTokens, defaultLightTokens } from '../../../Components/internal/theme/tokens';
+import { usePrimerTheme } from '../../../Components/internal/theme/usePrimerTheme';
+import type { PrimerTokens } from '../../../Components/internal/theme/types';
 
 let mockColorScheme: 'light' | 'dark' | null = 'light';
 


### PR DESCRIPTION
ORC-8116

Six fixes in Checkout Components. Colours, labels and icon tints only. No dimension changes, so a merchant who sets nothing gets the same layout with a few colours corrected.

**Field labels were never translated.** The form Bancontact, BLIK and MB WAY use had its labels hardcoded in English. They go through the localization layer now. Reusing the card form's strings rewords all six labels, which avoids adding new strings to 57 locale files. "One-time code" becomes "OTP Code" and "Cardholder name" becomes "Name on card". The one worth a look is expiry: "Expiry date (MM/YY)" becomes "Expiry Date", so the format hint is lost.

**The same form offered no autofill.** Each field now carries `autoComplete` for Android and `textContentType` for iOS, so the OS can fill the SMS one-time code, a saved card number and expiry, the cardholder name and the phone number. Cardholder name also capitalises words; the rest stay uncapitalised.

**Changing the theme did nothing.** The provider built its colours once, so a new theme mid-session had no effect.

**Icons ignored the theme.** The calendar, CVV hint, vault edit/done/delete, chevron, tick and status icons are flat images baked at light-mode colours, so in dark mode they were near-invisible. The delete X is an unlabelled button, so it was an invisible tap target. They tint from the theme now. Brand logos are left alone.

**Pay button labels were near-black on brand blue in dark mode.** Eleven places used the sheet colour for labels and spinners. iOS painted white, Android near-white, RN near-black, from the same config. There is a proper on-brand colour now, `onPrimary`, defaulting to white in light and `#efefef` in dark. The surcharge badge is the exception: it sits on the payment method's own brand colour, which merchant theming does not control, so it is pinned to white.

**Two dark border colours pointed at the wrong grey.** The disabled one matched the disabled fill exactly, so a disabled field had no outline at all. `border` moves from gray200 to gray300 and `borderDisabled` from gray100 to gray200, in dark only.

Also: two test files sat outside the folder `yarn test` looked at, so 16 tests never ran. Moved in, and the script now covers all of `src`.

## Public API

Additive. `PrimerColorTokens` gains `onPrimary`. Nothing renamed, nothing removed.

## What a merchant who has themed the checkout sees

Button labels and spinners read `onPrimary` instead of `background`, so anyone who was setting `background` to move their Pay button text needs to set `onPrimary` now. The surcharge badge no longer follows `background` at all. Icons that ignored the theme start following `iconPrimary`, `iconNegative`, `iconPositive` and `primary`, so a custom icon colour will now show up in places it previously did not.

## Not in scope

Brand logos and payment method tiles stay untinted. The raw-data form still has no per-field validation to show.

## Testing

Not run on a device or simulator. `yarn typecheck` and eslint clean, jest green.
