### PR TITLE
refactor(components): put the screens on the shared button and input (ORC-8270)

### DIFF
--- a/src/Components/internal/screens/BankSelectionScreen.tsx
+++ b/src/Components/internal/screens/BankSelectionScreen.tsx
@@ -11,6 +11,7 @@ import { CheckoutRoute } from '../navigation/types';
 import { usePrimerLocalization } from '../localization';
 import { useCheckoutFlow } from '../checkout-flow/CheckoutFlowContext';
 import { usePrimerPaymentMethod } from '../../hooks/usePrimerPaymentMethod';
+import { CheckoutButton } from '../ui/CheckoutButton';
 import { useBottomSafeArea } from './useBottomSafeArea';
 
 /**
@@ -100,23 +101,19 @@ export function BankSelectionScreen() {
         </ScrollView>
       )}
       <View style={[styles.footer, { paddingBottom: Math.max(bottomInset, tokens.spacing.large) }]}>
-        <TouchableOpacity
+        <CheckoutButton
+          title={t('primer_common_button_pay')}
           onPress={handleSubmit}
+          variant="primary"
           disabled={!canSubmit}
-          activeOpacity={0.7}
-          style={[styles.payButton, !canSubmit && styles.payButtonDisabled]}
-          accessibilityRole="button"
-          accessibilityState={{ disabled: !canSubmit }}
-        >
-          <Text style={styles.payButtonText}>{t('primer_common_button_pay')}</Text>
-        </TouchableOpacity>
+        />
       </View>
     </View>
   );
 }
 
 function createStyles(tokens: PrimerTokens) {
-  const { colors, radii, spacing, typography } = tokens;
+  const { colors, radii, spacing, typography, widths } = tokens;
   /* eslint-disable react-native/no-unused-styles */
   return StyleSheet.create({
     bankIcon: {
@@ -135,7 +132,7 @@ function createStyles(tokens: PrimerTokens) {
       alignItems: 'center',
       borderColor: colors.borderOutlinedDefault,
       borderRadius: radii.medium,
-      borderWidth: StyleSheet.hairlineWidth,
+      borderWidth: widths.default,
       flexDirection: 'row',
       gap: spacing.medium,
       minHeight: 56,
@@ -146,7 +143,7 @@ function createStyles(tokens: PrimerTokens) {
     },
     bankRowSelected: {
       borderColor: colors.brand,
-      borderWidth: 2,
+      borderWidth: widths.selected,
     },
     footer: {
       backgroundColor: colors.backgroundPrimary,
@@ -157,27 +154,6 @@ function createStyles(tokens: PrimerTokens) {
       alignItems: 'center',
       flex: 1,
       justifyContent: 'center',
-    },
-    payButton: {
-      alignItems: 'center',
-      backgroundColor: colors.brand,
-      borderRadius: radii.medium,
-      justifyContent: 'center',
-      minHeight: 44,
-      padding: spacing.medium,
-      width: '100%',
-    },
-    payButtonDisabled: {
-      opacity: 0.5,
-    },
-    payButtonText: {
-      color: colors.backgroundPrimary,
-      fontFamily: typography.titleLarge.fontFamily,
-      fontSize: typography.titleLarge.fontSize,
-      fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],
-      letterSpacing: typography.titleLarge.letterSpacing,
-      lineHeight: typography.titleLarge.lineHeight,
-      textAlign: 'center',
     },
     root: {
       flex: 1,

--- a/src/Components/internal/screens/CardFormScreen.tsx
+++ b/src/Components/internal/screens/CardFormScreen.tsx
@@ -1,14 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  ActivityIndicator,
-  Platform,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-  useWindowDimensions,
-} from 'react-native';
+import { Platform, ScrollView, StyleSheet, Text, View, useWindowDimensions } from 'react-native';
 import type { TextStyle } from 'react-native';
 import { usePrimerTheme } from '../theme';
 import type { PrimerTokens } from '../theme';
@@ -21,6 +12,7 @@ import { PrimerCardForm } from '../../PrimerCardForm';
 import { PrimerBillingAddressForm } from '../../PrimerBillingAddressForm';
 import { usePrimerCardForm } from '../../hooks/usePrimerCardForm';
 import { usePrimerBillingAddressForm } from '../../hooks/usePrimerBillingAddressForm';
+import { CheckoutButton } from '../ui/CheckoutButton';
 import { useSheetHeight } from '../checkout-sheet';
 import { useBottomSafeArea } from './useBottomSafeArea';
 import { useKeyboardPadding } from './useKeyboardPadding';
@@ -128,13 +120,12 @@ export function CardFormScreen() {
           },
         ]}
       >
-        <TouchableOpacity
+        <CheckoutButton
+          title={t('primer_common_button_pay')}
           onPress={handlePay}
+          variant="primary"
+          loading={cardForm.isSubmitting}
           disabled={!canSubmit}
-          activeOpacity={0.7}
-          style={[styles.payButton, canSubmit ? styles.payButtonEnabled : styles.payButtonDisabled]}
-          accessibilityRole="button"
-          accessibilityState={{ disabled: !canSubmit, busy: cardForm.isSubmitting }}
           accessibilityLabel={t('accessibility_card_form_submit_label')}
           accessibilityHint={
             cardForm.isSubmitting
@@ -144,20 +135,14 @@ export function CardFormScreen() {
                 : t('accessibility_card_form_submit_disabled')
           }
           testID="primer-card-form-submit"
-        >
-          {cardForm.isSubmitting ? (
-            <ActivityIndicator color={tokens.colors.backgroundPrimary} />
-          ) : (
-            <Text style={styles.payButtonText}>{t('primer_common_button_pay')}</Text>
-          )}
-        </TouchableOpacity>
+        />
       </View>
     </View>
   );
 }
 
 function createStyles(tokens: PrimerTokens) {
-  const { colors, radii, spacing, typography } = tokens;
+  const { colors, spacing, typography } = tokens;
   /* eslint-disable react-native/no-unused-styles */
   return StyleSheet.create({
     divider: {
@@ -176,30 +161,6 @@ function createStyles(tokens: PrimerTokens) {
       left: 0,
       position: 'absolute',
       right: 0,
-    },
-    payButton: {
-      alignItems: 'center',
-      backgroundColor: colors.brand,
-      borderRadius: radii.medium,
-      justifyContent: 'center',
-      minHeight: 44,
-      padding: spacing.medium,
-      width: '100%',
-    },
-    payButtonDisabled: {
-      opacity: 0.5,
-    },
-    payButtonEnabled: {
-      opacity: 1,
-    },
-    payButtonText: {
-      color: colors.backgroundPrimary,
-      fontFamily: typography.titleLarge.fontFamily,
-      fontSize: typography.titleLarge.fontSize,
-      fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],
-      letterSpacing: typography.titleLarge.letterSpacing,
-      lineHeight: typography.titleLarge.lineHeight,
-      textAlign: 'center',
     },
     root: {
       flex: 1,

--- a/src/Components/internal/screens/RawDataFormScreen.tsx
+++ b/src/Components/internal/screens/RawDataFormScreen.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
-import type { TextStyle } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
 
 import { usePrimerTheme } from '../theme';
 import type { PrimerTokens } from '../theme';
@@ -11,6 +10,8 @@ import { CheckoutRoute } from '../navigation/types';
 import { usePrimerLocalization } from '../localization';
 import { useCheckoutFlow } from '../checkout-flow/CheckoutFlowContext';
 import { usePrimerPaymentMethod } from '../../hooks/usePrimerPaymentMethod';
+import { PrimerTextInput } from '../../inputs/PrimerTextInput';
+import { CheckoutButton } from '../ui/CheckoutButton';
 import { useBottomSafeArea } from './useBottomSafeArea';
 import { buildRawData } from './buildRawData';
 
@@ -89,88 +90,42 @@ export function RawDataFormScreen() {
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        {requiredInputs.map((field) => (
-          <View key={field} style={styles.field}>
-            <Text style={styles.label}>{FIELD_LABEL[field] ?? field}</Text>
-            <TextInput
-              style={styles.input}
+        {requiredInputs.map((field) => {
+          const label = FIELD_LABEL[field] ?? field;
+          return (
+            <PrimerTextInput
+              key={field}
+              label={label}
               value={values[field] ?? ''}
               onChangeText={(text) => handleChange(field, text)}
               keyboardType={
                 field === 'PHONE_NUMBER' ? 'phone-pad' : NUMERIC_FIELDS.has(field) ? 'number-pad' : 'default'
               }
               autoCapitalize="none"
-              accessibilityLabel={FIELD_LABEL[field] ?? field}
             />
-          </View>
-        ))}
+          );
+        })}
       </ScrollView>
       <View style={[styles.footer, { paddingBottom: Math.max(bottomInset, tokens.spacing.large) }]}>
-        <TouchableOpacity
+        <CheckoutButton
+          title={t('primer_common_button_pay')}
           onPress={handleSubmit}
+          variant="primary"
           disabled={!isValid}
-          activeOpacity={0.7}
-          style={[styles.payButton, !isValid && styles.payButtonDisabled]}
-          accessibilityRole="button"
-          accessibilityState={{ disabled: !isValid }}
-        >
-          <Text style={styles.payButtonText}>{t('primer_common_button_pay')}</Text>
-        </TouchableOpacity>
+        />
       </View>
     </View>
   );
 }
 
 function createStyles(tokens: PrimerTokens) {
-  const { colors, radii, spacing, typography } = tokens;
+  const { colors, spacing } = tokens;
   /* eslint-disable react-native/no-unused-styles */
   return StyleSheet.create({
-    field: {
-      gap: spacing.xsmall,
-    },
     footer: {
       backgroundColor: colors.backgroundPrimary,
       paddingHorizontal: spacing.large,
       paddingTop: spacing.small,
-    },
-    input: {
-      borderColor: colors.borderOutlinedDefault,
-      borderRadius: radii.medium,
-      borderWidth: StyleSheet.hairlineWidth,
-      color: colors.textPrimary,
-      fontSize: typography.titleLarge.fontSize,
-      minHeight: 48,
-      paddingHorizontal: spacing.medium,
-      paddingVertical: spacing.small,
-    },
-    label: {
-      color: colors.textPrimary,
-      fontFamily: typography.titleLarge.fontFamily,
-      fontSize: typography.titleLarge.fontSize,
-      fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],
-      letterSpacing: typography.titleLarge.letterSpacing,
-      lineHeight: typography.titleLarge.lineHeight,
-    },
-    payButton: {
-      alignItems: 'center',
-      backgroundColor: colors.brand,
-      borderRadius: radii.medium,
-      justifyContent: 'center',
-      minHeight: 44,
-      padding: spacing.medium,
-      width: '100%',
-    },
-    payButtonDisabled: {
-      opacity: 0.5,
-    },
-    payButtonText: {
-      color: colors.backgroundPrimary,
-      fontFamily: typography.titleLarge.fontFamily,
-      fontSize: typography.titleLarge.fontSize,
-      fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],
-      letterSpacing: typography.titleLarge.letterSpacing,
-      lineHeight: typography.titleLarge.lineHeight,
-      textAlign: 'center',
     },
     root: {
       flex: 1,

--- a/src/Components/internal/screens/StripeAchMandateScreen.tsx
+++ b/src/Components/internal/screens/StripeAchMandateScreen.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { ActivityIndicator, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import type { TextStyle } from 'react-native';
 
 import { usePrimerTheme } from '../theme';
@@ -8,6 +8,7 @@ import { NavigationHeader } from '../navigation/NavigationHeader';
 import { useNavigation } from '../navigation/useNavigation';
 import { usePrimerLocalization } from '../localization';
 import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
+import { CheckoutButton } from '../ui/CheckoutButton';
 import { useBottomSafeArea } from './useBottomSafeArea';
 
 // Prebuilt ACH mandate screen: accept completes the payment, decline cancels it (→ error screen); no dismiss while mid-flight.
@@ -46,81 +47,29 @@ export function StripeAchMandateScreen() {
         <Text style={styles.mandateText}>{achMandate.text}</Text>
       </ScrollView>
       <View style={[styles.footer, { paddingBottom: Math.max(bottomInset, tokens.spacing.large) }]}>
-        <TouchableOpacity
+        <CheckoutButton
+          title={t('primer_ach_mandate_button_accept')}
           onPress={handleAccept}
-          disabled={answering}
-          activeOpacity={0.7}
-          style={[styles.acceptButton, answering && styles.buttonDisabled]}
-          accessibilityRole="button"
-          accessibilityState={{ disabled: answering, busy: answering }}
+          variant="primary"
+          loading={answering}
           accessibilityHint={t('accessibility_ach_mandate_accept_hint')}
-        >
-          {answering ? (
-            <ActivityIndicator color={tokens.colors.backgroundPrimary} />
-          ) : (
-            <Text style={styles.acceptButtonText}>{t('primer_ach_mandate_button_accept')}</Text>
-          )}
-        </TouchableOpacity>
-        <TouchableOpacity
+        />
+        <CheckoutButton
+          title={t('primer_ach_mandate_button_decline')}
           onPress={handleDecline}
+          variant="outlined"
           disabled={answering}
-          activeOpacity={0.7}
-          style={[styles.declineButton, answering && styles.buttonDisabled]}
-          accessibilityRole="button"
-          accessibilityState={{ disabled: answering }}
           accessibilityHint={t('accessibility_ach_mandate_decline_hint')}
-        >
-          <Text style={styles.declineButtonText}>{t('primer_ach_mandate_button_decline')}</Text>
-        </TouchableOpacity>
+        />
       </View>
     </View>
   );
 }
 
 function createStyles(tokens: PrimerTokens) {
-  const { colors, radii, spacing, typography } = tokens;
+  const { colors, spacing, typography } = tokens;
   /* eslint-disable react-native/no-unused-styles */
   return StyleSheet.create({
-    acceptButton: {
-      alignItems: 'center',
-      backgroundColor: colors.brand,
-      borderRadius: radii.medium,
-      justifyContent: 'center',
-      minHeight: 44,
-      padding: spacing.medium,
-      width: '100%',
-    },
-    acceptButtonText: {
-      color: colors.backgroundPrimary,
-      fontFamily: typography.titleLarge.fontFamily,
-      fontSize: typography.titleLarge.fontSize,
-      fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],
-      letterSpacing: typography.titleLarge.letterSpacing,
-      lineHeight: typography.titleLarge.lineHeight,
-      textAlign: 'center',
-    },
-    buttonDisabled: {
-      opacity: 0.5,
-    },
-    declineButton: {
-      alignItems: 'center',
-      borderColor: colors.borderOutlinedDefault,
-      borderRadius: radii.medium,
-      borderWidth: StyleSheet.hairlineWidth,
-      justifyContent: 'center',
-      minHeight: 44,
-      padding: spacing.medium,
-      width: '100%',
-    },
-    declineButtonText: {
-      color: colors.textPrimary,
-      fontFamily: typography.titleLarge.fontFamily,
-      fontSize: typography.titleLarge.fontSize,
-      fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],
-      letterSpacing: typography.titleLarge.letterSpacing,
-      lineHeight: typography.titleLarge.lineHeight,
-      textAlign: 'center',
-    },
     footer: {
       backgroundColor: colors.backgroundPrimary,
       gap: spacing.small,

--- a/src/Components/internal/screens/StripeAchUserDetailsScreen.tsx
+++ b/src/Components/internal/screens/StripeAchUserDetailsScreen.tsx
@@ -1,14 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import {
-  ActivityIndicator,
-  Platform,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-  useWindowDimensions,
-} from 'react-native';
+import { ActivityIndicator, Platform, ScrollView, StyleSheet, Text, View, useWindowDimensions } from 'react-native';
 import type { TextStyle } from 'react-native';
 
 import { usePrimerTheme } from '../theme';
@@ -22,6 +13,7 @@ import { useCheckoutFlow } from '../checkout-flow/CheckoutFlowContext';
 import { usePrimerCheckout } from '../../hooks/usePrimerCheckout';
 import { usePrimerPaymentMethod } from '../../hooks/usePrimerPaymentMethod';
 import { PrimerTextInput } from '../../inputs';
+import { CheckoutButton } from '../ui/CheckoutButton';
 import { useSheetHeight } from '../checkout-sheet';
 import { useBottomSafeArea } from './useBottomSafeArea';
 import { useKeyboardPadding } from './useKeyboardPadding';
@@ -174,51 +166,23 @@ export function StripeAchUserDetailsScreen() {
         onLayout={(e) => setFooterHeight(e.nativeEvent.layout.height)}
         style={[styles.footer, { paddingBottom: footerPaddingBottom, transform: [{ translateY: -keyboardPadding }] }]}
       >
-        <TouchableOpacity
+        <CheckoutButton
+          title={t('primer_ach_button_continue')}
           onPress={handleContinue}
+          variant="primary"
+          loading={isWaiting}
           disabled={!canSubmit}
-          activeOpacity={0.7}
-          style={[styles.continueButton, !canSubmit && styles.continueButtonDisabled]}
-          accessibilityRole="button"
-          accessibilityState={{ disabled: !canSubmit, busy: isWaiting }}
           accessibilityHint={t('accessibility_ach_continue_hint')}
-        >
-          {isWaiting ? (
-            <ActivityIndicator color={tokens.colors.backgroundPrimary} />
-          ) : (
-            <Text style={styles.continueButtonText}>{t('primer_ach_button_continue')}</Text>
-          )}
-        </TouchableOpacity>
+        />
       </View>
     </View>
   );
 }
 
 function createStyles(tokens: PrimerTokens) {
-  const { colors, radii, spacing, typography } = tokens;
+  const { colors, spacing, typography } = tokens;
   /* eslint-disable react-native/no-unused-styles */
   return StyleSheet.create({
-    continueButton: {
-      alignItems: 'center',
-      backgroundColor: colors.brand,
-      borderRadius: radii.medium,
-      justifyContent: 'center',
-      minHeight: 44,
-      padding: spacing.medium,
-      width: '100%',
-    },
-    continueButtonDisabled: {
-      opacity: 0.5,
-    },
-    continueButtonText: {
-      color: colors.backgroundPrimary,
-      fontFamily: typography.titleLarge.fontFamily,
-      fontSize: typography.titleLarge.fontSize,
-      fontWeight: typography.titleLarge.fontWeight as TextStyle['fontWeight'],
-      letterSpacing: typography.titleLarge.letterSpacing,
-      lineHeight: typography.titleLarge.lineHeight,
-      textAlign: 'center',
-    },
     disclaimer: {
       color: colors.textSecondary,
       fontFamily: typography.bodySmall.fontFamily,

--- a/src/Components/internal/theme/index.ts
+++ b/src/Components/internal/theme/index.ts
@@ -5,6 +5,8 @@ export type {
   PrimerSpacingTokens,
   PrimerTypographyTokens,
   PrimerTypographyStyle,
+  PrimerTypographyStyleOverride,
+  PrimerTypographyOverride,
   PrimerRadiusTokens,
   PrimerSizeTokens,
   PrimerWidthTokens,

--- a/src/Components/internal/theme/merge.ts
+++ b/src/Components/internal/theme/merge.ts
@@ -1,4 +1,12 @@
-import type { PrimerTokens, PrimerThemeOverride, PrimerColorTokens } from './types';
+import { resolveTypography, TYPOGRAPHY_STYLES } from './typography';
+import type { PrimerTypographyStyleName, PrimerTypographySource, PrimerTypographyStyleSource } from './typography';
+import type {
+  PrimerTokens,
+  PrimerThemeOverride,
+  PrimerColorTokens,
+  PrimerTypographyOverride,
+  PrimerTypographyTokens,
+} from './types';
 
 type ModeOverride = PrimerThemeOverride['light'];
 
@@ -66,6 +74,23 @@ function mergeColors(base: PrimerColorTokens, override: Partial<PrimerColorToken
   return merged;
 }
 
+function mergeTypography(base: PrimerTypographyTokens, override: PrimerTypographyOverride): PrimerTypographyTokens {
+  const set = stripNullish(override);
+  const fontFamily = set.fontFamily ?? base.fontFamily;
+  const styles = {} as Record<PrimerTypographyStyleName, PrimerTypographyStyleSource>;
+
+  for (const name of TYPOGRAPHY_STYLES) {
+    // A style that was following the brand font keeps following it, so drop its font and re-resolve.
+    const { fontFamily: current, ...metrics } = base[name];
+    const inherited = current === base.fontFamily ? metrics : base[name];
+    // Lay the override on top rather than replacing, so setting one field keeps the rest.
+    styles[name] = { ...inherited, ...stripNullish(set[name] ?? {}) };
+  }
+
+  const source: PrimerTypographySource = { fontFamily, ...styles };
+  return resolveTypography(source);
+}
+
 export function mergeTokens(base: PrimerTokens, override: ModeOverride): PrimerTokens {
   if (override == null) {
     return base;
@@ -74,7 +99,7 @@ export function mergeTokens(base: PrimerTokens, override: ModeOverride): PrimerT
   return {
     colors: override.colors ? mergeColors(base.colors, override.colors) : base.colors,
     spacing: override.spacing ? { ...base.spacing, ...stripNullish(override.spacing) } : base.spacing,
-    typography: override.typography ? { ...base.typography, ...stripNullish(override.typography) } : base.typography,
+    typography: override.typography ? mergeTypography(base.typography, override.typography) : base.typography,
     radii: override.radii ? { ...base.radii, ...stripNullish(override.radii) } : base.radii,
     sizes: override.sizes ? { ...base.sizes, ...stripNullish(override.sizes) } : base.sizes,
     widths: override.widths ? { ...base.widths, ...stripNullish(override.widths) } : base.widths,

--- a/src/Components/internal/theme/tokens/dark.ts
+++ b/src/Components/internal/theme/tokens/dark.ts
@@ -1,3 +1,4 @@
+import { resolveTypography } from '../typography';
 import type { PrimerTokens } from '../types';
 
 // Values derived from iOS dark.json (Style Dictionary generated, dark theme).
@@ -71,51 +72,46 @@ export const defaultDarkTokens: PrimerTokens = {
     xxlarge: 24,
     xxxlarge: 32,
   },
-  typography: {
-    fontFamily: 'Inter', // primerTypographyBrand
+  // Each style's font comes from the brand font above unless it names its own.
+  typography: resolveTypography({
+    fontFamily: 'Inter',
     titleXLarge: {
-      fontFamily: 'Inter', // primerTypographyTitleXlargeFont
       fontSize: 24,
       fontWeight: '600',
       lineHeight: 32,
       letterSpacing: -0.6,
     },
     titleLarge: {
-      fontFamily: 'Inter', // primerTypographyTitleLargeFont
       fontSize: 16,
       fontWeight: '600',
       lineHeight: 20,
       letterSpacing: -0.2,
     },
     bodyLarge: {
-      fontFamily: 'Inter', // primerTypographyBodyLargeFont
       fontSize: 16,
       fontWeight: '400',
       lineHeight: 20,
       letterSpacing: -0.2,
     },
     bodyMedium: {
-      fontFamily: 'Inter', // primerTypographyBodyMediumFont
       fontSize: 14,
       fontWeight: '400',
       lineHeight: 20,
       letterSpacing: 0,
     },
     bodySmall: {
-      fontFamily: 'Inter', // primerTypographyBodySmallFont
       fontSize: 12,
       fontWeight: '400',
       lineHeight: 16,
       letterSpacing: 0,
     },
     error: {
-      fontFamily: 'Inter', // primerTypographyErrorFont
-      fontSize: 12, // primerTypographyErrorSize
-      fontWeight: '400', // primerTypographyErrorWeight
-      lineHeight: 16, // primerTypographyErrorLineHeight
-      letterSpacing: 0, // primerTypographyErrorLetterSpacing
+      fontSize: 12,
+      fontWeight: '400',
+      lineHeight: 16,
+      letterSpacing: 0,
     },
-  },
+  }),
   radii: {
     none: 0,
     xsmall: 2,

--- a/src/Components/internal/theme/tokens/light.ts
+++ b/src/Components/internal/theme/tokens/light.ts
@@ -1,3 +1,4 @@
+import { resolveTypography } from '../typography';
 import type { PrimerTokens } from '../types';
 
 // Values derived from iOS DesignTokens.swift (Style Dictionary generated, light theme).
@@ -70,51 +71,46 @@ export const defaultLightTokens: PrimerTokens = {
     xxlarge: 24, // primerSpaceXxlarge
     xxxlarge: 32, // primerSizeXlarge (scale extension: 8×base)
   },
-  typography: {
+  // Each style's font comes from the brand font above unless it names its own.
+  typography: resolveTypography({
     fontFamily: 'Inter', // primerTypographyBrand
     titleXLarge: {
-      fontFamily: 'Inter', // primerTypographyTitleXlargeFont
       fontSize: 24, // primerTypographyTitleXlargeSize
       fontWeight: '600', // primerTypographyTitleXlargeWeight 550 → nearest RN value
       lineHeight: 32, // primerTypographyTitleXlargeLineHeight
       letterSpacing: -0.6, // primerTypographyTitleXlargeLetterSpacing
     },
     titleLarge: {
-      fontFamily: 'Inter', // primerTypographyTitleLargeFont
       fontSize: 16, // primerTypographyTitleLargeSize
       fontWeight: '600', // primerTypographyTitleLargeWeight 550 → nearest RN value
       lineHeight: 20, // primerTypographyTitleLargeLineHeight
       letterSpacing: -0.2, // primerTypographyTitleLargeLetterSpacing
     },
     bodyLarge: {
-      fontFamily: 'Inter', // primerTypographyBodyLargeFont
       fontSize: 16, // primerTypographyBodyLargeSize
       fontWeight: '400', // primerTypographyBodyLargeWeight
       lineHeight: 20, // primerTypographyBodyLargeLineHeight
       letterSpacing: -0.2, // primerTypographyBodyLargeLetterSpacing
     },
     bodyMedium: {
-      fontFamily: 'Inter', // primerTypographyBodyMediumFont
       fontSize: 14, // primerTypographyBodyMediumSize
       fontWeight: '400', // primerTypographyBodyMediumWeight
       lineHeight: 20, // primerTypographyBodyMediumLineHeight
       letterSpacing: 0, // primerTypographyBodyMediumLetterSpacing
     },
     bodySmall: {
-      fontFamily: 'Inter', // primerTypographyBodySmallFont
       fontSize: 12, // primerTypographyBodySmallSize
       fontWeight: '400', // primerTypographyBodySmallWeight
       lineHeight: 16, // primerTypographyBodySmallLineHeight
       letterSpacing: 0, // primerTypographyBodySmallLetterSpacing
     },
     error: {
-      fontFamily: 'Inter', // primerTypographyErrorFont
       fontSize: 12, // primerTypographyErrorSize
       fontWeight: '400', // primerTypographyErrorWeight
       lineHeight: 16, // primerTypographyErrorLineHeight
       letterSpacing: 0, // primerTypographyErrorLetterSpacing
     },
-  },
+  }),
   radii: {
     none: 0,
     xsmall: 2, // primerRadiusXsmall

--- a/src/Components/internal/theme/types.ts
+++ b/src/Components/internal/theme/types.ts
@@ -85,7 +85,14 @@ export interface PrimerTypographyStyle {
   fontFamily: string;
 }
 
+/**
+ * A style a merchant sets. Every field is optional: set only what you want to change and the rest
+ * keeps its default. Leave `fontFamily` out and the style follows the brand font.
+ */
+export type PrimerTypographyStyleOverride = Partial<PrimerTypographyStyle>;
+
 export interface PrimerTypographyTokens {
+  /** The brand font — the default typeface for all six styles. */
   fontFamily: string;
   titleXLarge: PrimerTypographyStyle;
   titleLarge: PrimerTypographyStyle;
@@ -93,6 +100,17 @@ export interface PrimerTypographyTokens {
   bodyMedium: PrimerTypographyStyle;
   bodySmall: PrimerTypographyStyle;
   error: PrimerTypographyStyle;
+}
+
+export interface PrimerTypographyOverride {
+  /** Set once to change the typeface of every style that does not name its own. */
+  fontFamily?: string;
+  titleXLarge?: PrimerTypographyStyleOverride;
+  titleLarge?: PrimerTypographyStyleOverride;
+  bodyLarge?: PrimerTypographyStyleOverride;
+  bodyMedium?: PrimerTypographyStyleOverride;
+  bodySmall?: PrimerTypographyStyleOverride;
+  error?: PrimerTypographyStyleOverride;
 }
 
 export interface PrimerRadiusTokens {
@@ -123,7 +141,7 @@ export interface PrimerThemeOverride {
   light?: {
     colors?: Partial<PrimerColorTokens>;
     spacing?: Partial<PrimerSpacingTokens>;
-    typography?: Partial<PrimerTypographyTokens>;
+    typography?: PrimerTypographyOverride;
     radii?: Partial<PrimerRadiusTokens>;
     sizes?: Partial<PrimerSizeTokens>;
     widths?: Partial<PrimerWidthTokens>;
@@ -131,7 +149,7 @@ export interface PrimerThemeOverride {
   dark?: {
     colors?: Partial<PrimerColorTokens>;
     spacing?: Partial<PrimerSpacingTokens>;
-    typography?: Partial<PrimerTypographyTokens>;
+    typography?: PrimerTypographyOverride;
     radii?: Partial<PrimerRadiusTokens>;
     sizes?: Partial<PrimerSizeTokens>;
     widths?: Partial<PrimerWidthTokens>;

--- a/src/Components/internal/theme/typography.ts
+++ b/src/Components/internal/theme/typography.ts
@@ -1,0 +1,32 @@
+import type { PrimerTypographyStyle, PrimerTypographyTokens } from './types';
+
+export const TYPOGRAPHY_STYLES = [
+  'titleXLarge',
+  'titleLarge',
+  'bodyLarge',
+  'bodyMedium',
+  'bodySmall',
+  'error',
+] as const;
+
+export type PrimerTypographyStyleName = (typeof TYPOGRAPHY_STYLES)[number];
+
+// What the resolver needs: every metric present, the typeface optional so it can fall back to the
+// brand font. Deliberately stricter than the public override, which lets a merchant set one field.
+export type PrimerTypographyStyleSource = Omit<PrimerTypographyStyle, 'fontFamily'> & { fontFamily?: string };
+
+export type PrimerTypographySource = {
+  fontFamily: string;
+} & Record<PrimerTypographyStyleName, PrimerTypographyStyleSource>;
+
+// The only place a style's typeface is decided: its own font when it names one, the brand font otherwise.
+export function resolveTypography(source: PrimerTypographySource): PrimerTypographyTokens {
+  const styles = {} as Record<PrimerTypographyStyleName, PrimerTypographyStyle>;
+
+  for (const name of TYPOGRAPHY_STYLES) {
+    const style = source[name];
+    styles[name] = { ...style, fontFamily: style.fontFamily ?? source.fontFamily };
+  }
+
+  return { fontFamily: source.fontFamily, ...styles };
+}

--- a/src/Components/internal/ui/CheckoutButton.tsx
+++ b/src/Components/internal/ui/CheckoutButton.tsx
@@ -12,6 +12,7 @@ export interface CheckoutButtonProps {
   disabled?: boolean;
   accessibilityLabel?: string;
   accessibilityHint?: string;
+  testID?: string;
 }
 
 export function CheckoutButton({
@@ -22,13 +23,14 @@ export function CheckoutButton({
   disabled = false,
   accessibilityLabel,
   accessibilityHint,
-}: CheckoutButtonProps) {
+  testID,
+}: Readonly<CheckoutButtonProps>) {
   const tokens = usePrimerTheme();
   const styles = useMemo(() => createStyles(tokens), [tokens]);
 
+  const isPrimary = variant === 'primary';
   const isInteractive = !disabled && !loading;
   const showDisabledTint = disabled && !loading;
-  const isPrimary = variant === 'primary';
   // Button and text always move together, so resolve them as a pair.
   const { button: buttonStyle, text: textStyle } = useMemo(() => {
     if (!isPrimary) {
@@ -51,6 +53,7 @@ export function CheckoutButton({
       accessibilityLabel={accessibilityLabel}
       accessibilityHint={accessibilityHint}
       accessibilityState={{ disabled: !isInteractive, busy: loading }}
+      testID={testID}
     >
       {loading ? <ActivityIndicator color={spinnerColor} /> : <Text style={textStyle}>{title}</Text>}
     </TouchableOpacity>
@@ -64,6 +67,9 @@ function createStyles(tokens: PrimerTokens) {
     alignItems: 'center' as const,
     borderRadius: radii.medium,
     justifyContent: 'center' as const,
+    // padding + label line-height already come to 44 at the default tokens, but both are
+    // themable, so the touch-target floor has to be pinned independently
+    minHeight: 44,
     padding: spacing.medium,
     width: '100%' as const,
   };

--- a/src/__tests__/components/RawDataFormScreen.test.tsx
+++ b/src/__tests__/components/RawDataFormScreen.test.tsx
@@ -8,6 +8,7 @@ import renderer, { act } from 'react-test-renderer';
 jest.mock(
   'react-native',
   () => ({
+    Platform: { OS: 'ios', select: (o: { ios?: unknown; default?: unknown }) => o.ios ?? o.default },
     ScrollView: 'ScrollView',
     StyleSheet: { create: (s: unknown) => s, flatten: (s: unknown) => s, hairlineWidth: 1 },
     Text: 'Text',
@@ -32,10 +33,32 @@ jest.mock('../../Components/hooks/usePrimerPaymentMethod', () => ({
 
 jest.mock('../../Components/internal/theme', () => ({
   usePrimerTheme: () => ({
-    colors: { background: '#fff', border: '#ccc', primary: '#08f', textPrimary: '#000' },
+    colors: {
+      backgroundPrimary: '#fff',
+      backgroundOutlinedDefault: '#fdfdfd',
+      backgroundOutlinedDisabled: '#eee',
+      backgroundSecondary: '#fafafa',
+      borderOutlinedDefault: '#ccc',
+      borderOutlinedDisabled: '#ddd',
+      borderOutlinedError: '#f00',
+      borderOutlinedFocus: '#08c',
+      brand: '#08f',
+      onBrand: '#fff',
+      textDisabled: '#aaa',
+      textNegative: '#c00',
+      textOutlinedDefault: '#111',
+      textPlaceholder: '#999',
+      textPrimary: '#000',
+    },
     spacing: { xsmall: 4, small: 8, medium: 12, large: 16 },
-    radii: { medium: 8 },
+    radii: { small: 4, medium: 8, large: 12 },
+    sizes: { small: 16, medium: 20, large: 24, xlarge: 32, xxlarge: 40, xxxlarge: 56, base: 4 },
+    widths: { default: 1, focus: 2, selected: 2, error: 2 },
     typography: {
+      fontFamily: 'system',
+      bodySmall: { fontFamily: 'system', fontSize: 12, fontWeight: '400', letterSpacing: 0, lineHeight: 16 },
+      bodyLarge: { fontFamily: 'system', fontSize: 16, fontWeight: '400', letterSpacing: 0, lineHeight: 20 },
+      error: { fontFamily: 'system', fontSize: 12, fontWeight: '400', letterSpacing: 0, lineHeight: 16 },
       titleLarge: { fontFamily: 'system', fontSize: 16, fontWeight: '500', letterSpacing: 0, lineHeight: 20 },
     },
   }),
@@ -88,6 +111,8 @@ function render() {
 }
 
 const textInputs = (root: any) => root.findAll((n: any) => n.type === 'TextInput');
+// The bordered View PrimerTextInput wraps each field in — carries the focus/error/disabled border.
+const fieldBorder = (root: any, index = 0) => textInputs(root)[index].parent.props.style;
 const payButton = (root: any) => root.findAll((n: any) => n.type === 'TouchableOpacity')[0];
 
 describe('RawDataFormScreen (ORC-6514)', () => {
@@ -104,6 +129,19 @@ describe('RawDataFormScreen (ORC-6514)', () => {
     expect(inputs.map((i: any) => i.props.keyboardType)).toEqual(['phone-pad', 'number-pad', 'default']);
   });
 
+  it('draws the focus border while a field is focused (ORC-8178)', () => {
+    mockMethod = rawDataForm({ requiredInputs: ['PHONE_NUMBER'] });
+    const root = render().root;
+
+    expect(fieldBorder(root)).toMatchObject({ borderColor: '#ccc', borderWidth: 1 });
+
+    act(() => textInputs(root)[0].props.onFocus());
+    expect(fieldBorder(root)).toMatchObject({ borderColor: '#08c', borderWidth: 2 });
+
+    act(() => textInputs(root)[0].props.onBlur());
+    expect(fieldBorder(root)).toMatchObject({ borderColor: '#ccc', borderWidth: 1 });
+  });
+
   it('forwards typed input to the SDK in the right raw-data shape', () => {
     mockMethod = rawDataForm({ requiredInputs: ['PHONE_NUMBER'] });
     const root = render().root;
@@ -117,6 +155,9 @@ describe('RawDataFormScreen (ORC-6514)', () => {
     const root = render().root;
 
     expect(payButton(root).props.disabled).toBe(true);
+    // Disabled reads as the grey fill, not a faded brand (ORC-8265).
+    expect(payButton(root).props.style[0].backgroundColor).toBe('#eee');
+    expect(payButton(root).props.style[1]).toEqual({ opacity: 1 });
     act(() => payButton(root).props.onPress());
     expect(mockSubmit).not.toHaveBeenCalled();
     expect(mockReplace).not.toHaveBeenCalled();
@@ -127,6 +168,7 @@ describe('RawDataFormScreen (ORC-6514)', () => {
     const root = render().root;
 
     expect(payButton(root).props.disabled).toBe(false);
+    expect(payButton(root).props.style[0].backgroundColor).toBe('#08f');
     act(() => payButton(root).props.onPress());
     expect(mockReplace).toHaveBeenCalledWith('processing');
     expect(mockSubmit).toHaveBeenCalledTimes(1);

--- a/src/__tests__/components/achScreens.test.tsx
+++ b/src/__tests__/components/achScreens.test.tsx
@@ -31,19 +31,24 @@ jest.mock(
 jest.mock('../../Components/internal/theme', () => ({
   usePrimerTheme: () => ({
     colors: {
-      background: '#fff',
-      surface: '#fafafa',
-      border: '#ccc',
-      primary: '#08f',
+      backgroundPrimary: '#fff',
+      backgroundOutlinedDisabled: '#eee',
+      backgroundSecondary: '#fafafa',
+      borderOutlinedDefault: '#ccc',
+      brand: '#08f',
+      onBrand: '#fff',
+      textDisabled: '#aaa',
       textPrimary: '#000',
       textSecondary: '#666',
     },
     spacing: { xxsmall: 2, xsmall: 4, small: 8, medium: 12, large: 16, xlarge: 20, xxlarge: 24 },
     radii: { small: 4, medium: 8, large: 12 },
-    borders: { input: 1, default: 1, strong: 2 },
+    sizes: { small: 16, medium: 20, large: 24, xlarge: 32, xxlarge: 40, xxxlarge: 56, base: 4 },
+    widths: { default: 1, focus: 2, selected: 2, error: 2 },
     typography: {
       fontFamily: 'system',
       bodySmall: { fontFamily: 'system', fontSize: 12, fontWeight: '400', letterSpacing: 0, lineHeight: 16 },
+      error: { fontFamily: 'system', fontSize: 12, fontWeight: '400', letterSpacing: 0, lineHeight: 16 },
       bodyMedium: { fontFamily: 'system', fontSize: 14, fontWeight: '400', letterSpacing: 0, lineHeight: 18 },
       bodyLarge: { fontFamily: 'system', fontSize: 16, fontWeight: '400', letterSpacing: 0, lineHeight: 20 },
       titleLarge: { fontFamily: 'system', fontSize: 16, fontWeight: '500', letterSpacing: 0, lineHeight: 20 },
@@ -182,6 +187,8 @@ describe('StripeAchUserDetailsScreen', () => {
     const root = render(createElement(StripeAchUserDetailsScreen));
     const button = continueButton(root);
     expect(button.props.disabled).toBe(true);
+    // Invalid reads as the grey fill, not a faded brand (ORC-8265).
+    expect((button.props.style as Array<Record<string, unknown>>)[0]!.backgroundColor).toBe('#eee');
 
     (button.props.onPress as () => void)();
     expect(mockAchVariant.submit).not.toHaveBeenCalled();
@@ -219,9 +226,12 @@ describe('StripeAchUserDetailsScreen', () => {
     mockAchVariant = baseVariant({ isValid: true, step: 'awaitingBankLink' });
     const root = render(createElement(StripeAchUserDetailsScreen));
 
-    // Spinner replaces the Continue label; the button is disabled.
+    // Spinner replaces the Continue label; the button is disabled but keeps the brand fill (ORC-8265).
     const button = continueButton(root);
     expect(button.props.disabled).toBe(true);
+    const style = button.props.style as Array<Record<string, unknown>>;
+    expect(style[0]!.backgroundColor).toBe('#08f');
+    expect(style[1]).toEqual({ opacity: 1 });
     expect(root.findAllByType('ActivityIndicator')).toHaveLength(1);
 
     // Back affordance is hidden, and a stray back press is a no-op.
@@ -262,6 +272,7 @@ describe('StripeAchMandateScreen', () => {
 
     const [accept, decline] = root.findAllByType('TouchableOpacity');
     expect(accept!.props.disabled).toBe(false);
+    expect((accept!.props.style as Array<Record<string, unknown>>)[0]!.backgroundColor).toBe('#08f');
     (accept!.props.onPress as () => void)();
     expect(acceptAchMandate).toHaveBeenCalledTimes(1);
 
@@ -283,6 +294,11 @@ describe('StripeAchMandateScreen', () => {
     for (const button of buttons) {
       expect(button.props.disabled).toBe(true);
     }
+    // Accept is loading, so it keeps the brand fill; decline is genuinely disabled and dims (ORC-8265).
+    const [accept, decline] = buttons;
+    expect((accept!.props.style as Array<Record<string, unknown>>)[0]!.backgroundColor).toBe('#08f');
+    expect((accept!.props.style as Array<Record<string, unknown>>)[1]).toEqual({ opacity: 1 });
+    expect((decline!.props.style as Array<Record<string, unknown>>)[1]).toEqual({ opacity: 0.5 });
   });
 
   it('renders nothing without a mandate (defensive)', () => {

--- a/src/__tests__/components/theme/merge.test.ts
+++ b/src/__tests__/components/theme/merge.test.ts
@@ -1,5 +1,5 @@
 import { mergeTokens } from '../../../Components/internal/theme/merge';
-import { defaultLightTokens } from '../../../Components/internal/theme/tokens';
+import { defaultDarkTokens, defaultLightTokens } from '../../../Components/internal/theme/tokens';
 import type { PrimerTypographyStyle } from '../../../Components/internal/theme/types';
 
 const base = defaultLightTokens;
@@ -32,7 +32,7 @@ describe('mergeTokens', () => {
     expect(result.spacing.medium).toBe(base.spacing.medium);
   });
 
-  it('replaces entire typography style when titleXLarge is overridden', () => {
+  it('applies a full typography style override', () => {
     const customStyle: PrimerTypographyStyle = {
       fontSize: 28,
       fontWeight: '700',
@@ -60,7 +60,7 @@ describe('mergeTokens', () => {
     expect(result.spacing.large).toBe(20);
     expect(result.spacing.small).toBe(base.spacing.small);
     expect(result.typography.fontFamily).toBe('Roboto');
-    expect(result.typography.titleXLarge).toEqual(base.typography.titleXLarge);
+    expect(result.typography.titleXLarge).toEqual({ ...base.typography.titleXLarge, fontFamily: 'Roboto' });
     expect(result.radii.medium).toBe(10);
     expect(result.radii.small).toBe(base.radii.small);
     expect(result.widths.focus).toBe(3);
@@ -156,5 +156,83 @@ describe('mergeTokens', () => {
 
     expect(result.colors.textPrimary).toBe(base.colors.textPrimary);
     expect(result.colors.backgroundSecondary).toBe(base.colors.backgroundSecondary);
+  });
+});
+
+describe('brand font', () => {
+  const STYLES = ['titleXLarge', 'titleLarge', 'bodyLarge', 'bodyMedium', 'bodySmall', 'error'] as const;
+
+  const withoutFont = ({ fontSize, fontWeight, lineHeight, letterSpacing }: PrimerTypographyStyle) => ({
+    fontSize,
+    fontWeight,
+    lineHeight,
+    letterSpacing,
+  });
+
+  it('leaves every style on Inter when nothing is set', () => {
+    for (const tokens of [defaultLightTokens, defaultDarkTokens]) {
+      expect(tokens.typography.fontFamily).toBe('Inter');
+      for (const style of STYLES) {
+        expect(tokens.typography[style].fontFamily).toBe('Inter');
+      }
+    }
+
+    expect(mergeTokens(base, { colors: { brand: '#ff0000' } }).typography).toBe(base.typography);
+  });
+
+  it('moves every style the merchant left alone to the brand font', () => {
+    const result = mergeTokens(base, { typography: { fontFamily: 'Roboto' } });
+
+    expect(result.typography.fontFamily).toBe('Roboto');
+    for (const style of STYLES) {
+      expect(result.typography[style]).toEqual({ ...base.typography[style], fontFamily: 'Roboto' });
+    }
+  });
+
+  it("lets a style's own font win over the brand font", () => {
+    const result = mergeTokens(base, {
+      typography: { fontFamily: 'Roboto', error: { ...base.typography.error, fontFamily: 'Menlo' } },
+    });
+
+    expect(result.typography.error.fontFamily).toBe('Menlo');
+    expect(result.typography.bodySmall.fontFamily).toBe('Roboto');
+  });
+
+  it('gives a style set without a font the brand font', () => {
+    const metrics = withoutFont(base.typography.bodyLarge);
+    const result = mergeTokens(base, { typography: { fontFamily: 'Roboto', bodyLarge: { ...metrics, fontSize: 18 } } });
+
+    expect(result.typography.bodyLarge).toEqual({ ...metrics, fontSize: 18, fontFamily: 'Roboto' });
+  });
+
+  it('changes one typography field and leaves the rest alone', () => {
+    const result = mergeTokens(base, { typography: { bodyLarge: { fontSize: 18 } } });
+
+    expect(result.typography.bodyLarge).toEqual({ ...base.typography.bodyLarge, fontSize: 18 });
+    expect(result.typography.bodyMedium).toEqual(base.typography.bodyMedium);
+  });
+
+  it('lets a one-field override still pick up a new brand font', () => {
+    const result = mergeTokens(base, { typography: { fontFamily: 'Roboto', bodyLarge: { fontSize: 18 } } });
+
+    expect(result.typography.bodyLarge.fontSize).toBe(18);
+    expect(result.typography.bodyLarge.fontFamily).toBe('Roboto');
+    expect(result.typography.bodyLarge.lineHeight).toBe(base.typography.bodyLarge.lineHeight);
+  });
+
+  it('keeps a style own font when only a metric is overridden', () => {
+    const withOwnFont = mergeTokens(base, { typography: { bodyLarge: { fontFamily: 'Menlo' } } });
+    const result = mergeTokens(withOwnFont, {
+      typography: { fontFamily: 'Roboto', bodyLarge: { fontSize: 22 } },
+    });
+
+    expect(result.typography.bodyLarge.fontFamily).toBe('Menlo');
+    expect(result.typography.bodyLarge.fontSize).toBe(22);
+  });
+
+  it('gives a style set without a font the default font when the brand font is not set', () => {
+    const result = mergeTokens(base, { typography: { bodyLarge: withoutFont(base.typography.bodyLarge) } });
+
+    expect(result.typography.bodyLarge.fontFamily).toBe('Inter');
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -217,6 +217,8 @@ export type {
   PrimerSpacingTokens,
   PrimerTypographyTokens,
   PrimerTypographyStyle,
+  PrimerTypographyStyleOverride,
+  PrimerTypographyOverride,
   PrimerRadiusTokens,
   PrimerSizeTokens,
   PrimerWidthTokens,


### PR DESCRIPTION
[ORC-8270](https://primerapi.atlassian.net/browse/ORC-8270)

Five screens each had their own `TouchableOpacity` button and the raw-data form its own `TextInput`, so they missed the shared components' disabled, loading and focus handling. Card form, bank selection, both Stripe ACH screens and the raw-data form move onto `CheckoutButton`; the raw-data form's input onto `PrimerTextInput`. About 150 lines of duplicated StyleSheet go.

`CheckoutButton` gains an explicit `minHeight: 44`. Folding the five screens onto it dropped their tap-target floor, since each had been setting it themselves. Padding and line height both come from the theme, so a merchant could otherwise shrink the button below the accessible minimum.



[ORC-8270]: https://primerapi.atlassian.net/browse/ORC-8270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ