### PR TITLE
feat(components): let merchants colour input fields separately from the sheet (ORC-8118)

### DIFF
--- a/src/Components/inputs/CountrySelectorRow.tsx
+++ b/src/Components/inputs/CountrySelectorRow.tsx
@@ -102,7 +102,7 @@ function createStyles(tokens: PrimerTokens) {
     },
     row: {
       alignItems: 'center',
-      backgroundColor: colors.background,
+      backgroundColor: colors.backgroundOutlinedDefault,
       borderColor: colors.border,
       borderRadius: radii.small,
       borderWidth: borders.input,
@@ -115,7 +115,7 @@ function createStyles(tokens: PrimerTokens) {
       borderColor: colors.borderDisabled,
     },
     value: {
-      color: colors.textPrimary,
+      color: colors.textOutlinedDefault,
       flex: 1,
       fontFamily: typography.fontFamily,
       fontSize: typography.bodyLarge.fontSize,

--- a/src/Components/inputs/PrimerTextInput.tsx
+++ b/src/Components/inputs/PrimerTextInput.tsx
@@ -13,7 +13,7 @@ function resolveTheme(tokens: PrimerTokens, override?: PrimerTextInputTheme) {
   const borderWidth = override?.borderWidth ?? tokens.borders.input;
   const focusedBorderWidth = Math.max(override?.focusedBorderWidth ?? tokens.borders.strong, borderWidth);
   return {
-    backgroundColor: override?.backgroundColor ?? tokens.colors.background,
+    backgroundColor: override?.backgroundColor ?? tokens.colors.backgroundOutlinedDefault,
     borderColor: override?.borderColor ?? tokens.colors.border,
     borderRadius: override?.borderRadius ?? tokens.radii.small,
     borderWidth,
@@ -29,7 +29,7 @@ function resolveTheme(tokens: PrimerTokens, override?: PrimerTextInputTheme) {
     labelFontSize: override?.labelFontSize ?? tokens.typography.bodySmall.fontSize,
     placeholderColor: override?.placeholderColor ?? tokens.colors.textPlaceholder,
     primaryColor: override?.primaryColor ?? tokens.colors.borderFocused,
-    textColor: override?.textColor ?? tokens.colors.textPrimary,
+    textColor: override?.textColor ?? tokens.colors.textOutlinedDefault,
   };
 }
 

--- a/src/Components/internal/screens/RawDataFormScreen.tsx
+++ b/src/Components/internal/screens/RawDataFormScreen.tsx
@@ -138,10 +138,11 @@ function createStyles(tokens: PrimerTokens) {
       paddingTop: spacing.small,
     },
     input: {
+      backgroundColor: colors.backgroundOutlinedDefault,
       borderColor: colors.border,
       borderRadius: radii.medium,
       borderWidth: StyleSheet.hairlineWidth,
-      color: colors.textPrimary,
+      color: colors.textOutlinedDefault,
       fontSize: typography.titleLarge.fontSize,
       minHeight: 48,
       paddingHorizontal: spacing.medium,

--- a/src/Components/internal/theme/merge.ts
+++ b/src/Components/internal/theme/merge.ts
@@ -1,4 +1,4 @@
-import type { PrimerTokens, PrimerThemeOverride } from './types';
+import type { PrimerTokens, PrimerThemeOverride, PrimerColorTokens } from './types';
 
 type ModeOverride = PrimerThemeOverride['light'];
 
@@ -12,13 +12,33 @@ function stripNullish<T extends object>(obj: Partial<T>): Partial<T> {
   return result;
 }
 
+// The input tokens alias their non-input counterparts, so a merchant who colours the sheet
+// without naming the input keeps matching inputs, as they did before the tokens were split.
+const COLOR_ALIASES: ReadonlyArray<[keyof PrimerColorTokens, keyof PrimerColorTokens]> = [
+  ['backgroundOutlinedDefault', 'background'],
+  ['textOutlinedDefault', 'textPrimary'],
+];
+
+function mergeColors(base: PrimerColorTokens, override: Partial<PrimerColorTokens>): PrimerColorTokens {
+  const set = stripNullish(override);
+  const merged = { ...base, ...set };
+
+  for (const [alias, source] of COLOR_ALIASES) {
+    if (set[alias] == null && set[source] != null) {
+      merged[alias] = set[source];
+    }
+  }
+
+  return merged;
+}
+
 export function mergeTokens(base: PrimerTokens, override: ModeOverride): PrimerTokens {
   if (override == null) {
     return base;
   }
 
   return {
-    colors: override.colors ? { ...base.colors, ...stripNullish(override.colors) } : base.colors,
+    colors: override.colors ? mergeColors(base.colors, override.colors) : base.colors,
     spacing: override.spacing ? { ...base.spacing, ...stripNullish(override.spacing) } : base.spacing,
     typography: override.typography ? { ...base.typography, ...stripNullish(override.typography) } : base.typography,
     radii: override.radii ? { ...base.radii, ...stripNullish(override.radii) } : base.radii,

--- a/src/Components/internal/theme/tokens/dark.ts
+++ b/src/Components/internal/theme/tokens/dark.ts
@@ -8,11 +8,11 @@ export const defaultDarkTokens: PrimerTokens = {
     primary: '#2f98ff', // primerColorBrand — unchanged in dark (0.184, 0.596, 1.0)
     onPrimary: '#efefef', // dark gray900 — matches Android's onColoredSurface in dark
     background: '#171619', // dark primerColorGray000 (0.090, 0.086, 0.098)
-    backgroundOutlinedDefault: '#292929', // dark primerColorBackgroundOutlinedDefault (gray100)
+    backgroundOutlinedDefault: '#171619', // dark primerColorBackgroundOutlinedDefault -> background.primary
     surface: '#292929', // dark primerColorGray100 (0.161, 0.161, 0.161)
     overlay: 'rgba(0,0,0,0.7)',
     textPrimary: '#efefef', // dark primerColorGray900 (0.937, 0.937, 0.937)
-    textOutlinedDefault: '#efefef', // dark primerColorTextOutlinedDefault (gray900)
+    textOutlinedDefault: '#efefef', // dark primerColorTextOutlinedDefault -> text.primary
     textSecondary: '#c7c7c7', // dark primerColorGray600 (0.780, 0.780, 0.780)
     textPlaceholder: '#767577', // dark primerColorGray500 (0.463, 0.459, 0.467)
     textDisabled: '#858585', // dark primerColorGray400 (0.522, 0.522, 0.522)

--- a/src/Components/internal/theme/tokens/dark.ts
+++ b/src/Components/internal/theme/tokens/dark.ts
@@ -8,9 +8,11 @@ export const defaultDarkTokens: PrimerTokens = {
     primary: '#2f98ff', // primerColorBrand — unchanged in dark (0.184, 0.596, 1.0)
     onPrimary: '#efefef', // dark gray900 — matches Android's onColoredSurface in dark
     background: '#171619', // dark primerColorGray000 (0.090, 0.086, 0.098)
+    backgroundOutlinedDefault: '#292929', // dark primerColorBackgroundOutlinedDefault (gray100)
     surface: '#292929', // dark primerColorGray100 (0.161, 0.161, 0.161)
     overlay: 'rgba(0,0,0,0.7)',
     textPrimary: '#efefef', // dark primerColorGray900 (0.937, 0.937, 0.937)
+    textOutlinedDefault: '#efefef', // dark primerColorTextOutlinedDefault (gray900)
     textSecondary: '#c7c7c7', // dark primerColorGray600 (0.780, 0.780, 0.780)
     textPlaceholder: '#767577', // dark primerColorGray500 (0.463, 0.459, 0.467)
     textDisabled: '#858585', // dark primerColorGray400 (0.522, 0.522, 0.522)

--- a/src/Components/internal/theme/tokens/light.ts
+++ b/src/Components/internal/theme/tokens/light.ts
@@ -7,9 +7,11 @@ export const defaultLightTokens: PrimerTokens = {
     primary: '#2f98ff', // primerColorBrand (0.184, 0.596, 1.0)
     onPrimary: '#ffffff', // gray000 — matches Android's onColoredSurface in light
     background: '#ffffff', // primerColorBackground (1.0, 1.0, 1.0)
+    backgroundOutlinedDefault: '#f5f5f5', // primerColorBackgroundOutlinedDefault (gray100)
     surface: '#f5f5f5', // primerColorGray100 (0.961, 0.961, 0.961)
     overlay: 'rgba(0,0,0,0.5)',
     textPrimary: '#212121', // primerColorTextPrimary (0.129, 0.129, 0.129)
+    textOutlinedDefault: '#212121', // primerColorTextOutlinedDefault (gray900)
     textSecondary: '#757575', // primerColorTextSecondary (0.459, 0.459, 0.459)
     textPlaceholder: '#9e9e9e', // primerColorTextPlaceholder (0.620, 0.620, 0.620)
     textDisabled: '#bdbdbd', // primerColorTextDisabled (0.741, 0.741, 0.741)

--- a/src/Components/internal/theme/tokens/light.ts
+++ b/src/Components/internal/theme/tokens/light.ts
@@ -7,11 +7,11 @@ export const defaultLightTokens: PrimerTokens = {
     primary: '#2f98ff', // primerColorBrand (0.184, 0.596, 1.0)
     onPrimary: '#ffffff', // gray000 — matches Android's onColoredSurface in light
     background: '#ffffff', // primerColorBackground (1.0, 1.0, 1.0)
-    backgroundOutlinedDefault: '#f5f5f5', // primerColorBackgroundOutlinedDefault (gray100)
+    backgroundOutlinedDefault: '#ffffff', // primerColorBackgroundOutlinedDefault -> background.primary
     surface: '#f5f5f5', // primerColorGray100 (0.961, 0.961, 0.961)
     overlay: 'rgba(0,0,0,0.5)',
     textPrimary: '#212121', // primerColorTextPrimary (0.129, 0.129, 0.129)
-    textOutlinedDefault: '#212121', // primerColorTextOutlinedDefault (gray900)
+    textOutlinedDefault: '#212121', // primerColorTextOutlinedDefault -> text.primary
     textSecondary: '#757575', // primerColorTextSecondary (0.459, 0.459, 0.459)
     textPlaceholder: '#9e9e9e', // primerColorTextPlaceholder (0.620, 0.620, 0.620)
     textDisabled: '#bdbdbd', // primerColorTextDisabled (0.741, 0.741, 0.741)

--- a/src/Components/internal/theme/types.ts
+++ b/src/Components/internal/theme/types.ts
@@ -2,9 +2,11 @@ export interface PrimerColorTokens {
   primary: string;
   onPrimary: string;
   background: string;
+  backgroundOutlinedDefault: string;
   surface: string;
   overlay: string;
   textPrimary: string;
+  textOutlinedDefault: string;
   textSecondary: string;
   textPlaceholder: string;
   textDisabled: string;

--- a/src/__tests__/components/PrimerCheckoutProvider.test.tsx
+++ b/src/__tests__/components/PrimerCheckoutProvider.test.tsx
@@ -17,6 +17,7 @@ jest.mock(
     const mockAddListener = jest.fn().mockImplementation(() => ({ remove: jest.fn() }));
     return {
       Platform: { OS: 'android', select: (o: any) => o.android ?? o.default },
+      useColorScheme: () => 'light',
       NativeModules: {
         PrimerHeadlessUniversalCheckout: {
           startWithClientToken: jest.fn(),
@@ -60,6 +61,7 @@ import { createElement } from 'react';
 // @ts-expect-error -- react-test-renderer has no types for React 19
 import renderer, { act } from 'react-test-renderer';
 import { PrimerCheckoutProvider } from '../../Components/PrimerCheckoutProvider';
+import { usePrimerTheme } from '../../Components/internal/theme';
 import { usePrimerCheckout } from '../../Components/hooks/usePrimerCheckout';
 import { PrimerError } from '../../models/PrimerError';
 import type { PrimerCheckoutContextValue } from '../../Components/types/PrimerCheckoutProviderTypes';
@@ -943,5 +945,43 @@ describe('PrimerCheckoutProvider — requiresVaultedCardCvv flag wiring', () => 
       await flushPromises();
     });
     expect(ctx().paymentOutcome?.status).toBe('error');
+  });
+
+  it('applies a changed theme prop to the tokens it provides', async () => {
+    // Regression: tokens were built with useState(() => ...), which runs once, so a
+    // merchant swapping theme at runtime kept the first theme for the whole session.
+    const seen: string[] = [];
+
+    function ThemeProbe() {
+      seen.push(usePrimerTheme().colors.primary);
+      return null;
+    }
+
+    let root: renderer.ReactTestRenderer;
+    await act(async () => {
+      root = renderer.create(
+        createElement(
+          PrimerCheckoutProvider,
+          { clientToken: 'token-1', theme: { light: { colors: { primary: '#111111' } } } },
+          createElement(ThemeProbe)
+        )
+      );
+      await flushPromises();
+    });
+
+    expect(seen[seen.length - 1]).toBe('#111111');
+
+    await act(async () => {
+      root!.update(
+        createElement(
+          PrimerCheckoutProvider,
+          { clientToken: 'token-1', theme: { light: { colors: { primary: '#222222' } } } },
+          createElement(ThemeProbe)
+        )
+      );
+      await flushPromises();
+    });
+
+    expect(seen[seen.length - 1]).toBe('#222222');
   });
 });

--- a/src/__tests__/components/theme/merge.test.ts
+++ b/src/__tests__/components/theme/merge.test.ts
@@ -65,4 +65,34 @@ describe('mergeTokens', () => {
     expect(result.borders.strong).toBe(3);
     expect(result.borders.default).toBe(base.borders.default);
   });
+
+  it('carries a background override into the input fill so inputs keep matching the sheet', () => {
+    const result = mergeTokens(base, { colors: { background: '#101010' } });
+
+    expect(result.colors.background).toBe('#101010');
+    expect(result.colors.backgroundOutlinedDefault).toBe('#101010');
+  });
+
+  it('carries a text override into the input text', () => {
+    const result = mergeTokens(base, { colors: { textPrimary: '#fafafa' } });
+
+    expect(result.colors.textPrimary).toBe('#fafafa');
+    expect(result.colors.textOutlinedDefault).toBe('#fafafa');
+  });
+
+  it('lets an explicit input colour win over the one it would inherit', () => {
+    const result = mergeTokens(base, {
+      colors: { background: '#101010', backgroundOutlinedDefault: '#202020' },
+    });
+
+    expect(result.colors.background).toBe('#101010');
+    expect(result.colors.backgroundOutlinedDefault).toBe('#202020');
+  });
+
+  it('leaves the input colours alone when neither is overridden', () => {
+    const result = mergeTokens(base, { colors: { primary: '#aabbcc' } });
+
+    expect(result.colors.backgroundOutlinedDefault).toBe(base.colors.backgroundOutlinedDefault);
+    expect(result.colors.textOutlinedDefault).toBe(base.colors.textOutlinedDefault);
+  });
 });


### PR DESCRIPTION
ORC-8118

Stacked on #409 — merge that first.

A merchant can't give input fields their own colour: one setting paints the fields, the sheet and the screens, so colouring the fields tints the whole checkout. Same problem reported on iOS in GitHub discussion primer-io/primer-sdk-ios#1832.

Input fields now have their own colour, and their text does too, using the same names as the other SDKs. Both default to today's values, so nothing changes unless a merchant sets them.

## Also here, from a review pass

If a merchant sets only the sheet colour, the input fields follow it. Without that, splitting the colours would have turned their fields white — a regression. Four tests cover it.

## Known, not fixed here

React Native still makes merchants set each border colour one by one, where the native SDKs let them change one base grey and have everything follow. That's on ORC-8179.

## Testing

Not run on a device or simulator.

`yarn typecheck` clean, eslint clean, 422 of 422 jest tests pass.

The colour table was checked entry by entry against the iOS token file — no drift.

