### PR TITLE
fix(components): paint standalone spinners from the loader colour (ORC-8271)

### DIFF
--- a/src/Components/PrimerPaymentMethodList.tsx
+++ b/src/Components/PrimerPaymentMethodList.tsx
@@ -42,7 +42,7 @@ export function PrimerPaymentMethodList({
   if (isLoading) {
     return (
       <View style={[styles.centered, style]}>
-        <ActivityIndicator size="small" color={tokens.colors.brand} />
+        <ActivityIndicator size="small" color={tokens.colors.loader} />
       </View>
     );
   }

--- a/src/Components/internal/screens/BankSelectionScreen.tsx
+++ b/src/Components/internal/screens/BankSelectionScreen.tsx
@@ -65,7 +65,7 @@ export function BankSelectionScreen() {
       />
       {isLoading && banks.length === 0 ? (
         <View style={styles.loading}>
-          <ActivityIndicator color={tokens.colors.brand} />
+          <ActivityIndicator color={tokens.colors.loader} />
         </View>
       ) : (
         <ScrollView

--- a/src/Components/internal/screens/StripeAchUserDetailsScreen.tsx
+++ b/src/Components/internal/screens/StripeAchUserDetailsScreen.tsx
@@ -110,7 +110,7 @@ export function StripeAchUserDetailsScreen() {
       </View>
       {isStarting ? (
         <View style={styles.loading}>
-          <ActivityIndicator color={tokens.colors.brand} />
+          <ActivityIndicator color={tokens.colors.loader} />
         </View>
       ) : (
         <ScrollView

--- a/src/Components/status/PrimerLoadingScreen.tsx
+++ b/src/Components/status/PrimerLoadingScreen.tsx
@@ -23,7 +23,7 @@ export function PrimerLoadingScreen({ title, subtitle, icon }: PrimerLoadingScre
   const resolvedSubtitle = subtitle ?? t('primer_checkout_loading_subtitle');
   const resolvedIcon = icon ?? (
     <View style={styles.iconWrapper}>
-      <ActivityIndicator size="large" color={tokens.colors.brand} style={styles.spinner} />
+      <ActivityIndicator size="large" color={tokens.colors.loader} style={styles.spinner} />
     </View>
   );
 

--- a/src/__tests__/components/status/primerStatusScreens.test.tsx
+++ b/src/__tests__/components/status/primerStatusScreens.test.tsx
@@ -18,6 +18,8 @@ import {
   PrimerErrorScreen,
 } from '../../../Components/status';
 import { CheckoutButton } from '../../../Components/internal/ui';
+import { ThemeContext } from '../../../Components/internal/theme/ThemeContext';
+import { defaultDarkTokens, defaultLightTokens } from '../../../Components/internal/theme/tokens';
 
 function render(element: ReturnType<typeof createElement>) {
   let testRenderer: ReturnType<typeof create>;
@@ -47,6 +49,20 @@ describe('public status components (standalone, no checkout/navigation provider)
   it('PrimerLoadingScreen renders with overridden copy', () => {
     const r = render(createElement(PrimerLoadingScreen, { title: 'Wait', subtitle: 'Almost there' }));
     expect(r.toJSON()).not.toBeNull();
+  });
+
+  it('PrimerLoadingScreen paints its spinner from the loader colour, not from brand', () => {
+    const tokens = {
+      ...defaultLightTokens,
+      colors: { ...defaultLightTokens.colors, brand: '#ff0000', loader: '#00ff00' },
+    };
+    const r = render(
+      createElement(ThemeContext.Provider, {
+        value: { lightTokens: tokens, darkTokens: defaultDarkTokens },
+        children: createElement(PrimerLoadingScreen, {}),
+      })
+    );
+    expect(r.root.findByType('ActivityIndicator').props.color).toBe('#00ff00');
   });
 
   it('PrimerSuccessScreen renders without throwing', () => {


### PR DESCRIPTION
[ORC-8271](https://primerapi.atlassian.net/browse/ORC-8271)

React Native has a loading-spinner colour in the public theme and nothing read it. Every spinner used brand instead. So setting the loading colour did nothing, and changing brand repainted every spinner. iOS reads this in eleven places, Android in five.

Four standalone spinners now read `colors.loader`: the payment method list, the loading screen, bank selection and the Stripe ACH details screen. `CheckoutButton`'s spinner is left alone. It sits on the button and takes `onBrand`/`textPrimary`, same as iOS.

No visible change out of the box: both default to #2f98ff and `COLOR_ALIASES` already moves `loader` when a merchant sets `brand`.

Sits on the ORC-8116 branch because the `loader` token only arrives with ORC-8229.



[ORC-8271]: https://primerapi.atlassian.net/browse/ORC-8271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ