### PR TITLE
feat(components): colour input fields separately from the sheet (ORC-8118)

### DIFF
--- a/src/Components/inputs/CountrySelectorRow.tsx
+++ b/src/Components/inputs/CountrySelectorRow.tsx
@@ -102,7 +102,7 @@ function createStyles(tokens: PrimerTokens) {
     },
     row: {
       alignItems: 'center',
-      backgroundColor: colors.backgroundPrimary,
+      backgroundColor: colors.backgroundOutlinedDefault,
       borderColor: colors.borderOutlinedDefault,
       borderRadius: radii.small,
       borderWidth: widths.default,
@@ -115,7 +115,7 @@ function createStyles(tokens: PrimerTokens) {
       borderColor: colors.borderOutlinedDisabled,
     },
     value: {
-      color: colors.textPrimary,
+      color: colors.textOutlinedDefault,
       flex: 1,
       fontFamily: typography.fontFamily,
       fontSize: typography.bodyLarge.fontSize,

--- a/src/Components/inputs/PrimerTextInput.tsx
+++ b/src/Components/inputs/PrimerTextInput.tsx
@@ -14,7 +14,7 @@ export function resolveTheme(tokens: PrimerTokens, override?: PrimerTextInputThe
   const borderWidth = override?.borderWidth ?? tokens.widths.default;
   const focusedBorderWidth = Math.max(override?.focusedBorderWidth ?? tokens.widths.focus, borderWidth);
   return {
-    backgroundColor: override?.backgroundColor ?? tokens.colors.backgroundPrimary,
+    backgroundColor: override?.backgroundColor ?? tokens.colors.backgroundOutlinedDefault,
     borderColor: override?.borderColor ?? tokens.colors.borderOutlinedDefault,
     borderRadius: override?.borderRadius ?? tokens.radii.small,
     borderWidth,
@@ -34,7 +34,7 @@ export function resolveTheme(tokens: PrimerTokens, override?: PrimerTextInputThe
     labelFontSize: override?.labelFontSize ?? tokens.typography.bodySmall.fontSize,
     placeholderColor: override?.placeholderColor ?? tokens.colors.textPlaceholder,
     primaryColor: override?.primaryColor ?? tokens.colors.borderOutlinedFocus,
-    textColor: override?.textColor ?? tokens.colors.textPrimary,
+    textColor: override?.textColor ?? tokens.colors.textOutlinedDefault,
   };
 }
 


### PR DESCRIPTION
[ORC-8118](https://primerapi.atlassian.net/browse/ORC-8118)

Inputs take the outlined background and text tokens rather than the sheet's, so a merchant can colour a field without colouring the sheet behind it. Covers `PrimerTextInput` and the country selector row.

The country row has two text colours; only the value is an input surface, so the label stays on `textPrimary`.



[ORC-8118]: https://primerapi.atlassian.net/browse/ORC-8118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ