### PR TITLE
feat(components): add the grey palette so one override moves everything built on it (ORC-8201)

### DIFF
--- a/src/Components/internal/theme/merge.ts
+++ b/src/Components/internal/theme/merge.ts
@@ -12,9 +12,20 @@ function stripNullish<T extends object>(obj: Partial<T>): Partial<T> {
   return result;
 }
 
-// The input tokens alias their non-input counterparts, so a merchant who colours the sheet
-// without naming the input keeps matching inputs, as they did before the tokens were split.
+// Each entry says "this colour is derived from that one". A merchant who sets the source and
+// not the alias gets the alias moved for them, which is how the native SDKs behave. Ordered
+// palette-first so a grey override reaches the semantic names and then the input ones.
 const COLOR_ALIASES: ReadonlyArray<[keyof PrimerColorTokens, keyof PrimerColorTokens]> = [
+  ['background', 'gray000'],
+  ['surface', 'gray100'],
+  ['textPrimary', 'gray900'],
+  ['textSecondary', 'gray600'],
+  ['textPlaceholder', 'gray500'],
+  ['textDisabled', 'gray400'],
+  ['border', 'gray300'],
+  ['borderDisabled', 'gray200'],
+  ['iconPrimary', 'gray900'],
+  ['iconDisabled', 'gray400'],
   ['backgroundOutlinedDefault', 'background'],
   ['textOutlinedDefault', 'textPrimary'],
 ];
@@ -24,9 +35,9 @@ function mergeColors(base: PrimerColorTokens, override: Partial<PrimerColorToken
   const merged = { ...base, ...set };
 
   for (const [alias, source] of COLOR_ALIASES) {
-    if (set[alias] == null && set[source] != null) {
-      merged[alias] = set[source];
-    }
+    // An explicit value always wins, and an unmoved source has nothing to pass on.
+    if (set[alias] != null || merged[source] === base[source]) continue;
+    merged[alias] = merged[source];
   }
 
   return merged;

--- a/src/Components/internal/theme/tokens/dark.ts
+++ b/src/Components/internal/theme/tokens/dark.ts
@@ -5,6 +5,14 @@ import type { PrimerTokens } from '../types';
 // Spacing, typography, radii, and borders are mode-independent and match light defaults.
 export const defaultDarkTokens: PrimerTokens = {
   colors: {
+    gray000: '#171619',
+    gray100: '#292929',
+    gray200: '#424242',
+    gray300: '#575757',
+    gray400: '#858585',
+    gray500: '#767577',
+    gray600: '#c7c7c7',
+    gray900: '#efefef',
     primary: '#2f98ff', // primerColorBrand — unchanged in dark (0.184, 0.596, 1.0)
     onPrimary: '#efefef', // dark gray900 — matches Android's onColoredSurface in dark
     background: '#171619', // dark primerColorGray000 (0.090, 0.086, 0.098)

--- a/src/Components/internal/theme/tokens/light.ts
+++ b/src/Components/internal/theme/tokens/light.ts
@@ -4,6 +4,14 @@ import type { PrimerTokens } from '../types';
 // Source: /Users/onurvar/Projects/primer-sdk-ios/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokens.swift
 export const defaultLightTokens: PrimerTokens = {
   colors: {
+    gray000: '#ffffff',
+    gray100: '#f5f5f5',
+    gray200: '#eeeeee',
+    gray300: '#e0e0e0',
+    gray400: '#bdbdbd',
+    gray500: '#9e9e9e',
+    gray600: '#757575',
+    gray900: '#212121',
     primary: '#2f98ff', // primerColorBrand (0.184, 0.596, 1.0)
     onPrimary: '#ffffff', // gray000 — matches Android's onColoredSurface in light
     background: '#ffffff', // primerColorBackground (1.0, 1.0, 1.0)

--- a/src/Components/internal/theme/types.ts
+++ b/src/Components/internal/theme/types.ts
@@ -1,4 +1,15 @@
 export interface PrimerColorTokens {
+  // Palette. Every grey below feeds the semantic names that follow, so setting one moves
+  // everything derived from it — the same base layer iOS, Android and web already have.
+  gray000: string;
+  gray100: string;
+  gray200: string;
+  gray300: string;
+  gray400: string;
+  gray500: string;
+  gray600: string;
+  gray900: string;
+
   primary: string;
   onPrimary: string;
   background: string;

--- a/src/__tests__/components/theme/merge.test.ts
+++ b/src/__tests__/components/theme/merge.test.ts
@@ -95,4 +95,31 @@ describe('mergeTokens', () => {
     expect(result.colors.backgroundOutlinedDefault).toBe(base.colors.backgroundOutlinedDefault);
     expect(result.colors.textOutlinedDefault).toBe(base.colors.textOutlinedDefault);
   });
+
+  it('moves every border built on a grey when that grey is overridden', () => {
+    const result = mergeTokens(base, { colors: { gray300: '#123456' } });
+
+    expect(result.colors.gray300).toBe('#123456');
+    expect(result.colors.border).toBe('#123456');
+  });
+
+  it('carries a grey override two hops, through the semantic colour into the input one', () => {
+    const result = mergeTokens(base, { colors: { gray000: '#0b0b0b' } });
+
+    expect(result.colors.background).toBe('#0b0b0b');
+    expect(result.colors.backgroundOutlinedDefault).toBe('#0b0b0b');
+  });
+
+  it('lets an explicit semantic colour win over the grey it derives from', () => {
+    const result = mergeTokens(base, { colors: { gray300: '#123456', border: '#654321' } });
+
+    expect(result.colors.border).toBe('#654321');
+  });
+
+  it('leaves colours built on other greys untouched', () => {
+    const result = mergeTokens(base, { colors: { gray300: '#123456' } });
+
+    expect(result.colors.textPrimary).toBe(base.colors.textPrimary);
+    expect(result.colors.surface).toBe(base.colors.surface);
+  });
 });


### PR DESCRIPTION
ORC-8201

Stacked on #412, merge that first.

On iOS, Android and web a merchant can set one grey and every colour built on it moves. On React Native they had to set each one by hand: there were no greys at all, just 23 flat semantic names.

The eight greys are public now, and the colours derived from them inherit:

| Grey | Colours that follow it |
|---|---|
| `gray000` | `background`, and through it the input fill |
| `gray100` | `surface` |
| `gray200` | `borderDisabled` |
| `gray300` | `border` |
| `gray400` | `textDisabled`, `iconDisabled` |
| `gray500` | `textPlaceholder` |
| `gray600` | `textSecondary` |
| `gray900` | `textPrimary`, `iconPrimary`, and through it the input text |

So setting `gray300` moves every default border, which is the thing that wasn't possible before.

## Also here

The inheritance now follows chains. As written in #412 it read the override object, so a two-hop derivation stopped after one step: setting `gray000` moved the sheet but not the input fill that follows the sheet. It reads the merged result instead, and skips anything the merchant named explicitly.

## What a merchant who sets nothing sees

No change. Every grey holds the value its semantic colours already had, in both themes, so nothing moves and nothing recolours. Mappings checked against the iOS token file; the dark hexes are Android's, since iOS writes its dark greys as alpha overlays.

## Public API

Additive. `PrimerColorTokens` gains eight names, nothing is renamed or removed, and overrides take `Partial<PrimerColorTokens>`, so nothing merchants pass today breaks.

## Not in scope

The greys are the palette layer only. The colour names themselves are still RN's own rather than the shared vocabulary the other SDKs use; that is #414 on top of this.

## Testing

Not run on a device or simulator.

`yarn typecheck` clean, eslint clean on the changed files, jest green. Four new tests: a grey moving its border, a grey carrying two hops, an explicit semantic colour beating the grey it derives from, and colours built on other greys staying put.
