### PR TITLE
fix: scope listener teardown to own subscriptions (ESC-1131)

### DIFF
--- a/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/AchManager.ts
+++ b/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/AchManager.ts
@@ -7,8 +7,8 @@ import type {
   PrimerValidatingComponentData,
 } from '../../../models/PrimerComponentDataValidation';
 import { PrimerError } from '../../../models/PrimerError';
-import { eventTypes } from './Utils/EventType';
 import type { EventType } from './Utils/EventType';
+import { subscribeToComponentEvents } from './Utils/subscribeToComponentEvents';
 import type { AchStep } from '../../../models/ach/AchSteps';
 import type { AchValidatableData } from '../../../models/ach/AchCollectableData';
 
@@ -59,6 +59,8 @@ export interface StripeAchUserDetailsComponent {
 }
 
 export class PrimerHeadlessUniversalCheckoutAchManager {
+  private subscriptions: EmitterSubscription[] = [];
+
   ///////////////////////////////////////////
   // Init
   ///////////////////////////////////////////
@@ -69,6 +71,7 @@ export class PrimerHeadlessUniversalCheckoutAchManager {
   ///////////////////////////////////////////
 
   async provide(props: AchManagerProps): Promise<StripeAchUserDetailsComponent | any> {
+    this.removeAllListeners();
     await this.configureListeners(props);
 
     if (props.paymentMethodType === 'STRIPE_ACH') {
@@ -97,41 +100,10 @@ export class PrimerHeadlessUniversalCheckoutAchManager {
   }
 
   private async configureListeners(props: AchManagerProps): Promise<void> {
-    if (props?.onStep) {
-      this.addListener('onStep', (data) => {
-        props.onStep?.(data);
-      });
-    }
-
-    if (props?.onInvalid) {
-      this.addListener('onInvalid', (data) => {
-        props.onInvalid?.(data);
-      });
-    }
-
-    if (props?.onError) {
-      this.addListener('onError', (data) => {
-        props.onError?.(data);
-      });
-    }
-
-    if (props?.onValid) {
-      this.addListener('onValid', (data) => {
-        props.onValid?.(data);
-      });
-    }
-
-    if (props?.onValidating) {
-      this.addListener('onValidating', (data) => {
-        props.onValidating?.(data);
-      });
-    }
-
-    if (props?.onValidationError) {
-      this.addListener('onValidationError', (data) => {
-        props.onValidationError?.(data);
-      });
-    }
+    const subscriptions = await subscribeToComponentEvents<AchStep, AchValidatableData>(props, (eventType, listener) =>
+      this.addListener(eventType, listener)
+    );
+    this.subscriptions.push(...subscriptions);
   }
 
   ///////////////////////////////////////////
@@ -151,6 +123,7 @@ export class PrimerHeadlessUniversalCheckoutAchManager {
   }
 
   removeAllListeners() {
-    eventTypes.forEach((eventType) => this.removeAllListenersForEvent(eventType));
+    this.subscriptions.forEach((subscription) => subscription.remove());
+    this.subscriptions = [];
   }
 }

--- a/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/ComponentWithRedirectManager.ts
+++ b/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/ComponentWithRedirectManager.ts
@@ -9,8 +9,8 @@ import type {
 } from '../../../models/PrimerComponentDataValidation';
 import { PrimerError } from '../../../models/PrimerError';
 import type { BanksStep } from '../../../models/banks/BanksSteps';
-import { eventTypes } from './Utils/EventType';
 import type { EventType } from './Utils/EventType';
+import { subscribeToComponentEvents } from './Utils/subscribeToComponentEvents';
 
 const { RNTPrimerHeadlessUniversalCheckoutBanksComponent } = NativeModules;
 
@@ -77,6 +77,8 @@ export interface BanksComponent {
 }
 
 export class PrimerHeadlessUniversalCheckoutComponentWithRedirectManager {
+  private subscriptions: EmitterSubscription[] = [];
+
   ///////////////////////////////////////////
   // Init
   ///////////////////////////////////////////
@@ -87,6 +89,7 @@ export class PrimerHeadlessUniversalCheckoutComponentWithRedirectManager {
   ///////////////////////////////////////////
 
   async provide(props: ComponentWithRedirectManagerProps): Promise<BanksComponent | any> {
+    this.removeAllListeners();
     await this.configureListeners(props);
 
     if (props.paymentMethodType === 'ADYEN_IDEAL') {
@@ -118,41 +121,11 @@ export class PrimerHeadlessUniversalCheckoutComponentWithRedirectManager {
   }
 
   private async configureListeners(props: ComponentWithRedirectManagerProps): Promise<void> {
-    if (props?.onStep) {
-      this.addListener('onStep', (data) => {
-        props.onStep?.(data);
-      });
-    }
-
-    if (props?.onInvalid) {
-      this.addListener('onInvalid', (data) => {
-        props.onInvalid?.(data);
-      });
-    }
-
-    if (props?.onError) {
-      this.addListener('onError', (data) => {
-        props.onError?.(data);
-      });
-    }
-
-    if (props?.onValid) {
-      this.addListener('onValid', (data) => {
-        props.onValid?.(data);
-      });
-    }
-
-    if (props?.onValidating) {
-      this.addListener('onValidating', (data) => {
-        props.onValidating?.(data);
-      });
-    }
-
-    if (props?.onValidationError) {
-      this.addListener('onValidationError', (data) => {
-        props.onValidationError?.(data);
-      });
-    }
+    const subscriptions = await subscribeToComponentEvents<BanksStep, BanksValidatableData>(
+      props,
+      (eventType, listener) => this.addListener(eventType, listener)
+    );
+    this.subscriptions.push(...subscriptions);
   }
 
   ///////////////////////////////////////////
@@ -172,6 +145,7 @@ export class PrimerHeadlessUniversalCheckoutComponentWithRedirectManager {
   }
 
   removeAllListeners() {
-    eventTypes.forEach((eventType) => this.removeAllListenersForEvent(eventType));
+    this.subscriptions.forEach((subscription) => subscription.remove());
+    this.subscriptions = [];
   }
 }

--- a/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/RawDataManager.ts
+++ b/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/RawDataManager.ts
@@ -11,8 +11,6 @@ const eventEmitter = new NativeEventEmitter(RNTPrimerHeadlessUniversalCheckoutRa
 
 type EventType = 'onMetadataChange' | 'onValidation' | 'onBinDataChange';
 
-const eventTypes: EventType[] = ['onMetadataChange', 'onValidation', 'onBinDataChange'];
-
 export interface RawDataManagerProps {
   paymentMethodType: string;
   onMetadataChange?: (metadata: any) => void;
@@ -187,7 +185,8 @@ class PrimerHeadlessUniversalCheckoutRawDataManager {
   }
 
   removeAllListeners() {
-    eventTypes.forEach((eventType) => this.removeAllListenersForEvent(eventType));
+    this.subscriptions.forEach((subscription) => subscription.remove());
+    this.subscriptions = [];
   }
 }
 

--- a/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/RawDataManager.ts
+++ b/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/RawDataManager.ts
@@ -33,6 +33,7 @@ class PrimerHeadlessUniversalCheckoutRawDataManager {
   ///////////////////////////////////////////
 
   async configure(options: RawDataManagerProps): Promise<{ initializationData: PrimerInitializationData } | void> {
+    this.removeAllListeners();
     return new Promise(async (resolve, reject) => {
       try {
         this.options = options;

--- a/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/Utils/EventType.ts
+++ b/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/Utils/EventType.ts
@@ -1,10 +1,1 @@
 export type EventType = 'onStep' | 'onError' | 'onInvalid' | 'onValid' | 'onValidating' | 'onValidationError';
-
-export const eventTypes: EventType[] = [
-  'onStep',
-  'onError',
-  'onInvalid',
-  'onValid',
-  'onValidating',
-  'onValidationError',
-];

--- a/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/Utils/subscribeToComponentEvents.ts
+++ b/src/HeadlessUniversalCheckout/Managers/PaymentMethodManagers/Utils/subscribeToComponentEvents.ts
@@ -1,0 +1,66 @@
+import type { EmitterSubscription } from 'react-native';
+import type {
+  PrimerComponentDataValidationError,
+  PrimerInvalidComponentData,
+  PrimerValidComponentData,
+  PrimerValidatingComponentData,
+} from '../../../../models/PrimerComponentDataValidation';
+import type { PrimerError } from '../../../../models/PrimerError';
+import type { NamedComponentValidatableData } from '../../../../models/NamedComponentValidatableData';
+import type { EventType } from './EventType';
+
+export interface ComponentEventProps<TStep, TValidatableData extends NamedComponentValidatableData> {
+  onStep?: (data: TStep) => void;
+  onError?: (error: PrimerError) => void;
+  onInvalid?: (data: PrimerInvalidComponentData<TValidatableData>) => void;
+  onValid?: (data: PrimerValidComponentData<TValidatableData>) => void;
+  onValidating?: (data: PrimerValidatingComponentData<TValidatableData>) => void;
+  onValidationError?: (data: PrimerComponentDataValidationError<TValidatableData>) => void;
+}
+
+type AddListener = (eventType: EventType, listener: (...args: any[]) => any) => Promise<EmitterSubscription>;
+
+export async function subscribeToComponentEvents<TStep, TValidatableData extends NamedComponentValidatableData>(
+  props: ComponentEventProps<TStep, TValidatableData>,
+  addListener: AddListener
+): Promise<EmitterSubscription[]> {
+  const subscriptions: EmitterSubscription[] = [];
+
+  if (props.onStep) {
+    subscriptions.push(await addListener('onStep', (data: TStep) => props.onStep?.(data)));
+  }
+
+  if (props.onInvalid) {
+    subscriptions.push(
+      await addListener('onInvalid', (data: PrimerInvalidComponentData<TValidatableData>) => props.onInvalid?.(data))
+    );
+  }
+
+  if (props.onError) {
+    subscriptions.push(await addListener('onError', (error: PrimerError) => props.onError?.(error)));
+  }
+
+  if (props.onValid) {
+    subscriptions.push(
+      await addListener('onValid', (data: PrimerValidComponentData<TValidatableData>) => props.onValid?.(data))
+    );
+  }
+
+  if (props.onValidating) {
+    subscriptions.push(
+      await addListener('onValidating', (data: PrimerValidatingComponentData<TValidatableData>) =>
+        props.onValidating?.(data)
+      )
+    );
+  }
+
+  if (props.onValidationError) {
+    subscriptions.push(
+      await addListener('onValidationError', (data: PrimerComponentDataValidationError<TValidatableData>) =>
+        props.onValidationError?.(data)
+      )
+    );
+  }
+
+  return subscriptions;
+}

--- a/src/HeadlessUniversalCheckout/RNPrimerHeadlessUniversalCheckout.ts
+++ b/src/HeadlessUniversalCheckout/RNPrimerHeadlessUniversalCheckout.ts
@@ -21,43 +21,25 @@ type EventType =
   | 'onPreparationStart'
   | 'onPaymentMethodShow';
 
-const eventTypes: EventType[] = [
-  'onAvailablePaymentMethodsLoad',
-  'onTokenizationStart',
-  'onTokenizationSuccess',
-
-  'onCheckoutResume',
-  'onCheckoutPending',
-  'onCheckoutAdditionalInfo',
-
-  'onError',
-  'onCheckoutComplete',
-  'onBeforeClientSessionUpdate',
-
-  'onClientSessionUpdate',
-  'onBeforePaymentCreate',
-  'onPreparationStart',
-
-  'onPaymentMethodShow',
-];
+let subscriptions: EventSubscription[] = [];
 
 const RNPrimerHeadlessUniversalCheckout = {
   ///////////////////////////////////////////
   // Event Emitter
   ///////////////////////////////////////////
   addListener(eventType: EventType, listener: (...args: any[]) => any): EventSubscription {
-    return eventEmitter.addListener(eventType, listener);
+    const subscription = eventEmitter.addListener(eventType, listener);
+    subscriptions.push(subscription);
+    return subscription;
   },
 
   removeListener(subscription: EmitterSubscription): void {
     return subscription.remove();
   },
-  removeAllListenersForEvent(eventType: EventType) {
-    eventEmitter.removeAllListeners(eventType);
-  },
 
   removeAllListeners() {
-    eventTypes.forEach((eventType) => RNPrimerHeadlessUniversalCheckout.removeAllListenersForEvent(eventType));
+    subscriptions.forEach((subscription) => subscription.remove());
+    subscriptions = [];
   },
 
   ///////////////////////////////////////////

--- a/src/Primer.ts
+++ b/src/Primer.ts
@@ -308,14 +308,12 @@ export const Primer: IPrimer = {
   cleanUp(): void {
     RNPrimerHeadlessUniversalCheckout.removeAllListeners();
     RNPrimer.removeAllListeners();
-    primerSettings = undefined;
     RNPrimer.dismiss();
   },
 
   dismiss(): void {
     RNPrimerHeadlessUniversalCheckout.removeAllListeners();
     RNPrimer.removeAllListeners();
-    primerSettings = undefined;
     RNPrimer.dismiss();
   },
 };

--- a/src/__tests__/PaymentMethodManagers.removeAllListeners.test.ts
+++ b/src/__tests__/PaymentMethodManagers.removeAllListeners.test.ts
@@ -1,0 +1,118 @@
+jest.mock(
+  'react-native',
+  () => {
+    const mockAddListener = jest.fn();
+    const mockRemoveAllListeners = jest.fn();
+    return {
+      NativeModules: {
+        RNTPrimerHeadlessUniversalCheckoutStripeAchUserDetailsComponent: {
+          configure: jest.fn().mockResolvedValue(undefined),
+          start: jest.fn(),
+          submit: jest.fn(),
+          onSetFirstName: jest.fn(),
+          onSetLastName: jest.fn(),
+          onSetEmailAddress: jest.fn(),
+        },
+        RNTPrimerHeadlessUniversalCheckoutBanksComponent: {
+          configure: jest.fn().mockResolvedValue(undefined),
+          start: jest.fn(),
+          submit: jest.fn(),
+          onBankFilterChange: jest.fn(),
+          onBankSelected: jest.fn(),
+        },
+      },
+      NativeEventEmitter: jest.fn().mockImplementation(() => ({
+        addListener: mockAddListener,
+        removeAllListeners: mockRemoveAllListeners,
+      })),
+      __mockAddListener: mockAddListener,
+      __mockRemoveAllListeners: mockRemoveAllListeners,
+    };
+  },
+  { virtual: true }
+);
+
+import { PrimerHeadlessUniversalCheckoutAchManager } from '../HeadlessUniversalCheckout/Managers/PaymentMethodManagers/AchManager';
+import { PrimerHeadlessUniversalCheckoutComponentWithRedirectManager } from '../HeadlessUniversalCheckout/Managers/PaymentMethodManagers/ComponentWithRedirectManager';
+
+type RnMock = { __mockAddListener: jest.Mock; __mockRemoveAllListeners: jest.Mock };
+const { __mockAddListener: mockAddListener, __mockRemoveAllListeners: mockRemoveAllListeners } =
+  require('react-native') as RnMock;
+
+const callbacks = () => ({
+  onStep: jest.fn(),
+  onError: jest.fn(),
+  onInvalid: jest.fn(),
+  onValid: jest.fn(),
+  onValidating: jest.fn(),
+  onValidationError: jest.fn(),
+});
+
+type TeardownCapable = {
+  provide(props: { paymentMethodType: string } & ReturnType<typeof callbacks>): Promise<unknown>;
+  removeAllListeners(): void;
+};
+
+describe.each<[string, string, () => TeardownCapable]>([
+  ['AchManager', 'STRIPE_ACH', () => new PrimerHeadlessUniversalCheckoutAchManager()],
+  [
+    'ComponentWithRedirectManager',
+    'ADYEN_IDEAL',
+    () => new PrimerHeadlessUniversalCheckoutComponentWithRedirectManager(),
+  ],
+])('%s.removeAllListeners — ESC-1131', (_name, paymentMethodType, makeManager) => {
+  let created: Array<{ remove: jest.Mock }>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    created = [];
+    mockAddListener.mockImplementation(() => {
+      const subscription = { remove: jest.fn() };
+      created.push(subscription);
+      return subscription;
+    });
+  });
+
+  it('removes exactly the subscriptions this instance registered, never by event name', async () => {
+    const manager = makeManager();
+    await manager.provide({ paymentMethodType, ...callbacks() });
+    expect(created).toHaveLength(6);
+
+    manager.removeAllListeners();
+
+    created.forEach((subscription) => expect(subscription.remove).toHaveBeenCalledTimes(1));
+    expect(mockRemoveAllListeners).not.toHaveBeenCalled();
+  });
+
+  it('a second provide() drains the first one instead of stacking a duplicate listener set', async () => {
+    const manager = makeManager();
+    await manager.provide({ paymentMethodType, ...callbacks() });
+    await manager.provide({ paymentMethodType, ...callbacks() });
+
+    expect(created).toHaveLength(12);
+    const live = created.filter((subscription) => subscription.remove.mock.calls.length === 0);
+    expect(live).toHaveLength(6);
+  });
+
+  it('concurrent provide() calls leave every subscription tracked and removable', async () => {
+    const manager = makeManager();
+    await Promise.all([
+      manager.provide({ paymentMethodType, ...callbacks() }),
+      manager.provide({ paymentMethodType, ...callbacks() }),
+    ]);
+
+    manager.removeAllListeners();
+
+    created.forEach((subscription) => expect(subscription.remove).toHaveBeenCalled());
+  });
+
+  it('a second removeAllListeners() removes nothing more', async () => {
+    const manager = makeManager();
+    await manager.provide({ paymentMethodType, ...callbacks() });
+
+    manager.removeAllListeners();
+    manager.removeAllListeners();
+
+    created.forEach((subscription) => expect(subscription.remove).toHaveBeenCalledTimes(1));
+  });
+});

--- a/src/__tests__/Primer.dismiss.test.ts
+++ b/src/__tests__/Primer.dismiss.test.ts
@@ -1,0 +1,260 @@
+type Listener = (data: object) => void;
+
+type FakeSubscription = {
+  eventType: string;
+  listener: Listener;
+  remove: () => void;
+};
+
+type CountedModule = {
+  listenerCount: number;
+  overRemovals: number;
+  addListener: jest.Mock;
+  removeListeners: jest.Mock;
+};
+
+type FakeNativeEventEmitter = {
+  addListener(eventType: string, listener: Listener): FakeSubscription;
+  removeAllListeners(eventType: string): void;
+};
+
+type RnMock = {
+  NativeEventEmitter: new (nativeModule?: CountedModule) => FakeNativeEventEmitter;
+  __registry: FakeSubscription[];
+  __emit: (eventType: string, data: object) => void;
+  __dropInModule: CountedModule & { dismiss: jest.Mock; setImplementedRNCallbacks: jest.Mock };
+  __headlessModule: CountedModule & { cleanUp: jest.Mock };
+  __hostModule: CountedModule;
+};
+
+jest.mock('../specs/NativePrimer', () => ({
+  __esModule: true,
+  default: {
+    configure: jest.fn().mockResolvedValue(undefined),
+    showUniversalCheckoutWithClientToken: jest.fn().mockResolvedValue(undefined),
+    showVaultManagerWithClientToken: jest.fn().mockResolvedValue(undefined),
+    showPaymentMethod: jest.fn().mockResolvedValue(undefined),
+    dismiss: jest.fn().mockResolvedValue(undefined),
+    cleanUp: jest.fn().mockResolvedValue(undefined),
+    handleTokenizationNewClientToken: jest.fn(),
+    handleTokenizationSuccess: jest.fn(),
+    handleTokenizationFailure: jest.fn(),
+    handleResumeWithNewClientToken: jest.fn(),
+    handleResumeSuccess: jest.fn(),
+    handleResumeFailure: jest.fn(),
+    handlePaymentCreationAbort: jest.fn(),
+    handlePaymentCreationContinue: jest.fn(),
+    showErrorMessage: jest.fn(),
+    setImplementedRNCallbacks: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock(
+  'react-native',
+  () => {
+    const registry: FakeSubscription[] = [];
+
+    const withListenerCounter = <T extends object>(base: T): T & CountedModule => {
+      const counted = Object.assign(base, {
+        listenerCount: 0,
+        overRemovals: 0,
+        addListener: jest.fn(),
+        removeListeners: jest.fn(),
+      });
+      counted.addListener.mockImplementation(() => {
+        counted.listenerCount += 1;
+      });
+      counted.removeListeners.mockImplementation((count: number) => {
+        if (count > counted.listenerCount) {
+          counted.overRemovals += 1;
+        }
+        counted.listenerCount = Math.max(counted.listenerCount - count, 0);
+      });
+      return counted;
+    };
+
+    class NativeEventEmitter {
+      private readonly nativeModule?: CountedModule;
+
+      constructor(nativeModule?: CountedModule) {
+        this.nativeModule = nativeModule;
+      }
+
+      addListener(eventType: string, listener: Listener): FakeSubscription {
+        this.nativeModule?.addListener(eventType);
+        let removed = false;
+        const subscription: FakeSubscription = {
+          eventType,
+          listener,
+          remove: () => {
+            if (removed) {
+              return;
+            }
+            removed = true;
+            this.nativeModule?.removeListeners(1);
+            const index = registry.indexOf(subscription);
+            if (index !== -1) {
+              registry.splice(index, 1);
+            }
+          },
+        };
+        registry.push(subscription);
+        return subscription;
+      }
+
+      removeAllListeners(eventType: string): void {
+        const globalCount = registry.filter((s) => s.eventType === eventType).length;
+        this.nativeModule?.removeListeners(globalCount);
+        for (let i = registry.length - 1; i >= 0; i--) {
+          if (registry[i]?.eventType === eventType) {
+            registry.splice(i, 1);
+          }
+        }
+      }
+    }
+
+    const { default: nativePrimer } = jest.requireMock('../specs/NativePrimer');
+    const dropInModule = withListenerCounter(nativePrimer);
+    const headlessModule = withListenerCounter({
+      startWithClientToken: jest.fn().mockResolvedValue({ availablePaymentMethods: [] }),
+      cleanUp: jest.fn().mockResolvedValue(undefined),
+      handleTokenizationNewClientToken: jest.fn().mockResolvedValue(undefined),
+      handleResumeWithNewClientToken: jest.fn().mockResolvedValue(undefined),
+      handleCompleteFlow: jest.fn().mockResolvedValue(undefined),
+      handlePaymentCreationAbort: jest.fn().mockResolvedValue(undefined),
+      handlePaymentCreationContinue: jest.fn().mockResolvedValue(undefined),
+      setImplementedRNCallbacks: jest.fn().mockResolvedValue(undefined),
+    });
+    const hostModule = withListenerCounter({});
+
+    return {
+      NativeModules: {
+        NativePrimer: dropInModule,
+        PrimerHeadlessUniversalCheckout: headlessModule,
+      },
+      NativeEventEmitter,
+      __registry: registry,
+      __emit: (eventType: string, data: object) => {
+        registry.filter((s) => s.eventType === eventType).forEach((s) => s.listener(data));
+      },
+      __dropInModule: dropInModule,
+      __headlessModule: headlessModule,
+      __hostModule: hostModule,
+    };
+  },
+  { virtual: true }
+);
+
+import { Primer } from '../Primer';
+import { PrimerHeadlessUniversalCheckout } from '../HeadlessUniversalCheckout/PrimerHeadlessUniversalCheckout';
+
+const rnMock = require('react-native') as RnMock;
+const {
+  __registry: registry,
+  __emit: emit,
+  __dropInModule: dropInModule,
+  __headlessModule: headlessModule,
+  __hostModule: hostModule,
+} = rnMock;
+
+const payloadError = { error: { errorId: 'native-err', description: 'boom' } };
+
+const resetCounter = (module: CountedModule) => {
+  module.listenerCount = 0;
+  module.overRemovals = 0;
+};
+
+const lastImplementedCallbacks = (): Record<string, boolean> =>
+  JSON.parse(dropInModule.setImplementedRNCallbacks.mock.lastCall?.[0] ?? '{}');
+
+describe('Primer.dismiss / cleanUp listener teardown — ESC-1131', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    registry.length = 0;
+    [dropInModule, headlessModule, hostModule].forEach(resetCounter);
+  });
+
+  afterEach(async () => {
+    Primer.dismiss();
+    await PrimerHeadlessUniversalCheckout.cleanUp();
+  });
+
+  it('Drop-in only: dismiss() removes only Drop-in listeners and never touches the Headless native counter', async () => {
+    await Primer.configure({ onError: jest.fn(), onCheckoutComplete: jest.fn() });
+    await Primer.showUniversalCheckout('tok-1');
+    expect(dropInModule.listenerCount).toBe(2);
+
+    Primer.dismiss();
+
+    expect(headlessModule.removeListeners).not.toHaveBeenCalled();
+    expect(headlessModule.overRemovals).toBe(0);
+    expect(dropInModule.overRemovals).toBe(0);
+    expect(dropInModule.listenerCount).toBe(0);
+    expect(registry).toHaveLength(0);
+  });
+
+  it.each<[string, () => void]>([
+    ['dismiss', () => Primer.dismiss()],
+    ['cleanUp', () => Primer.cleanUp()],
+  ])(
+    'callbacks from configure() survive %s(): the next showUniversalCheckout() re-registers them',
+    async (_name, teardown) => {
+      const onCheckoutComplete = jest.fn();
+      await Primer.configure({ onCheckoutComplete });
+      await Primer.showUniversalCheckout('tok-1');
+
+      teardown();
+      await Primer.showUniversalCheckout('tok-2');
+
+      expect(lastImplementedCallbacks().onCheckoutComplete).toBe(true);
+      emit('onCheckoutComplete', { payment: { id: 'pay_1' } });
+      expect(onCheckoutComplete).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it('a host-app listener on a shared event name survives dismiss()', async () => {
+    const hostOnError = jest.fn();
+    new rnMock.NativeEventEmitter(hostModule).addListener('onError', hostOnError);
+    await Primer.configure({ onError: jest.fn() });
+    await Primer.showUniversalCheckout('tok-1');
+
+    Primer.dismiss();
+    emit('onError', payloadError);
+
+    expect(hostOnError).toHaveBeenCalledTimes(1);
+    expect(hostModule.listenerCount).toBe(1);
+  });
+
+  it('back-to-back Headless starts do not stack listeners from the previous session', async () => {
+    const onError = jest.fn();
+    await PrimerHeadlessUniversalCheckout.startWithClientToken('tok-1', {
+      headlessUniversalCheckoutCallbacks: { onError: jest.fn() },
+    });
+    await PrimerHeadlessUniversalCheckout.startWithClientToken('tok-2', {
+      headlessUniversalCheckoutCallbacks: { onError },
+    });
+
+    emit('onError', payloadError);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(headlessModule.listenerCount).toBe(1);
+  });
+
+  it('Headless then Drop-in: the stale Headless handler does not fire (ESC-852 still holds)', async () => {
+    const headlessOnError = jest.fn();
+    const dropInOnError = jest.fn();
+    await PrimerHeadlessUniversalCheckout.startWithClientToken('tok-h', {
+      headlessUniversalCheckoutCallbacks: { onError: headlessOnError },
+    });
+    expect(headlessModule.listenerCount).toBe(1);
+
+    await Primer.configure({ onError: dropInOnError });
+    await Primer.showUniversalCheckout('tok-d');
+    emit('onError', payloadError);
+
+    expect(dropInOnError).toHaveBeenCalledTimes(1);
+    expect(headlessOnError).not.toHaveBeenCalled();
+    expect(headlessModule.listenerCount).toBe(0);
+    expect(headlessModule.overRemovals).toBe(0);
+  });
+});

--- a/src/__tests__/RawDataManager.test.ts
+++ b/src/__tests__/RawDataManager.test.ts
@@ -124,5 +124,27 @@ describe('RawDataManager', () => {
 
       created.forEach((subscription) => expect(subscription.remove).toHaveBeenCalledTimes(1));
     });
+
+    it('a second configure() drains the first one instead of stacking a duplicate listener set', async () => {
+      const created: Array<{ remove: jest.Mock }> = [];
+      mockAddListener.mockImplementation(() => {
+        const subscription = { remove: jest.fn() };
+        created.push(subscription);
+        return subscription;
+      });
+      const props = {
+        paymentMethodType: 'PAYMENT_CARD',
+        onMetadataChange: jest.fn(),
+        onValidation: jest.fn(),
+        onBinDataChange: jest.fn(),
+      };
+
+      await manager.configure(props);
+      await manager.configure(props);
+
+      expect(created).toHaveLength(6);
+      created.slice(0, 3).forEach((subscription) => expect(subscription.remove).toHaveBeenCalledTimes(1));
+      created.slice(3).forEach((subscription) => expect(subscription.remove).not.toHaveBeenCalled());
+    });
   });
 });

--- a/src/__tests__/RawDataManager.test.ts
+++ b/src/__tests__/RawDataManager.test.ts
@@ -102,4 +102,27 @@ describe('RawDataManager', () => {
       expect(nativeModule.configure).toHaveBeenCalledWith('PAYMENT_CARD');
     });
   });
+
+  describe('removeAllListeners — ESC-1131', () => {
+    it('removes exactly the subscriptions registered by configure, once', async () => {
+      const created: Array<{ remove: jest.Mock }> = [];
+      mockAddListener.mockImplementation(() => {
+        const subscription = { remove: jest.fn() };
+        created.push(subscription);
+        return subscription;
+      });
+      await manager.configure({
+        paymentMethodType: 'PAYMENT_CARD',
+        onMetadataChange: jest.fn(),
+        onValidation: jest.fn(),
+        onBinDataChange: jest.fn(),
+      });
+      expect(created).toHaveLength(3);
+
+      manager.removeAllListeners();
+      manager.removeAllListeners();
+
+      created.forEach((subscription) => expect(subscription.remove).toHaveBeenCalledTimes(1));
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Since 2.43.0, `Primer.dismiss()` and `Primer.cleanUp()` did two things they should not.

They removed event listeners that were not theirs. React Native keeps every listener in one app-wide list keyed by event name, and Drop-in and Headless share five names, so clearing by name also took out the other mode's listeners and any the merchant's own app had registered. On iOS debug builds this surfaced as `Attempted to remove more PrimerHeadlessUniversalCheckout listeners than added`, once per affected callback.

They also threw away whatever was passed to `Primer.configure()`. The next `showUniversalCheckout()` then registered none of the merchant's callbacks, so nothing fired until they configured again, with nothing logged to say why.

Dabble hit the first one on a debug build while upgrading from 2.42.2.

What changed:

* Each module now removes only the listeners it added.
* `dismiss()` and `cleanUp()` keep the settings from `configure()`. Headless still clears its own, since it receives settings on every start.
* The ACH, bank redirect and raw data managers had the same problem and got the same treatment, matching what Klarna already does. Setting one of them up again on the same instance now replaces the previous callbacks instead of adding a second set.

Switching between Headless and Drop-in still clears the previous mode's listeners, so ESC-852 stays fixed.

## Jira

[ESC-1131](https://primerapi.atlassian.net/browse/ESC-1131)

## Test plan

- [x] Unit tests for both behaviours, plus the existing ESC-852 suite. 36 tests, 7 suites.
- [x] `yarn typescript` and `yarn lint` clean.
- [x] iOS example app, the same flow with and without the fix: five errors before, none after. The example implements all five colliding callbacks, which is why it shows five. Dabble implements two, which is why they saw two.
- [x] iOS and Android, Headless then Drop-in then Headless, followed by a payment. Exactly one callback each time, and one listener per event name at every transition.


[ESC-1131]: https://primerapi.atlassian.net/browse/ESC-1131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ