### PR TITLE
fix(components): translate the raw-data form labels and add autofill hints (ORC-8116)

### DIFF
--- a/src/Components/inputs/PrimerTextInput.tsx
+++ b/src/Components/inputs/PrimerTextInput.tsx
@@ -51,6 +51,7 @@ export const PrimerTextInput = forwardRef<PrimerTextInputRef, PrimerTextInputPro
     maxLength,
     secureTextEntry = false,
     autoComplete,
+    textContentType,
     autoCapitalize = 'none',
     label,
     showLabel = true,
@@ -183,6 +184,7 @@ export const PrimerTextInput = forwardRef<PrimerTextInputRef, PrimerTextInputPro
           maxLength={maxLength}
           secureTextEntry={secureTextEntry}
           autoComplete={autoComplete}
+          textContentType={textContentType}
           autoCapitalize={autoCapitalize}
           placeholder={placeholder}
           placeholderTextColor={resolved.placeholderColor}

--- a/src/Components/internal/screens/RawDataFormScreen.tsx
+++ b/src/Components/internal/screens/RawDataFormScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
+import type { TextInputProps } from 'react-native';
 
 import { usePrimerTheme } from '../theme';
 import type { PrimerTokens } from '../theme';
@@ -17,16 +18,29 @@ import { buildRawData } from './buildRawData';
 
 // Field keys are the SDK's input-element-type strings. NOTE the platform split for BLIK's
 // one-time code: iOS reports 'OTP', Android reports 'OTP_CODE' — both are handled.
-const FIELD_LABEL: Record<string, string> = {
-  PHONE_NUMBER: 'Phone number',
-  OTP: 'One-time code',
-  OTP_CODE: 'One-time code',
-  CARD_NUMBER: 'Card number',
-  EXPIRY_DATE: 'Expiry date (MM/YY)',
-  CARDHOLDER_NAME: 'Cardholder name',
+const FIELD_LABEL_KEY: Record<string, string> = {
+  PHONE_NUMBER: 'primer_card_form_label_phone',
+  OTP: 'primer_card_form_label_otp',
+  OTP_CODE: 'primer_card_form_label_otp',
+  CARD_NUMBER: 'primer_card_form_label_number',
+  EXPIRY_DATE: 'primer_card_form_label_expiry',
+  CARDHOLDER_NAME: 'primer_card_form_label_name',
 };
 
 const NUMERIC_FIELDS = new Set<string>(['PHONE_NUMBER', 'OTP', 'OTP_CODE', 'CARD_NUMBER', 'EXPIRY_DATE']);
+
+// Autofill hints and capitalisation, per field. `autoComplete` drives Android, `textContentType`
+// drives iOS, and only the cardholder name wants capitalisation.
+type FieldInputProps = Pick<TextInputProps, 'autoComplete' | 'textContentType' | 'autoCapitalize'>;
+
+const FIELD_INPUT_PROPS: Record<string, FieldInputProps> = {
+  PHONE_NUMBER: { autoComplete: 'tel', textContentType: 'telephoneNumber' },
+  OTP: { autoComplete: 'one-time-code', textContentType: 'oneTimeCode' },
+  OTP_CODE: { autoComplete: 'one-time-code', textContentType: 'oneTimeCode' },
+  CARD_NUMBER: { autoComplete: 'cc-number', textContentType: 'creditCardNumber' },
+  EXPIRY_DATE: { autoComplete: 'cc-exp', textContentType: 'creditCardExpiration' },
+  CARDHOLDER_NAME: { autoComplete: 'cc-name', textContentType: 'creditCardName', autoCapitalize: 'words' },
+};
 
 type FieldValues = Record<string, string>;
 
@@ -91,7 +105,8 @@ export function RawDataFormScreen() {
         showsVerticalScrollIndicator={false}
       >
         {requiredInputs.map((field) => {
-          const label = FIELD_LABEL[field] ?? field;
+          const labelKey = FIELD_LABEL_KEY[field];
+          const label = labelKey ? t(labelKey) : field;
           return (
             <PrimerTextInput
               key={field}
@@ -102,6 +117,7 @@ export function RawDataFormScreen() {
                 field === 'PHONE_NUMBER' ? 'phone-pad' : NUMERIC_FIELDS.has(field) ? 'number-pad' : 'default'
               }
               autoCapitalize="none"
+              {...FIELD_INPUT_PROPS[field]}
             />
           );
         })}

--- a/src/Components/types/CardInputTypes.ts
+++ b/src/Components/types/CardInputTypes.ts
@@ -38,6 +38,8 @@ export interface PrimerTextInputProps {
   maxLength?: number;
   secureTextEntry?: boolean;
   autoComplete?: TextInputProps['autoComplete'];
+  /** iOS autofill hint; `autoComplete` covers Android. */
+  textContentType?: TextInputProps['textContentType'];
   autoCapitalize?: TextInputProps['autoCapitalize'];
   label?: string;
   showLabel?: boolean;

--- a/src/__tests__/components/RawDataFormScreen.test.tsx
+++ b/src/__tests__/components/RawDataFormScreen.test.tsx
@@ -129,6 +129,26 @@ describe('RawDataFormScreen (ORC-6514)', () => {
     expect(inputs.map((i: any) => i.props.keyboardType)).toEqual(['phone-pad', 'number-pad', 'default']);
   });
 
+  it('offers the right autofill hint per field', () => {
+    mockMethod = rawDataForm({ requiredInputs: ['PHONE_NUMBER', 'OTP', 'CARD_NUMBER', 'CARDHOLDER_NAME'] });
+    const inputs = textInputs(render().root);
+
+    expect(inputs.map((i: any) => i.props.autoComplete)).toEqual(['tel', 'one-time-code', 'cc-number', 'cc-name']);
+    expect(inputs.map((i: any) => i.props.textContentType)).toEqual([
+      'telephoneNumber',
+      'oneTimeCode',
+      'creditCardNumber',
+      'creditCardName',
+    ]);
+  });
+
+  it('capitalises the cardholder name and nothing else', () => {
+    mockMethod = rawDataForm({ requiredInputs: ['PHONE_NUMBER', 'CARDHOLDER_NAME'] });
+    const inputs = textInputs(render().root);
+
+    expect(inputs.map((i: any) => i.props.autoCapitalize)).toEqual(['none', 'words']);
+  });
+
   it('draws the focus border while a field is focused (ORC-8178)', () => {
     mockMethod = rawDataForm({ requiredInputs: ['PHONE_NUMBER'] });
     const root = render().root;

--- a/src/__tests__/components/theme/merge.test.ts
+++ b/src/__tests__/components/theme/merge.test.ts
@@ -69,6 +69,7 @@ describe('mergeTokens', () => {
 
   it('keeps the error text style separate from the body-small label', () => {
     const result = mergeTokens(base, { typography: { error: { ...base.typography.error, fontSize: 20 } } });
+
     expect(result.typography.error.fontSize).toBe(20);
     expect(result.typography.bodySmall.fontSize).toBe(base.typography.bodySmall.fontSize);
   });


### PR DESCRIPTION
[ORC-8116](https://primerapi.atlassian.net/browse/ORC-8116)

Two things wrong with the raw-data form, which is what we show for payment methods that collect their own fields.

**Labels were hardcoded English**, so a shopper on a French or German checkout saw English on those screens only. They come from the translation catalogue now.

**No autofill.** Each field tells the keyboard what it is, `autoComplete` for Android and `textContentType` for iOS, so a phone number or one-time code can be filled rather than typed.

Capitalisation is set on the cardholder name and nowhere else; on a one-time code or card number it would be actively unhelpful.



[ORC-8116]: https://primerapi.atlassian.net/browse/ORC-8116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ