### PR TITLE
fix(components): let the card network chips inherit the field (ORC-8267)

### DIFF
--- a/src/Components/PrimerVaultedPaymentMethod.tsx
+++ b/src/Components/PrimerVaultedPaymentMethod.tsx
@@ -217,7 +217,7 @@ function createStyles(tokens: PrimerTokens) {
       backgroundColor: colors.backgroundPrimary,
       borderColor: colors.brand,
       borderRadius: radii.medium,
-      borderWidth: widths.focus,
+      borderWidth: widths.selected,
       gap: spacing.medium,
       padding: spacing.medium,
     },

--- a/src/Components/inputs/CountrySelectorRow.tsx
+++ b/src/Components/inputs/CountrySelectorRow.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, Text, TouchableOpacity, View, type StyleProp, type ViewStyl
 import { usePrimerTheme } from '../internal/theme';
 import type { PrimerTokens } from '../internal/theme';
 import { flagEmoji } from '../internal/flags';
-import { FIELD_HEIGHT, LINE_HEIGHT_RATIO } from './dimensions';
+import { LINE_HEIGHT_RATIO } from './dimensions';
 
 export interface CountrySelectorRowProps {
   /** ISO country code currently selected, or empty if none. */
@@ -76,13 +76,13 @@ export function CountrySelectorRow({
 }
 
 function createStyles(tokens: PrimerTokens) {
-  const { colors, radii, spacing, typography, widths } = tokens;
+  const { colors, radii, sizes, spacing, typography, widths } = tokens;
   /* eslint-disable react-native/no-unused-styles */
   return StyleSheet.create({
     chevron: {
       color: tokens.colors.textSecondary,
       fontSize: typography.bodyLarge.fontSize + 4,
-      lineHeight: FIELD_HEIGHT,
+      lineHeight: sizes.xxlarge,
       marginLeft: spacing.small,
     },
     container: {},
@@ -107,7 +107,7 @@ function createStyles(tokens: PrimerTokens) {
       borderRadius: radii.small,
       borderWidth: widths.default,
       flexDirection: 'row',
-      height: FIELD_HEIGHT,
+      height: sizes.xxlarge,
       paddingHorizontal: spacing.medium,
     },
     rowDisabled: {

--- a/src/Components/inputs/CountrySelectorRow.tsx
+++ b/src/Components/inputs/CountrySelectorRow.tsx
@@ -102,7 +102,7 @@ function createStyles(tokens: PrimerTokens) {
     },
     row: {
       alignItems: 'center',
-      backgroundColor: colors.backgroundPrimary,
+      backgroundColor: colors.backgroundOutlinedDefault,
       borderColor: colors.borderOutlinedDefault,
       borderRadius: radii.small,
       borderWidth: widths.default,
@@ -115,7 +115,7 @@ function createStyles(tokens: PrimerTokens) {
       borderColor: colors.borderOutlinedDisabled,
     },
     value: {
-      color: colors.textPrimary,
+      color: colors.textOutlinedDefault,
       flex: 1,
       fontFamily: typography.fontFamily,
       fontSize: typography.bodyLarge.fontSize,

--- a/src/Components/inputs/PrimerTextInput.tsx
+++ b/src/Components/inputs/PrimerTextInput.tsx
@@ -9,7 +9,8 @@ import type { PrimerTokens } from '../internal/theme/types';
 // Suppresses iOS's auto-added Previous/Next/Done navigation toolbar above the keyboard.
 export const PRIMER_EMPTY_ACCESSORY_ID = 'primer-empty-input-accessory';
 
-function resolveTheme(tokens: PrimerTokens, override?: PrimerTextInputTheme) {
+// Exported for tests: the override chain is easy to break silently.
+export function resolveTheme(tokens: PrimerTokens, override?: PrimerTextInputTheme) {
   const borderWidth = override?.borderWidth ?? tokens.widths.default;
   const focusedBorderWidth = Math.max(override?.focusedBorderWidth ?? tokens.widths.focus, borderWidth);
   return {
@@ -21,6 +22,10 @@ function resolveTheme(tokens: PrimerTokens, override?: PrimerTextInputTheme) {
     disabledBorderColor: override?.disabledBorderColor ?? tokens.colors.borderOutlinedDisabled,
     errorColor: override?.errorColor ?? tokens.colors.borderOutlinedError,
     errorTextColor: override?.errorTextColor ?? tokens.colors.textNegative,
+    // `fontFamily`/`labelFontSize` stay in the chain: they styled the error text before the
+    // error token existed, so a merchant already setting them keeps working.
+    errorFontFamily: override?.errorFontFamily ?? override?.fontFamily ?? tokens.typography.error.fontFamily,
+    errorFontSize: override?.errorFontSize ?? override?.labelFontSize ?? tokens.typography.error.fontSize,
     fieldHeight: override?.fieldHeight ?? tokens.sizes.xxlarge,
     focusedBorderWidth,
     fontFamily: override?.fontFamily ?? tokens.typography.fontFamily,
@@ -112,8 +117,8 @@ export const PrimerTextInput = forwardRef<PrimerTextInputRef, PrimerTextInputPro
         container: {},
         error: {
           color: resolved.errorTextColor,
-          fontFamily: resolved.fontFamily,
-          fontSize: resolved.labelFontSize,
+          fontFamily: resolved.errorFontFamily,
+          fontSize: resolved.errorFontSize,
           marginTop: tokens.spacing.xsmall,
         },
         input: {

--- a/src/Components/inputs/PrimerTextInput.tsx
+++ b/src/Components/inputs/PrimerTextInput.tsx
@@ -14,7 +14,7 @@ export function resolveTheme(tokens: PrimerTokens, override?: PrimerTextInputThe
   const borderWidth = override?.borderWidth ?? tokens.widths.default;
   const focusedBorderWidth = Math.max(override?.focusedBorderWidth ?? tokens.widths.focus, borderWidth);
   return {
-    backgroundColor: override?.backgroundColor ?? tokens.colors.backgroundPrimary,
+    backgroundColor: override?.backgroundColor ?? tokens.colors.backgroundOutlinedDefault,
     borderColor: override?.borderColor ?? tokens.colors.borderOutlinedDefault,
     borderRadius: override?.borderRadius ?? tokens.radii.small,
     borderWidth,
@@ -34,7 +34,7 @@ export function resolveTheme(tokens: PrimerTokens, override?: PrimerTextInputThe
     labelFontSize: override?.labelFontSize ?? tokens.typography.bodySmall.fontSize,
     placeholderColor: override?.placeholderColor ?? tokens.colors.textPlaceholder,
     primaryColor: override?.primaryColor ?? tokens.colors.borderOutlinedFocus,
-    textColor: override?.textColor ?? tokens.colors.textPrimary,
+    textColor: override?.textColor ?? tokens.colors.textOutlinedDefault,
   };
 }
 

--- a/src/Components/inputs/PrimerTextInput.tsx
+++ b/src/Components/inputs/PrimerTextInput.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, useImperativeHandle, useMemo, useRef, useState, type ComponentRef } from 'react';
 import { Platform, StyleSheet, Text, TextInput, View, type TextStyle } from 'react-native';
 import { usePrimerTheme } from '../internal/theme';
-import { FIELD_HEIGHT, LINE_HEIGHT_RATIO } from './dimensions';
+import { LINE_HEIGHT_RATIO } from './dimensions';
 import type { PrimerTextInputProps, PrimerTextInputRef, PrimerTextInputTheme } from '../types/CardInputTypes';
 import type { PrimerTokens } from '../internal/theme/types';
 
@@ -21,7 +21,7 @@ function resolveTheme(tokens: PrimerTokens, override?: PrimerTextInputTheme) {
     disabledBorderColor: override?.disabledBorderColor ?? tokens.colors.borderOutlinedDisabled,
     errorColor: override?.errorColor ?? tokens.colors.borderOutlinedError,
     errorTextColor: override?.errorTextColor ?? tokens.colors.textNegative,
-    fieldHeight: override?.fieldHeight ?? FIELD_HEIGHT,
+    fieldHeight: override?.fieldHeight ?? tokens.sizes.xxlarge,
     focusedBorderWidth,
     fontFamily: override?.fontFamily ?? tokens.typography.fontFamily,
     fontSize: override?.fontSize ?? tokens.typography.bodyLarge.fontSize,

--- a/src/Components/inputs/PrimerTextInput.tsx
+++ b/src/Components/inputs/PrimerTextInput.tsx
@@ -13,6 +13,7 @@ export const PRIMER_EMPTY_ACCESSORY_ID = 'primer-empty-input-accessory';
 export function resolveTheme(tokens: PrimerTokens, override?: PrimerTextInputTheme) {
   const borderWidth = override?.borderWidth ?? tokens.widths.default;
   const focusedBorderWidth = Math.max(override?.focusedBorderWidth ?? tokens.widths.focus, borderWidth);
+  const errorBorderWidth = Math.max(override?.errorBorderWidth ?? tokens.widths.error, borderWidth);
   return {
     backgroundColor: override?.backgroundColor ?? tokens.colors.backgroundOutlinedDefault,
     borderColor: override?.borderColor ?? tokens.colors.borderOutlinedDefault,
@@ -27,6 +28,7 @@ export function resolveTheme(tokens: PrimerTokens, override?: PrimerTextInputThe
     errorFontFamily: override?.errorFontFamily ?? override?.fontFamily ?? tokens.typography.error.fontFamily,
     errorFontSize: override?.errorFontSize ?? override?.labelFontSize ?? tokens.typography.error.fontSize,
     fieldHeight: override?.fieldHeight ?? tokens.sizes.xxlarge,
+    errorBorderWidth,
     focusedBorderWidth,
     fontFamily: override?.fontFamily ?? tokens.typography.fontFamily,
     fontSize: override?.fontSize ?? tokens.typography.bodyLarge.fontSize,
@@ -98,7 +100,12 @@ export const PrimerTextInput = forwardRef<PrimerTextInputRef, PrimerTextInputPro
   );
 
   const hasError = !!error;
-  const currentBorderWidth = isFocused || hasError ? resolved.focusedBorderWidth : resolved.borderWidth;
+  // Error beats focus beats resting.
+  const currentBorderWidth = useMemo(() => {
+    if (hasError) return resolved.errorBorderWidth;
+    if (isFocused) return resolved.focusedBorderWidth;
+    return resolved.borderWidth;
+  }, [hasError, isFocused, resolved]);
   const borderWidthDiff = currentBorderWidth - resolved.borderWidth;
 
   // Error takes precedence over focus — the validation signal is more important than the

--- a/src/Components/inputs/dimensions.ts
+++ b/src/Components/inputs/dimensions.ts
@@ -1,8 +1,6 @@
-// Card-input dimension constants. Sourced from Figma and not theme-driven
-// because the token system has no slot for icon size / field height. Keep all
-// design-spec numerics in this one file so any future spec change is local.
+// Card-input dimension constants sourced from Figma. Field height comes from the
+// size tokens now; the icon sizes below have no token slot yet.
 
-export const FIELD_HEIGHT = 44;
 export const LINE_HEIGHT_RATIO = 1.25;
 
 // Trailing glyph inside the input (expiry calendar, CVV hint). Square, 20×20,

--- a/src/Components/internal/CardNetworkBadge.tsx
+++ b/src/Components/internal/CardNetworkBadge.tsx
@@ -63,11 +63,7 @@ export function CardNetworkBadge({ identifier, testID, marginLeft }: CardNetwork
     return (
       <Image
         source={{ uri }}
-        style={[
-          styles.chipImage,
-          baseStyle,
-          { backgroundColor: tokens.colors.backgroundSecondary, borderRadius: tokens.radii.xsmall },
-        ]}
+        style={[styles.chipImage, baseStyle, { borderRadius: tokens.radii.xsmall }]}
         resizeMode="contain"
         testID={testID}
       />
@@ -81,7 +77,6 @@ export function CardNetworkBadge({ identifier, testID, marginLeft }: CardNetwork
           styles.chip,
           baseStyle,
           {
-            backgroundColor: tokens.colors.backgroundSecondary,
             borderColor: tokens.colors.borderOutlinedDefault,
             borderRadius: tokens.radii.xsmall,
             borderWidth: tokens.widths.default,

--- a/src/Components/internal/Popover.tsx
+++ b/src/Components/internal/Popover.tsx
@@ -46,6 +46,7 @@ export function Popover({ visible, onDismiss, children, anchor, testID }: Popove
       backgroundColor: tokens.colors.backgroundPrimary,
       borderColor: tokens.colors.borderOutlinedDefault,
       borderRadius: tokens.radii.medium,
+      borderWidth: tokens.widths.default,
     },
   ];
 
@@ -76,7 +77,6 @@ export function Popover({ visible, onDismiss, children, anchor, testID }: Popove
 
 const styles = StyleSheet.create({
   card: {
-    borderWidth: StyleSheet.hairlineWidth,
     overflow: 'hidden',
     width: '100%',
   },

--- a/src/Components/internal/screens/KlarnaScreen.tsx
+++ b/src/Components/internal/screens/KlarnaScreen.tsx
@@ -161,7 +161,7 @@ export function KlarnaScreen() {
 }
 
 function createStyles(tokens: PrimerTokens) {
-  const { colors, radii, spacing, typography } = tokens;
+  const { colors, radii, spacing, typography, widths } = tokens;
   /* eslint-disable react-native/no-unused-styles */
   return StyleSheet.create({
     categoryName: {
@@ -176,7 +176,7 @@ function createStyles(tokens: PrimerTokens) {
       alignItems: 'center',
       borderColor: colors.borderOutlinedDefault,
       borderRadius: radii.medium,
-      borderWidth: StyleSheet.hairlineWidth,
+      borderWidth: widths.default,
       flexDirection: 'row',
       gap: spacing.medium,
       minHeight: 56,
@@ -184,7 +184,7 @@ function createStyles(tokens: PrimerTokens) {
     },
     categoryRowSelected: {
       borderColor: colors.brand,
-      borderWidth: 2,
+      borderWidth: widths.selected,
     },
     description: {
       color: colors.textSecondary,

--- a/src/Components/internal/screens/MethodSelectionScreen.tsx
+++ b/src/Components/internal/screens/MethodSelectionScreen.tsx
@@ -31,9 +31,6 @@ const LOG = '[MethodSelectionScreen]';
 // Outer grey padding + tile padding are added into sheetHeight separately below.
 const VAULT_TILE_CONTENT_HEIGHT = 44;
 
-// Matches `FIELD_HEIGHT` in `Components/inputs/dimensions.ts`.
-const VAULT_TILE_CVV_ROW_HEIGHT = 44;
-
 const CHEVRON_ICON_SIZE = 20;
 const chevronDownIcon = require('./assets/chevron-down.png');
 
@@ -75,7 +72,8 @@ export function MethodSelectionScreen() {
   //   (+ inner-tile gap + CVV row, when CVV state is open)
   //   + tile-to-button gap + Pay button (CheckoutButton: padding.medium*2 + titleLarge lineHeight)
   //   + section-to-APM gap.
-  const cvvExtraHeight = cvvInputVisible ? tokens.spacing.medium + VAULT_TILE_CVV_ROW_HEIGHT : 0;
+  // CVV row height is the height of the input field it wraps.
+  const cvvExtraHeight = cvvInputVisible ? tokens.spacing.medium + tokens.sizes.xxlarge : 0;
   const vaultSectionHeight =
     activeVaultedMethod != null
       ? titleArea +

--- a/src/Components/internal/screens/VaultedMethodsScreen.tsx
+++ b/src/Components/internal/screens/VaultedMethodsScreen.tsx
@@ -397,6 +397,7 @@ function createStyles(tokens: PrimerTokens) {
     },
     headerIcon: {
       height: HEADER_ICON_SIZE,
+      tintColor: colors.iconPrimary,
       width: HEADER_ICON_SIZE,
     },
     listContent: {
@@ -433,6 +434,7 @@ function createRowStyles(tokens: PrimerTokens, isActive: boolean) {
     },
     checkIcon: {
       height: CHECK_ICON_SIZE,
+      tintColor: colors.brand,
       width: CHECK_ICON_SIZE,
     },
     checkIconBox: {
@@ -449,6 +451,7 @@ function createRowStyles(tokens: PrimerTokens, isActive: boolean) {
     },
     deleteIcon: {
       height: DELETE_ICON_SIZE,
+      tintColor: colors.iconPrimary,
       width: DELETE_ICON_SIZE,
     },
     leftCol: {
@@ -499,7 +502,7 @@ function createRowStyles(tokens: PrimerTokens, isActive: boolean) {
       backgroundColor: colors.backgroundPrimary,
       borderColor: isActive ? colors.brand : colors.borderOutlinedDefault,
       borderRadius: radii.medium,
-      borderWidth: isActive ? widths.focus : widths.default,
+      borderWidth: isActive ? widths.selected : widths.default,
       padding: innerPadding,
     },
     tileFull: {

--- a/src/Components/internal/theme/tokens/dark.ts
+++ b/src/Components/internal/theme/tokens/dark.ts
@@ -108,6 +108,13 @@ export const defaultDarkTokens: PrimerTokens = {
       lineHeight: 16,
       letterSpacing: 0,
     },
+    error: {
+      fontFamily: 'Inter', // primerTypographyErrorFont
+      fontSize: 12, // primerTypographyErrorSize
+      fontWeight: '400', // primerTypographyErrorWeight
+      lineHeight: 16, // primerTypographyErrorLineHeight
+      letterSpacing: 0, // primerTypographyErrorLetterSpacing
+    },
   },
   radii: {
     none: 0,

--- a/src/Components/internal/theme/tokens/light.ts
+++ b/src/Components/internal/theme/tokens/light.ts
@@ -107,6 +107,13 @@ export const defaultLightTokens: PrimerTokens = {
       lineHeight: 16, // primerTypographyBodySmallLineHeight
       letterSpacing: 0, // primerTypographyBodySmallLetterSpacing
     },
+    error: {
+      fontFamily: 'Inter', // primerTypographyErrorFont
+      fontSize: 12, // primerTypographyErrorSize
+      fontWeight: '400', // primerTypographyErrorWeight
+      lineHeight: 16, // primerTypographyErrorLineHeight
+      letterSpacing: 0, // primerTypographyErrorLetterSpacing
+    },
   },
   radii: {
     none: 0,

--- a/src/Components/internal/theme/types.ts
+++ b/src/Components/internal/theme/types.ts
@@ -92,6 +92,7 @@ export interface PrimerTypographyTokens {
   bodyLarge: PrimerTypographyStyle;
   bodyMedium: PrimerTypographyStyle;
   bodySmall: PrimerTypographyStyle;
+  error: PrimerTypographyStyle;
 }
 
 export interface PrimerRadiusTokens {

--- a/src/Components/internal/ui/CheckoutButton.tsx
+++ b/src/Components/internal/ui/CheckoutButton.tsx
@@ -28,7 +28,7 @@ export function CheckoutButton({
 
   const buttonStyle = variant === 'primary' ? styles.primaryButton : styles.outlinedButton;
   const textStyle = variant === 'primary' ? styles.primaryText : styles.outlinedText;
-  const spinnerColor = variant === 'primary' ? tokens.colors.backgroundPrimary : tokens.colors.textPrimary;
+  const spinnerColor = variant === 'primary' ? tokens.colors.onBrand : tokens.colors.textPrimary;
   const isInteractive = !disabled && !loading;
   const showDisabledTint = disabled && !loading;
 
@@ -92,7 +92,7 @@ function createStyles(tokens: PrimerTokens) {
     },
     primaryText: {
       ...baseText,
-      color: colors.backgroundPrimary,
+      color: colors.onBrand,
     },
   });
   /* eslint-enable react-native/no-unused-styles */

--- a/src/Components/internal/ui/CheckoutButton.tsx
+++ b/src/Components/internal/ui/CheckoutButton.tsx
@@ -26,15 +26,24 @@ export function CheckoutButton({
   const tokens = usePrimerTheme();
   const styles = useMemo(() => createStyles(tokens), [tokens]);
 
-  const buttonStyle = variant === 'primary' ? styles.primaryButton : styles.outlinedButton;
-  const textStyle = variant === 'primary' ? styles.primaryText : styles.outlinedText;
-  const spinnerColor = variant === 'primary' ? tokens.colors.onBrand : tokens.colors.textPrimary;
   const isInteractive = !disabled && !loading;
   const showDisabledTint = disabled && !loading;
+  const isPrimary = variant === 'primary';
+  // Button and text always move together, so resolve them as a pair.
+  const { button: buttonStyle, text: textStyle } = useMemo(() => {
+    if (!isPrimary) {
+      return { button: styles.outlinedButton, text: styles.outlinedText };
+    }
+    if (showDisabledTint) {
+      return { button: styles.primaryButtonDisabled, text: styles.primaryTextDisabled };
+    }
+    return { button: styles.primaryButton, text: styles.primaryText };
+  }, [isPrimary, showDisabledTint, styles]);
+  const spinnerColor = isPrimary ? tokens.colors.onBrand : tokens.colors.textPrimary;
 
   return (
     <TouchableOpacity
-      style={[buttonStyle, showDisabledTint ? styles.dimmed : styles.opaque]}
+      style={[buttonStyle, !isPrimary && showDisabledTint ? styles.dimmed : styles.opaque]}
       onPress={onPress}
       disabled={!isInteractive}
       activeOpacity={0.7}
@@ -90,9 +99,17 @@ function createStyles(tokens: PrimerTokens) {
       ...baseButton,
       backgroundColor: colors.brand,
     },
+    primaryButtonDisabled: {
+      ...baseButton,
+      backgroundColor: colors.backgroundOutlinedDisabled,
+    },
     primaryText: {
       ...baseText,
       color: colors.onBrand,
+    },
+    primaryTextDisabled: {
+      ...baseText,
+      color: colors.textDisabled,
     },
   });
   /* eslint-enable react-native/no-unused-styles */

--- a/src/Components/internal/ui/PaymentMethodButton.tsx
+++ b/src/Components/internal/ui/PaymentMethodButton.tsx
@@ -9,6 +9,9 @@ import type { PaymentMethodButtonProps } from '../../types/PrimerPaymentMethodLi
 
 export const PAYMENT_METHOD_BUTTON_HEIGHT = 44;
 const BUTTON_HEIGHT = PAYMENT_METHOD_BUTTON_HEIGHT;
+// the surcharge badge sits on the payment method's own brand colour, which merchant theming
+// doesn't control, so it stays a fixed light value
+const ON_BRAND_SURFACE_TEXT = '#ffffff';
 
 export function PaymentMethodButton({ item, onPress }: PaymentMethodButtonProps) {
   const tokens = usePrimerTheme();
@@ -119,7 +122,7 @@ function createStyles(tokens: PrimerTokens) {
       right: spacing.small,
     },
     surchargeLight: {
-      color: colors.backgroundPrimary,
+      color: ON_BRAND_SURFACE_TEXT,
       fontFamily: typography.bodySmall.fontFamily,
       fontSize: typography.bodySmall.fontSize,
       fontWeight: typography.bodySmall.fontWeight as TextStyle['fontWeight'],

--- a/src/Components/types/CardInputTypes.ts
+++ b/src/Components/types/CardInputTypes.ts
@@ -16,6 +16,7 @@ export interface PrimerTextInputTheme {
   errorTextColor?: string;
   borderWidth?: number;
   focusedBorderWidth?: number;
+  errorBorderWidth?: number;
   errorFontFamily?: string;
   errorFontSize?: number;
   borderRadius?: number;

--- a/src/Components/types/CardInputTypes.ts
+++ b/src/Components/types/CardInputTypes.ts
@@ -16,6 +16,8 @@ export interface PrimerTextInputTheme {
   errorTextColor?: string;
   borderWidth?: number;
   focusedBorderWidth?: number;
+  errorFontFamily?: string;
+  errorFontSize?: number;
   borderRadius?: number;
   fontSize?: number;
   labelFontSize?: number;

--- a/src/__tests__/components/primerTextInputTheme.test.ts
+++ b/src/__tests__/components/primerTextInputTheme.test.ts
@@ -27,4 +27,11 @@ describe('PrimerTextInput resolveTheme', () => {
     expect(r.errorFontFamily).toBe('Menlo');
     expect(r.errorFontSize).toBe(9);
   });
+
+  it('gives error and focus their own widths, both clamped to at least the resting width', () => {
+    const r = resolveTheme(defaultLightTokens, { borderWidth: 5 });
+
+    expect(r.errorBorderWidth).toBe(5);
+    expect(r.focusedBorderWidth).toBe(5);
+  });
 });

--- a/src/__tests__/components/primerTextInputTheme.test.ts
+++ b/src/__tests__/components/primerTextInputTheme.test.ts
@@ -1,0 +1,30 @@
+import { resolveTheme } from '../../Components/inputs/PrimerTextInput';
+import { defaultLightTokens } from '../../Components/internal/theme/tokens/light';
+
+describe('PrimerTextInput resolveTheme', () => {
+  it('falls back to the error typography token when nothing is overridden', () => {
+    const r = resolveTheme(defaultLightTokens);
+
+    expect(r.errorFontFamily).toBe(defaultLightTokens.typography.error.fontFamily);
+    expect(r.errorFontSize).toBe(defaultLightTokens.typography.error.fontSize);
+  });
+
+  it('still honours fontFamily and labelFontSize, which styled the error text before the error token existed', () => {
+    const r = resolveTheme(defaultLightTokens, { fontFamily: 'Courier', labelFontSize: 18 });
+
+    expect(r.errorFontFamily).toBe('Courier');
+    expect(r.errorFontSize).toBe(18);
+  });
+
+  it('lets the dedicated error overrides win', () => {
+    const r = resolveTheme(defaultLightTokens, {
+      fontFamily: 'Courier',
+      labelFontSize: 18,
+      errorFontFamily: 'Menlo',
+      errorFontSize: 9,
+    });
+
+    expect(r.errorFontFamily).toBe('Menlo');
+    expect(r.errorFontSize).toBe(9);
+  });
+});

--- a/src/__tests__/components/theme/merge.test.ts
+++ b/src/__tests__/components/theme/merge.test.ts
@@ -67,6 +67,12 @@ describe('mergeTokens', () => {
     expect(result.widths.default).toBe(base.widths.default);
   });
 
+  it('keeps the error text style separate from the body-small label', () => {
+    const result = mergeTokens(base, { typography: { error: { ...base.typography.error, fontSize: 20 } } });
+    expect(result.typography.error.fontSize).toBe(20);
+    expect(result.typography.bodySmall.fontSize).toBe(base.typography.bodySmall.fontSize);
+  });
+
   it('carries the same colour vocabulary as the other SDKs', () => {
     // 53 shared tokens, plus onBrand and overlay which RN needs and the token files do not carry.
     expect(Object.keys(base.colors)).toHaveLength(55);


### PR DESCRIPTION
[ORC-8267](https://primerapi.atlassian.net/browse/ORC-8267)

The card network chips painted their own fill, so they showed as light rectangles once a merchant coloured the field. They are transparent now and inherit the field, matching Android.


[ORC-8267]: https://primerapi.atlassian.net/browse/ORC-8267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ