### PR TITLE
feat(components): give error text its own typography token (ORC-8264)

### DIFF
--- a/src/Components/inputs/PrimerTextInput.tsx
+++ b/src/Components/inputs/PrimerTextInput.tsx
@@ -9,7 +9,8 @@ import type { PrimerTokens } from '../internal/theme/types';
 // Suppresses iOS's auto-added Previous/Next/Done navigation toolbar above the keyboard.
 export const PRIMER_EMPTY_ACCESSORY_ID = 'primer-empty-input-accessory';
 
-function resolveTheme(tokens: PrimerTokens, override?: PrimerTextInputTheme) {
+// Exported for tests: the override chain is easy to break silently.
+export function resolveTheme(tokens: PrimerTokens, override?: PrimerTextInputTheme) {
   const borderWidth = override?.borderWidth ?? tokens.widths.default;
   const focusedBorderWidth = Math.max(override?.focusedBorderWidth ?? tokens.widths.focus, borderWidth);
   return {
@@ -21,6 +22,10 @@ function resolveTheme(tokens: PrimerTokens, override?: PrimerTextInputTheme) {
     disabledBorderColor: override?.disabledBorderColor ?? tokens.colors.borderOutlinedDisabled,
     errorColor: override?.errorColor ?? tokens.colors.borderOutlinedError,
     errorTextColor: override?.errorTextColor ?? tokens.colors.textNegative,
+    // `fontFamily`/`labelFontSize` stay in the chain: they styled the error text before the
+    // error token existed, so a merchant already setting them keeps working.
+    errorFontFamily: override?.errorFontFamily ?? override?.fontFamily ?? tokens.typography.error.fontFamily,
+    errorFontSize: override?.errorFontSize ?? override?.labelFontSize ?? tokens.typography.error.fontSize,
     fieldHeight: override?.fieldHeight ?? tokens.sizes.xxlarge,
     focusedBorderWidth,
     fontFamily: override?.fontFamily ?? tokens.typography.fontFamily,
@@ -112,8 +117,8 @@ export const PrimerTextInput = forwardRef<PrimerTextInputRef, PrimerTextInputPro
         container: {},
         error: {
           color: resolved.errorTextColor,
-          fontFamily: resolved.fontFamily,
-          fontSize: resolved.labelFontSize,
+          fontFamily: resolved.errorFontFamily,
+          fontSize: resolved.errorFontSize,
           marginTop: tokens.spacing.xsmall,
         },
         input: {

--- a/src/Components/internal/theme/tokens/dark.ts
+++ b/src/Components/internal/theme/tokens/dark.ts
@@ -108,6 +108,13 @@ export const defaultDarkTokens: PrimerTokens = {
       lineHeight: 16,
       letterSpacing: 0,
     },
+    error: {
+      fontFamily: 'Inter', // primerTypographyErrorFont
+      fontSize: 12, // primerTypographyErrorSize
+      fontWeight: '400', // primerTypographyErrorWeight
+      lineHeight: 16, // primerTypographyErrorLineHeight
+      letterSpacing: 0, // primerTypographyErrorLetterSpacing
+    },
   },
   radii: {
     none: 0,

--- a/src/Components/internal/theme/tokens/light.ts
+++ b/src/Components/internal/theme/tokens/light.ts
@@ -107,6 +107,13 @@ export const defaultLightTokens: PrimerTokens = {
       lineHeight: 16, // primerTypographyBodySmallLineHeight
       letterSpacing: 0, // primerTypographyBodySmallLetterSpacing
     },
+    error: {
+      fontFamily: 'Inter', // primerTypographyErrorFont
+      fontSize: 12, // primerTypographyErrorSize
+      fontWeight: '400', // primerTypographyErrorWeight
+      lineHeight: 16, // primerTypographyErrorLineHeight
+      letterSpacing: 0, // primerTypographyErrorLetterSpacing
+    },
   },
   radii: {
     none: 0,

--- a/src/Components/internal/theme/types.ts
+++ b/src/Components/internal/theme/types.ts
@@ -92,6 +92,7 @@ export interface PrimerTypographyTokens {
   bodyLarge: PrimerTypographyStyle;
   bodyMedium: PrimerTypographyStyle;
   bodySmall: PrimerTypographyStyle;
+  error: PrimerTypographyStyle;
 }
 
 export interface PrimerRadiusTokens {

--- a/src/Components/types/CardInputTypes.ts
+++ b/src/Components/types/CardInputTypes.ts
@@ -16,6 +16,8 @@ export interface PrimerTextInputTheme {
   errorTextColor?: string;
   borderWidth?: number;
   focusedBorderWidth?: number;
+  errorFontFamily?: string;
+  errorFontSize?: number;
   borderRadius?: number;
   fontSize?: number;
   labelFontSize?: number;

--- a/src/__tests__/components/primerTextInputTheme.test.ts
+++ b/src/__tests__/components/primerTextInputTheme.test.ts
@@ -1,0 +1,30 @@
+import { resolveTheme } from '../../Components/inputs/PrimerTextInput';
+import { defaultLightTokens } from '../../Components/internal/theme/tokens/light';
+
+describe('PrimerTextInput resolveTheme', () => {
+  it('falls back to the error typography token when nothing is overridden', () => {
+    const r = resolveTheme(defaultLightTokens);
+
+    expect(r.errorFontFamily).toBe(defaultLightTokens.typography.error.fontFamily);
+    expect(r.errorFontSize).toBe(defaultLightTokens.typography.error.fontSize);
+  });
+
+  it('still honours fontFamily and labelFontSize, which styled the error text before the error token existed', () => {
+    const r = resolveTheme(defaultLightTokens, { fontFamily: 'Courier', labelFontSize: 18 });
+
+    expect(r.errorFontFamily).toBe('Courier');
+    expect(r.errorFontSize).toBe(18);
+  });
+
+  it('lets the dedicated error overrides win', () => {
+    const r = resolveTheme(defaultLightTokens, {
+      fontFamily: 'Courier',
+      labelFontSize: 18,
+      errorFontFamily: 'Menlo',
+      errorFontSize: 9,
+    });
+
+    expect(r.errorFontFamily).toBe('Menlo');
+    expect(r.errorFontSize).toBe(9);
+  });
+});

--- a/src/__tests__/components/theme/merge.test.ts
+++ b/src/__tests__/components/theme/merge.test.ts
@@ -67,6 +67,12 @@ describe('mergeTokens', () => {
     expect(result.widths.default).toBe(base.widths.default);
   });
 
+  it('keeps the error text style separate from the body-small label', () => {
+    const result = mergeTokens(base, { typography: { error: { ...base.typography.error, fontSize: 20 } } });
+    expect(result.typography.error.fontSize).toBe(20);
+    expect(result.typography.bodySmall.fontSize).toBe(base.typography.bodySmall.fontSize);
+  });
+
   it('carries the same colour vocabulary as the other SDKs', () => {
     // 53 shared tokens, plus onBrand and overlay which RN needs and the token files do not carry.
     expect(Object.keys(base.colors)).toHaveLength(55);


### PR DESCRIPTION
[ORC-8264](https://primerapi.atlassian.net/browse/ORC-8264)

Error text was drawing at the field label's size, so a merchant couldn't restyle one without moving the other. It has its own token now, defaulting to the body-small values.

A merchant already styling error text indirectly through `fontFamily` or `labelFontSize` keeps working: those stay in the resolution chain behind the new `errorFontFamily` and `errorFontSize`. Dropping them would have silently broken existing themes. `resolveTheme` is exported so the chain can be tested directly.



[ORC-8264]: https://primerapi.atlassian.net/browse/ORC-8264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ