### PR TITLE
fix(components): draw borders at the width the state calls for (ORC-8178)

### DIFF
--- a/src/Components/PrimerVaultedPaymentMethod.tsx
+++ b/src/Components/PrimerVaultedPaymentMethod.tsx
@@ -217,7 +217,7 @@ function createStyles(tokens: PrimerTokens) {
       backgroundColor: colors.backgroundPrimary,
       borderColor: colors.brand,
       borderRadius: radii.medium,
-      borderWidth: widths.focus,
+      borderWidth: widths.selected,
       gap: spacing.medium,
       padding: spacing.medium,
     },

--- a/src/Components/inputs/PrimerTextInput.tsx
+++ b/src/Components/inputs/PrimerTextInput.tsx
@@ -13,6 +13,7 @@ export const PRIMER_EMPTY_ACCESSORY_ID = 'primer-empty-input-accessory';
 export function resolveTheme(tokens: PrimerTokens, override?: PrimerTextInputTheme) {
   const borderWidth = override?.borderWidth ?? tokens.widths.default;
   const focusedBorderWidth = Math.max(override?.focusedBorderWidth ?? tokens.widths.focus, borderWidth);
+  const errorBorderWidth = Math.max(override?.errorBorderWidth ?? tokens.widths.error, borderWidth);
   return {
     backgroundColor: override?.backgroundColor ?? tokens.colors.backgroundOutlinedDefault,
     borderColor: override?.borderColor ?? tokens.colors.borderOutlinedDefault,
@@ -27,6 +28,7 @@ export function resolveTheme(tokens: PrimerTokens, override?: PrimerTextInputThe
     errorFontFamily: override?.errorFontFamily ?? override?.fontFamily ?? tokens.typography.error.fontFamily,
     errorFontSize: override?.errorFontSize ?? override?.labelFontSize ?? tokens.typography.error.fontSize,
     fieldHeight: override?.fieldHeight ?? tokens.sizes.xxlarge,
+    errorBorderWidth,
     focusedBorderWidth,
     fontFamily: override?.fontFamily ?? tokens.typography.fontFamily,
     fontSize: override?.fontSize ?? tokens.typography.bodyLarge.fontSize,
@@ -98,7 +100,12 @@ export const PrimerTextInput = forwardRef<PrimerTextInputRef, PrimerTextInputPro
   );
 
   const hasError = !!error;
-  const currentBorderWidth = isFocused || hasError ? resolved.focusedBorderWidth : resolved.borderWidth;
+  // Error beats focus beats resting.
+  const currentBorderWidth = useMemo(() => {
+    if (hasError) return resolved.errorBorderWidth;
+    if (isFocused) return resolved.focusedBorderWidth;
+    return resolved.borderWidth;
+  }, [hasError, isFocused, resolved]);
   const borderWidthDiff = currentBorderWidth - resolved.borderWidth;
 
   // Error takes precedence over focus — the validation signal is more important than the

--- a/src/Components/internal/Popover.tsx
+++ b/src/Components/internal/Popover.tsx
@@ -46,6 +46,7 @@ export function Popover({ visible, onDismiss, children, anchor, testID }: Popove
       backgroundColor: tokens.colors.backgroundPrimary,
       borderColor: tokens.colors.borderOutlinedDefault,
       borderRadius: tokens.radii.medium,
+      borderWidth: tokens.widths.default,
     },
   ];
 
@@ -76,7 +77,6 @@ export function Popover({ visible, onDismiss, children, anchor, testID }: Popove
 
 const styles = StyleSheet.create({
   card: {
-    borderWidth: StyleSheet.hairlineWidth,
     overflow: 'hidden',
     width: '100%',
   },

--- a/src/Components/internal/screens/KlarnaScreen.tsx
+++ b/src/Components/internal/screens/KlarnaScreen.tsx
@@ -161,7 +161,7 @@ export function KlarnaScreen() {
 }
 
 function createStyles(tokens: PrimerTokens) {
-  const { colors, radii, spacing, typography } = tokens;
+  const { colors, radii, spacing, typography, widths } = tokens;
   /* eslint-disable react-native/no-unused-styles */
   return StyleSheet.create({
     categoryName: {
@@ -176,7 +176,7 @@ function createStyles(tokens: PrimerTokens) {
       alignItems: 'center',
       borderColor: colors.borderOutlinedDefault,
       borderRadius: radii.medium,
-      borderWidth: StyleSheet.hairlineWidth,
+      borderWidth: widths.default,
       flexDirection: 'row',
       gap: spacing.medium,
       minHeight: 56,
@@ -184,7 +184,7 @@ function createStyles(tokens: PrimerTokens) {
     },
     categoryRowSelected: {
       borderColor: colors.brand,
-      borderWidth: 2,
+      borderWidth: widths.selected,
     },
     description: {
       color: colors.textSecondary,

--- a/src/Components/internal/screens/VaultedMethodsScreen.tsx
+++ b/src/Components/internal/screens/VaultedMethodsScreen.tsx
@@ -397,6 +397,7 @@ function createStyles(tokens: PrimerTokens) {
     },
     headerIcon: {
       height: HEADER_ICON_SIZE,
+      tintColor: colors.iconPrimary,
       width: HEADER_ICON_SIZE,
     },
     listContent: {
@@ -433,6 +434,7 @@ function createRowStyles(tokens: PrimerTokens, isActive: boolean) {
     },
     checkIcon: {
       height: CHECK_ICON_SIZE,
+      tintColor: colors.brand,
       width: CHECK_ICON_SIZE,
     },
     checkIconBox: {
@@ -449,6 +451,7 @@ function createRowStyles(tokens: PrimerTokens, isActive: boolean) {
     },
     deleteIcon: {
       height: DELETE_ICON_SIZE,
+      tintColor: colors.iconPrimary,
       width: DELETE_ICON_SIZE,
     },
     leftCol: {
@@ -499,7 +502,7 @@ function createRowStyles(tokens: PrimerTokens, isActive: boolean) {
       backgroundColor: colors.backgroundPrimary,
       borderColor: isActive ? colors.brand : colors.borderOutlinedDefault,
       borderRadius: radii.medium,
-      borderWidth: isActive ? widths.focus : widths.default,
+      borderWidth: isActive ? widths.selected : widths.default,
       padding: innerPadding,
     },
     tileFull: {

--- a/src/Components/types/CardInputTypes.ts
+++ b/src/Components/types/CardInputTypes.ts
@@ -16,6 +16,7 @@ export interface PrimerTextInputTheme {
   errorTextColor?: string;
   borderWidth?: number;
   focusedBorderWidth?: number;
+  errorBorderWidth?: number;
   errorFontFamily?: string;
   errorFontSize?: number;
   borderRadius?: number;

--- a/src/__tests__/components/primerTextInputTheme.test.ts
+++ b/src/__tests__/components/primerTextInputTheme.test.ts
@@ -27,4 +27,11 @@ describe('PrimerTextInput resolveTheme', () => {
     expect(r.errorFontFamily).toBe('Menlo');
     expect(r.errorFontSize).toBe(9);
   });
+
+  it('gives error and focus their own widths, both clamped to at least the resting width', () => {
+    const r = resolveTheme(defaultLightTokens, { borderWidth: 5 });
+
+    expect(r.errorBorderWidth).toBe(5);
+    expect(r.focusedBorderWidth).toBe(5);
+  });
 });


### PR DESCRIPTION
[ORC-8178](https://primerapi.atlassian.net/browse/ORC-8178)

An errored field drew at the focus width. Error, focus and resting each have their own width token now, and the remaining hairline borders move onto the default width.

`errorBorderWidth` is clamped to at least the resting width, same as the focus one. Otherwise a merchant setting a thinner error border would get a border that gets *thinner* when something goes wrong.



[ORC-8178]: https://primerapi.atlassian.net/browse/ORC-8178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ