### PR TITLE
fix(components): give the primary button label an on-brand colour (ORC-8179)

### DIFF
--- a/src/Components/internal/ui/CheckoutButton.tsx
+++ b/src/Components/internal/ui/CheckoutButton.tsx
@@ -28,7 +28,7 @@ export function CheckoutButton({
 
   const buttonStyle = variant === 'primary' ? styles.primaryButton : styles.outlinedButton;
   const textStyle = variant === 'primary' ? styles.primaryText : styles.outlinedText;
-  const spinnerColor = variant === 'primary' ? tokens.colors.backgroundPrimary : tokens.colors.textPrimary;
+  const spinnerColor = variant === 'primary' ? tokens.colors.onBrand : tokens.colors.textPrimary;
   const isInteractive = !disabled && !loading;
   const showDisabledTint = disabled && !loading;
 
@@ -92,7 +92,7 @@ function createStyles(tokens: PrimerTokens) {
     },
     primaryText: {
       ...baseText,
-      color: colors.backgroundPrimary,
+      color: colors.onBrand,
     },
   });
   /* eslint-enable react-native/no-unused-styles */

--- a/src/Components/internal/ui/PaymentMethodButton.tsx
+++ b/src/Components/internal/ui/PaymentMethodButton.tsx
@@ -9,6 +9,9 @@ import type { PaymentMethodButtonProps } from '../../types/PrimerPaymentMethodLi
 
 export const PAYMENT_METHOD_BUTTON_HEIGHT = 44;
 const BUTTON_HEIGHT = PAYMENT_METHOD_BUTTON_HEIGHT;
+// the surcharge badge sits on the payment method's own brand colour, which merchant theming
+// doesn't control, so it stays a fixed light value
+const ON_BRAND_SURFACE_TEXT = '#ffffff';
 
 export function PaymentMethodButton({ item, onPress }: PaymentMethodButtonProps) {
   const tokens = usePrimerTheme();
@@ -119,7 +122,7 @@ function createStyles(tokens: PrimerTokens) {
       right: spacing.small,
     },
     surchargeLight: {
-      color: colors.backgroundPrimary,
+      color: ON_BRAND_SURFACE_TEXT,
       fontFamily: typography.bodySmall.fontFamily,
       fontSize: typography.bodySmall.fontSize,
       fontWeight: typography.bodySmall.fontWeight as TextStyle['fontWeight'],


### PR DESCRIPTION
[ORC-8179](https://primerapi.atlassian.net/browse/ORC-8179)

The label and spinner on a brand-filled button were taking the sheet colour, which inverts in dark mode. They use `colors.onBrand` now.


[ORC-8179]: https://primerapi.atlassian.net/browse/ORC-8179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ