### PR TITLE
fix(components): take field height from the size token (ORC-8263)

### DIFF
--- a/src/Components/inputs/CountrySelectorRow.tsx
+++ b/src/Components/inputs/CountrySelectorRow.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, Text, TouchableOpacity, View, type StyleProp, type ViewStyl
 import { usePrimerTheme } from '../internal/theme';
 import type { PrimerTokens } from '../internal/theme';
 import { flagEmoji } from '../internal/flags';
-import { FIELD_HEIGHT, LINE_HEIGHT_RATIO } from './dimensions';
+import { LINE_HEIGHT_RATIO } from './dimensions';
 
 export interface CountrySelectorRowProps {
   /** ISO country code currently selected, or empty if none. */
@@ -76,13 +76,13 @@ export function CountrySelectorRow({
 }
 
 function createStyles(tokens: PrimerTokens) {
-  const { colors, radii, spacing, typography, widths } = tokens;
+  const { colors, radii, sizes, spacing, typography, widths } = tokens;
   /* eslint-disable react-native/no-unused-styles */
   return StyleSheet.create({
     chevron: {
       color: tokens.colors.textSecondary,
       fontSize: typography.bodyLarge.fontSize + 4,
-      lineHeight: FIELD_HEIGHT,
+      lineHeight: sizes.xxlarge,
       marginLeft: spacing.small,
     },
     container: {},
@@ -107,7 +107,7 @@ function createStyles(tokens: PrimerTokens) {
       borderRadius: radii.small,
       borderWidth: widths.default,
       flexDirection: 'row',
-      height: FIELD_HEIGHT,
+      height: sizes.xxlarge,
       paddingHorizontal: spacing.medium,
     },
     rowDisabled: {

--- a/src/Components/inputs/PrimerTextInput.tsx
+++ b/src/Components/inputs/PrimerTextInput.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, useImperativeHandle, useMemo, useRef, useState, type ComponentRef } from 'react';
 import { Platform, StyleSheet, Text, TextInput, View, type TextStyle } from 'react-native';
 import { usePrimerTheme } from '../internal/theme';
-import { FIELD_HEIGHT, LINE_HEIGHT_RATIO } from './dimensions';
+import { LINE_HEIGHT_RATIO } from './dimensions';
 import type { PrimerTextInputProps, PrimerTextInputRef, PrimerTextInputTheme } from '../types/CardInputTypes';
 import type { PrimerTokens } from '../internal/theme/types';
 
@@ -21,7 +21,7 @@ function resolveTheme(tokens: PrimerTokens, override?: PrimerTextInputTheme) {
     disabledBorderColor: override?.disabledBorderColor ?? tokens.colors.borderOutlinedDisabled,
     errorColor: override?.errorColor ?? tokens.colors.borderOutlinedError,
     errorTextColor: override?.errorTextColor ?? tokens.colors.textNegative,
-    fieldHeight: override?.fieldHeight ?? FIELD_HEIGHT,
+    fieldHeight: override?.fieldHeight ?? tokens.sizes.xxlarge,
     focusedBorderWidth,
     fontFamily: override?.fontFamily ?? tokens.typography.fontFamily,
     fontSize: override?.fontSize ?? tokens.typography.bodyLarge.fontSize,

--- a/src/Components/inputs/dimensions.ts
+++ b/src/Components/inputs/dimensions.ts
@@ -1,8 +1,6 @@
-// Card-input dimension constants. Sourced from Figma and not theme-driven
-// because the token system has no slot for icon size / field height. Keep all
-// design-spec numerics in this one file so any future spec change is local.
+// Card-input dimension constants sourced from Figma. Field height comes from the
+// size tokens now; the icon sizes below have no token slot yet.
 
-export const FIELD_HEIGHT = 44;
 export const LINE_HEIGHT_RATIO = 1.25;
 
 // Trailing glyph inside the input (expiry calendar, CVV hint). Square, 20×20,

--- a/src/Components/internal/screens/MethodSelectionScreen.tsx
+++ b/src/Components/internal/screens/MethodSelectionScreen.tsx
@@ -31,9 +31,6 @@ const LOG = '[MethodSelectionScreen]';
 // Outer grey padding + tile padding are added into sheetHeight separately below.
 const VAULT_TILE_CONTENT_HEIGHT = 44;
 
-// Matches `FIELD_HEIGHT` in `Components/inputs/dimensions.ts`.
-const VAULT_TILE_CVV_ROW_HEIGHT = 44;
-
 const CHEVRON_ICON_SIZE = 20;
 const chevronDownIcon = require('./assets/chevron-down.png');
 
@@ -75,7 +72,8 @@ export function MethodSelectionScreen() {
   //   (+ inner-tile gap + CVV row, when CVV state is open)
   //   + tile-to-button gap + Pay button (CheckoutButton: padding.medium*2 + titleLarge lineHeight)
   //   + section-to-APM gap.
-  const cvvExtraHeight = cvvInputVisible ? tokens.spacing.medium + VAULT_TILE_CVV_ROW_HEIGHT : 0;
+  // CVV row height is the height of the input field it wraps.
+  const cvvExtraHeight = cvvInputVisible ? tokens.spacing.medium + tokens.sizes.xxlarge : 0;
   const vaultSectionHeight =
     activeVaultedMethod != null
       ? titleArea +


### PR DESCRIPTION
[ORC-8263](https://primerapi.atlassian.net/browse/ORC-8263)

Field height was a hardcoded 44 in `dimensions.ts`. It reads `sizes.xxlarge` now, which is 40 to match Figma and the other SDKs, so input fields and the country row lose 4pt.

The vault tile's content row keeps 44 as its own constant, since it is not a field. Its CVV row follows the token, because it wraps an input field.



[ORC-8263]: https://primerapi.atlassian.net/browse/ORC-8263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ