### PR TITLE
fix(components): grey the disabled primary button instead of fading it (ORC-8265)

### DIFF
--- a/src/Components/internal/ui/CheckoutButton.tsx
+++ b/src/Components/internal/ui/CheckoutButton.tsx
@@ -26,15 +26,24 @@ export function CheckoutButton({
   const tokens = usePrimerTheme();
   const styles = useMemo(() => createStyles(tokens), [tokens]);
 
-  const buttonStyle = variant === 'primary' ? styles.primaryButton : styles.outlinedButton;
-  const textStyle = variant === 'primary' ? styles.primaryText : styles.outlinedText;
-  const spinnerColor = variant === 'primary' ? tokens.colors.onBrand : tokens.colors.textPrimary;
   const isInteractive = !disabled && !loading;
   const showDisabledTint = disabled && !loading;
+  const isPrimary = variant === 'primary';
+  // Button and text always move together, so resolve them as a pair.
+  const { button: buttonStyle, text: textStyle } = useMemo(() => {
+    if (!isPrimary) {
+      return { button: styles.outlinedButton, text: styles.outlinedText };
+    }
+    if (showDisabledTint) {
+      return { button: styles.primaryButtonDisabled, text: styles.primaryTextDisabled };
+    }
+    return { button: styles.primaryButton, text: styles.primaryText };
+  }, [isPrimary, showDisabledTint, styles]);
+  const spinnerColor = isPrimary ? tokens.colors.onBrand : tokens.colors.textPrimary;
 
   return (
     <TouchableOpacity
-      style={[buttonStyle, showDisabledTint ? styles.dimmed : styles.opaque]}
+      style={[buttonStyle, !isPrimary && showDisabledTint ? styles.dimmed : styles.opaque]}
       onPress={onPress}
       disabled={!isInteractive}
       activeOpacity={0.7}
@@ -90,9 +99,17 @@ function createStyles(tokens: PrimerTokens) {
       ...baseButton,
       backgroundColor: colors.brand,
     },
+    primaryButtonDisabled: {
+      ...baseButton,
+      backgroundColor: colors.backgroundOutlinedDisabled,
+    },
     primaryText: {
       ...baseText,
       color: colors.onBrand,
+    },
+    primaryTextDisabled: {
+      ...baseText,
+      color: colors.textDisabled,
     },
   });
   /* eslint-enable react-native/no-unused-styles */


### PR DESCRIPTION
[ORC-8265](https://primerapi.atlassian.net/browse/ORC-8265)

A disabled primary button was the brand fill at reduced opacity, so it read as a live button behind glass. It takes the disabled background and disabled text tokens now, matching the other SDKs.

Outlined buttons keep the opacity dim, since they have no fill to swap.


[ORC-8265]: https://primerapi.atlassian.net/browse/ORC-8265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ