### PR TITLE
feat(components): resolve every text style from one brand font (ORC-8268)

### DIFF
--- a/src/Components/internal/theme/index.ts
+++ b/src/Components/internal/theme/index.ts
@@ -5,6 +5,8 @@ export type {
   PrimerSpacingTokens,
   PrimerTypographyTokens,
   PrimerTypographyStyle,
+  PrimerTypographyStyleOverride,
+  PrimerTypographyOverride,
   PrimerRadiusTokens,
   PrimerSizeTokens,
   PrimerWidthTokens,

--- a/src/Components/internal/theme/merge.ts
+++ b/src/Components/internal/theme/merge.ts
@@ -1,4 +1,12 @@
-import type { PrimerTokens, PrimerThemeOverride, PrimerColorTokens } from './types';
+import { resolveTypography, TYPOGRAPHY_STYLES } from './typography';
+import type { PrimerTypographyStyleName, PrimerTypographySource, PrimerTypographyStyleSource } from './typography';
+import type {
+  PrimerTokens,
+  PrimerThemeOverride,
+  PrimerColorTokens,
+  PrimerTypographyOverride,
+  PrimerTypographyTokens,
+} from './types';
 
 type ModeOverride = PrimerThemeOverride['light'];
 
@@ -66,6 +74,23 @@ function mergeColors(base: PrimerColorTokens, override: Partial<PrimerColorToken
   return merged;
 }
 
+function mergeTypography(base: PrimerTypographyTokens, override: PrimerTypographyOverride): PrimerTypographyTokens {
+  const set = stripNullish(override);
+  const fontFamily = set.fontFamily ?? base.fontFamily;
+  const styles = {} as Record<PrimerTypographyStyleName, PrimerTypographyStyleSource>;
+
+  for (const name of TYPOGRAPHY_STYLES) {
+    // A style that was following the brand font keeps following it, so drop its font and re-resolve.
+    const { fontFamily: current, ...metrics } = base[name];
+    const inherited = current === base.fontFamily ? metrics : base[name];
+    // Lay the override on top rather than replacing, so setting one field keeps the rest.
+    styles[name] = { ...inherited, ...stripNullish(set[name] ?? {}) };
+  }
+
+  const source: PrimerTypographySource = { fontFamily, ...styles };
+  return resolveTypography(source);
+}
+
 export function mergeTokens(base: PrimerTokens, override: ModeOverride): PrimerTokens {
   if (override == null) {
     return base;
@@ -74,7 +99,7 @@ export function mergeTokens(base: PrimerTokens, override: ModeOverride): PrimerT
   return {
     colors: override.colors ? mergeColors(base.colors, override.colors) : base.colors,
     spacing: override.spacing ? { ...base.spacing, ...stripNullish(override.spacing) } : base.spacing,
-    typography: override.typography ? { ...base.typography, ...stripNullish(override.typography) } : base.typography,
+    typography: override.typography ? mergeTypography(base.typography, override.typography) : base.typography,
     radii: override.radii ? { ...base.radii, ...stripNullish(override.radii) } : base.radii,
     sizes: override.sizes ? { ...base.sizes, ...stripNullish(override.sizes) } : base.sizes,
     widths: override.widths ? { ...base.widths, ...stripNullish(override.widths) } : base.widths,

--- a/src/Components/internal/theme/tokens/dark.ts
+++ b/src/Components/internal/theme/tokens/dark.ts
@@ -1,3 +1,4 @@
+import { resolveTypography } from '../typography';
 import type { PrimerTokens } from '../types';
 
 // Values derived from iOS dark.json (Style Dictionary generated, dark theme).
@@ -71,51 +72,46 @@ export const defaultDarkTokens: PrimerTokens = {
     xxlarge: 24,
     xxxlarge: 32,
   },
-  typography: {
-    fontFamily: 'Inter', // primerTypographyBrand
+  // Each style's font comes from the brand font above unless it names its own.
+  typography: resolveTypography({
+    fontFamily: 'Inter',
     titleXLarge: {
-      fontFamily: 'Inter', // primerTypographyTitleXlargeFont
       fontSize: 24,
       fontWeight: '600',
       lineHeight: 32,
       letterSpacing: -0.6,
     },
     titleLarge: {
-      fontFamily: 'Inter', // primerTypographyTitleLargeFont
       fontSize: 16,
       fontWeight: '600',
       lineHeight: 20,
       letterSpacing: -0.2,
     },
     bodyLarge: {
-      fontFamily: 'Inter', // primerTypographyBodyLargeFont
       fontSize: 16,
       fontWeight: '400',
       lineHeight: 20,
       letterSpacing: -0.2,
     },
     bodyMedium: {
-      fontFamily: 'Inter', // primerTypographyBodyMediumFont
       fontSize: 14,
       fontWeight: '400',
       lineHeight: 20,
       letterSpacing: 0,
     },
     bodySmall: {
-      fontFamily: 'Inter', // primerTypographyBodySmallFont
       fontSize: 12,
       fontWeight: '400',
       lineHeight: 16,
       letterSpacing: 0,
     },
     error: {
-      fontFamily: 'Inter', // primerTypographyErrorFont
-      fontSize: 12, // primerTypographyErrorSize
-      fontWeight: '400', // primerTypographyErrorWeight
-      lineHeight: 16, // primerTypographyErrorLineHeight
-      letterSpacing: 0, // primerTypographyErrorLetterSpacing
+      fontSize: 12,
+      fontWeight: '400',
+      lineHeight: 16,
+      letterSpacing: 0,
     },
-  },
+  }),
   radii: {
     none: 0,
     xsmall: 2,

--- a/src/Components/internal/theme/tokens/light.ts
+++ b/src/Components/internal/theme/tokens/light.ts
@@ -1,3 +1,4 @@
+import { resolveTypography } from '../typography';
 import type { PrimerTokens } from '../types';
 
 // Values derived from iOS DesignTokens.swift (Style Dictionary generated, light theme).
@@ -70,51 +71,46 @@ export const defaultLightTokens: PrimerTokens = {
     xxlarge: 24, // primerSpaceXxlarge
     xxxlarge: 32, // primerSizeXlarge (scale extension: 8×base)
   },
-  typography: {
+  // Each style's font comes from the brand font above unless it names its own.
+  typography: resolveTypography({
     fontFamily: 'Inter', // primerTypographyBrand
     titleXLarge: {
-      fontFamily: 'Inter', // primerTypographyTitleXlargeFont
       fontSize: 24, // primerTypographyTitleXlargeSize
       fontWeight: '600', // primerTypographyTitleXlargeWeight 550 → nearest RN value
       lineHeight: 32, // primerTypographyTitleXlargeLineHeight
       letterSpacing: -0.6, // primerTypographyTitleXlargeLetterSpacing
     },
     titleLarge: {
-      fontFamily: 'Inter', // primerTypographyTitleLargeFont
       fontSize: 16, // primerTypographyTitleLargeSize
       fontWeight: '600', // primerTypographyTitleLargeWeight 550 → nearest RN value
       lineHeight: 20, // primerTypographyTitleLargeLineHeight
       letterSpacing: -0.2, // primerTypographyTitleLargeLetterSpacing
     },
     bodyLarge: {
-      fontFamily: 'Inter', // primerTypographyBodyLargeFont
       fontSize: 16, // primerTypographyBodyLargeSize
       fontWeight: '400', // primerTypographyBodyLargeWeight
       lineHeight: 20, // primerTypographyBodyLargeLineHeight
       letterSpacing: -0.2, // primerTypographyBodyLargeLetterSpacing
     },
     bodyMedium: {
-      fontFamily: 'Inter', // primerTypographyBodyMediumFont
       fontSize: 14, // primerTypographyBodyMediumSize
       fontWeight: '400', // primerTypographyBodyMediumWeight
       lineHeight: 20, // primerTypographyBodyMediumLineHeight
       letterSpacing: 0, // primerTypographyBodyMediumLetterSpacing
     },
     bodySmall: {
-      fontFamily: 'Inter', // primerTypographyBodySmallFont
       fontSize: 12, // primerTypographyBodySmallSize
       fontWeight: '400', // primerTypographyBodySmallWeight
       lineHeight: 16, // primerTypographyBodySmallLineHeight
       letterSpacing: 0, // primerTypographyBodySmallLetterSpacing
     },
     error: {
-      fontFamily: 'Inter', // primerTypographyErrorFont
       fontSize: 12, // primerTypographyErrorSize
       fontWeight: '400', // primerTypographyErrorWeight
       lineHeight: 16, // primerTypographyErrorLineHeight
       letterSpacing: 0, // primerTypographyErrorLetterSpacing
     },
-  },
+  }),
   radii: {
     none: 0,
     xsmall: 2, // primerRadiusXsmall

--- a/src/Components/internal/theme/types.ts
+++ b/src/Components/internal/theme/types.ts
@@ -85,7 +85,14 @@ export interface PrimerTypographyStyle {
   fontFamily: string;
 }
 
+/**
+ * A style a merchant sets. Every field is optional: set only what you want to change and the rest
+ * keeps its default. Leave `fontFamily` out and the style follows the brand font.
+ */
+export type PrimerTypographyStyleOverride = Partial<PrimerTypographyStyle>;
+
 export interface PrimerTypographyTokens {
+  /** The brand font — the default typeface for all six styles. */
   fontFamily: string;
   titleXLarge: PrimerTypographyStyle;
   titleLarge: PrimerTypographyStyle;
@@ -93,6 +100,17 @@ export interface PrimerTypographyTokens {
   bodyMedium: PrimerTypographyStyle;
   bodySmall: PrimerTypographyStyle;
   error: PrimerTypographyStyle;
+}
+
+export interface PrimerTypographyOverride {
+  /** Set once to change the typeface of every style that does not name its own. */
+  fontFamily?: string;
+  titleXLarge?: PrimerTypographyStyleOverride;
+  titleLarge?: PrimerTypographyStyleOverride;
+  bodyLarge?: PrimerTypographyStyleOverride;
+  bodyMedium?: PrimerTypographyStyleOverride;
+  bodySmall?: PrimerTypographyStyleOverride;
+  error?: PrimerTypographyStyleOverride;
 }
 
 export interface PrimerRadiusTokens {
@@ -123,7 +141,7 @@ export interface PrimerThemeOverride {
   light?: {
     colors?: Partial<PrimerColorTokens>;
     spacing?: Partial<PrimerSpacingTokens>;
-    typography?: Partial<PrimerTypographyTokens>;
+    typography?: PrimerTypographyOverride;
     radii?: Partial<PrimerRadiusTokens>;
     sizes?: Partial<PrimerSizeTokens>;
     widths?: Partial<PrimerWidthTokens>;
@@ -131,7 +149,7 @@ export interface PrimerThemeOverride {
   dark?: {
     colors?: Partial<PrimerColorTokens>;
     spacing?: Partial<PrimerSpacingTokens>;
-    typography?: Partial<PrimerTypographyTokens>;
+    typography?: PrimerTypographyOverride;
     radii?: Partial<PrimerRadiusTokens>;
     sizes?: Partial<PrimerSizeTokens>;
     widths?: Partial<PrimerWidthTokens>;

--- a/src/Components/internal/theme/typography.ts
+++ b/src/Components/internal/theme/typography.ts
@@ -1,0 +1,32 @@
+import type { PrimerTypographyStyle, PrimerTypographyTokens } from './types';
+
+export const TYPOGRAPHY_STYLES = [
+  'titleXLarge',
+  'titleLarge',
+  'bodyLarge',
+  'bodyMedium',
+  'bodySmall',
+  'error',
+] as const;
+
+export type PrimerTypographyStyleName = (typeof TYPOGRAPHY_STYLES)[number];
+
+// What the resolver needs: every metric present, the typeface optional so it can fall back to the
+// brand font. Deliberately stricter than the public override, which lets a merchant set one field.
+export type PrimerTypographyStyleSource = Omit<PrimerTypographyStyle, 'fontFamily'> & { fontFamily?: string };
+
+export type PrimerTypographySource = {
+  fontFamily: string;
+} & Record<PrimerTypographyStyleName, PrimerTypographyStyleSource>;
+
+// The only place a style's typeface is decided: its own font when it names one, the brand font otherwise.
+export function resolveTypography(source: PrimerTypographySource): PrimerTypographyTokens {
+  const styles = {} as Record<PrimerTypographyStyleName, PrimerTypographyStyle>;
+
+  for (const name of TYPOGRAPHY_STYLES) {
+    const style = source[name];
+    styles[name] = { ...style, fontFamily: style.fontFamily ?? source.fontFamily };
+  }
+
+  return { fontFamily: source.fontFamily, ...styles };
+}

--- a/src/__tests__/components/theme/merge.test.ts
+++ b/src/__tests__/components/theme/merge.test.ts
@@ -1,5 +1,5 @@
 import { mergeTokens } from '../../../Components/internal/theme/merge';
-import { defaultLightTokens } from '../../../Components/internal/theme/tokens';
+import { defaultDarkTokens, defaultLightTokens } from '../../../Components/internal/theme/tokens';
 import type { PrimerTypographyStyle } from '../../../Components/internal/theme/types';
 
 const base = defaultLightTokens;
@@ -32,7 +32,7 @@ describe('mergeTokens', () => {
     expect(result.spacing.medium).toBe(base.spacing.medium);
   });
 
-  it('replaces entire typography style when titleXLarge is overridden', () => {
+  it('applies a full typography style override', () => {
     const customStyle: PrimerTypographyStyle = {
       fontSize: 28,
       fontWeight: '700',
@@ -60,7 +60,7 @@ describe('mergeTokens', () => {
     expect(result.spacing.large).toBe(20);
     expect(result.spacing.small).toBe(base.spacing.small);
     expect(result.typography.fontFamily).toBe('Roboto');
-    expect(result.typography.titleXLarge).toEqual(base.typography.titleXLarge);
+    expect(result.typography.titleXLarge).toEqual({ ...base.typography.titleXLarge, fontFamily: 'Roboto' });
     expect(result.radii.medium).toBe(10);
     expect(result.radii.small).toBe(base.radii.small);
     expect(result.widths.focus).toBe(3);
@@ -156,5 +156,83 @@ describe('mergeTokens', () => {
 
     expect(result.colors.textPrimary).toBe(base.colors.textPrimary);
     expect(result.colors.backgroundSecondary).toBe(base.colors.backgroundSecondary);
+  });
+});
+
+describe('brand font', () => {
+  const STYLES = ['titleXLarge', 'titleLarge', 'bodyLarge', 'bodyMedium', 'bodySmall', 'error'] as const;
+
+  const withoutFont = ({ fontSize, fontWeight, lineHeight, letterSpacing }: PrimerTypographyStyle) => ({
+    fontSize,
+    fontWeight,
+    lineHeight,
+    letterSpacing,
+  });
+
+  it('leaves every style on Inter when nothing is set', () => {
+    for (const tokens of [defaultLightTokens, defaultDarkTokens]) {
+      expect(tokens.typography.fontFamily).toBe('Inter');
+      for (const style of STYLES) {
+        expect(tokens.typography[style].fontFamily).toBe('Inter');
+      }
+    }
+
+    expect(mergeTokens(base, { colors: { brand: '#ff0000' } }).typography).toBe(base.typography);
+  });
+
+  it('moves every style the merchant left alone to the brand font', () => {
+    const result = mergeTokens(base, { typography: { fontFamily: 'Roboto' } });
+
+    expect(result.typography.fontFamily).toBe('Roboto');
+    for (const style of STYLES) {
+      expect(result.typography[style]).toEqual({ ...base.typography[style], fontFamily: 'Roboto' });
+    }
+  });
+
+  it("lets a style's own font win over the brand font", () => {
+    const result = mergeTokens(base, {
+      typography: { fontFamily: 'Roboto', error: { ...base.typography.error, fontFamily: 'Menlo' } },
+    });
+
+    expect(result.typography.error.fontFamily).toBe('Menlo');
+    expect(result.typography.bodySmall.fontFamily).toBe('Roboto');
+  });
+
+  it('gives a style set without a font the brand font', () => {
+    const metrics = withoutFont(base.typography.bodyLarge);
+    const result = mergeTokens(base, { typography: { fontFamily: 'Roboto', bodyLarge: { ...metrics, fontSize: 18 } } });
+
+    expect(result.typography.bodyLarge).toEqual({ ...metrics, fontSize: 18, fontFamily: 'Roboto' });
+  });
+
+  it('changes one typography field and leaves the rest alone', () => {
+    const result = mergeTokens(base, { typography: { bodyLarge: { fontSize: 18 } } });
+
+    expect(result.typography.bodyLarge).toEqual({ ...base.typography.bodyLarge, fontSize: 18 });
+    expect(result.typography.bodyMedium).toEqual(base.typography.bodyMedium);
+  });
+
+  it('lets a one-field override still pick up a new brand font', () => {
+    const result = mergeTokens(base, { typography: { fontFamily: 'Roboto', bodyLarge: { fontSize: 18 } } });
+
+    expect(result.typography.bodyLarge.fontSize).toBe(18);
+    expect(result.typography.bodyLarge.fontFamily).toBe('Roboto');
+    expect(result.typography.bodyLarge.lineHeight).toBe(base.typography.bodyLarge.lineHeight);
+  });
+
+  it('keeps a style own font when only a metric is overridden', () => {
+    const withOwnFont = mergeTokens(base, { typography: { bodyLarge: { fontFamily: 'Menlo' } } });
+    const result = mergeTokens(withOwnFont, {
+      typography: { fontFamily: 'Roboto', bodyLarge: { fontSize: 22 } },
+    });
+
+    expect(result.typography.bodyLarge.fontFamily).toBe('Menlo');
+    expect(result.typography.bodyLarge.fontSize).toBe(22);
+  });
+
+  it('gives a style set without a font the default font when the brand font is not set', () => {
+    const result = mergeTokens(base, { typography: { bodyLarge: withoutFont(base.typography.bodyLarge) } });
+
+    expect(result.typography.bodyLarge.fontFamily).toBe('Inter');
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -217,6 +217,8 @@ export type {
   PrimerSpacingTokens,
   PrimerTypographyTokens,
   PrimerTypographyStyle,
+  PrimerTypographyStyleOverride,
+  PrimerTypographyOverride,
   PrimerRadiusTokens,
   PrimerSizeTokens,
   PrimerWidthTokens,


### PR DESCRIPTION
[ORC-8268](https://primerapi.atlassian.net/browse/ORC-8268)

A merchant wanting their own typeface had to set it six times. Setting the brand font now moves every style that hasn't named its own; a style's own font still wins.

`resolveTypography` is the single place a typeface is decided, so the six per-style `fontFamily: 'Inter'` copies are gone. The merge path is subtler than it looks: a style following the brand font has its font dropped and re-resolved, so changing the brand font moves it. Covered by the brand-font tests.



[ORC-8268]: https://primerapi.atlassian.net/browse/ORC-8268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ