### PR TITLE
fix: keep android listener attached after dismiss (ORC-8335)

### DIFF
--- a/android/src/main/java/com/primerioreactnative/DefaultNativePrimerModule.kt
+++ b/android/src/main/java/com/primerioreactnative/DefaultNativePrimerModule.kt
@@ -33,7 +33,6 @@ internal open class DefaultNativePrimerModule(
         mListener.sendEvent = { eventName, paramsJson -> sendEvent(eventName, paramsJson) }
         mListener.sendError = { paramsJson -> onError(paramsJson) }
         mListener.sendErrorWithCheckoutData = { paramsJson, checkoutData -> onError(paramsJson, checkoutData) }
-        mListener.onDismissedEvent = { Primer.instance.dismiss(true) }
     }
 
     open fun sendEvent(
@@ -141,12 +140,12 @@ internal open class DefaultNativePrimerModule(
     }
 
     fun dismiss(promise: Promise) {
-        Primer.instance.dismiss(true)
+        Primer.instance.dismiss(false)
         promise.resolve(null)
     }
 
     fun cleanUp(promise: Promise) {
-        Primer.instance.dismiss(true)
+        Primer.instance.dismiss(false)
         promise.resolve(null)
     }
 

--- a/android/src/main/java/com/primerioreactnative/DefaultNativePrimerModule.kt
+++ b/android/src/main/java/com/primerioreactnative/DefaultNativePrimerModule.kt
@@ -150,8 +150,7 @@ internal open class DefaultNativePrimerModule(
         promise.resolve(null)
     }
 
-    // The SDK holds this module's listener until told otherwise, so release it when
-    // React Native disposes the module.
+    // The SDK holds our listener until told otherwise.
     fun invalidate() {
         if (!listenerAttached) return
         listenerAttached = false

--- a/android/src/main/java/com/primerioreactnative/DefaultNativePrimerModule.kt
+++ b/android/src/main/java/com/primerioreactnative/DefaultNativePrimerModule.kt
@@ -28,6 +28,7 @@ internal open class DefaultNativePrimerModule(
     private val eventSender: (String, WritableMap) -> Unit,
 ) {
     private val mListener = PrimerRNEventListener()
+    private var listenerAttached = false
 
     init {
         mListener.sendEvent = { eventName, paramsJson -> sendEvent(eventName, paramsJson) }
@@ -140,13 +141,21 @@ internal open class DefaultNativePrimerModule(
     }
 
     fun dismiss(promise: Promise) {
-        Primer.instance.dismiss(false)
+        Primer.instance.dismiss()
         promise.resolve(null)
     }
 
     fun cleanUp(promise: Promise) {
-        Primer.instance.dismiss(false)
+        Primer.instance.dismiss()
         promise.resolve(null)
+    }
+
+    // The SDK holds this module's listener until told otherwise, so release it when
+    // React Native disposes the module.
+    fun invalidate() {
+        if (!listenerAttached) return
+        listenerAttached = false
+        Primer.instance.cleanup(cleanClientSessionCache = false)
     }
 
     // region tokenization handlers
@@ -239,6 +248,7 @@ internal open class DefaultNativePrimerModule(
 
     private fun startSdk(settings: PrimerSettings) {
         Primer.instance.configure(settings, mListener)
+        listenerAttached = true
     }
 
     private fun onError(

--- a/android/src/main/java/com/primerioreactnative/PrimerRNEventListener.kt
+++ b/android/src/main/java/com/primerioreactnative/PrimerRNEventListener.kt
@@ -42,7 +42,6 @@ class PrimerRNEventListener : PrimerCheckoutListener {
     var sendError: ((error: PrimerErrorRN) -> Unit)? = null
     var sendErrorWithCheckoutData: ((error: PrimerErrorRN, checkoutData: PrimerCheckoutDataRN?) -> Unit)? =
         null
-    var onDismissedEvent: (() -> Unit)? = null
 
     override fun onCheckoutCompleted(checkoutData: PrimerCheckoutData) {
         if (implementedRNCallbacks?.isOnCheckoutCompleteImplemented == true) {
@@ -201,7 +200,6 @@ class PrimerRNEventListener : PrimerCheckoutListener {
             )
         }
 
-        onDismissedEvent?.invoke()
         removeCallbacksAndHandlers()
     }
 

--- a/android/src/newarch/java/com/primerioreactnative/NativePrimerModule.kt
+++ b/android/src/newarch/java/com/primerioreactnative/NativePrimerModule.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.json.Json
 @ReactModule(name = DefaultNativePrimerModule.NAME)
 class NativePrimerModule(private val reactContext: ReactApplicationContext, private val json: Json) :
   NativePrimerSpec(reactContext) {
-  private val implementation by lazy {
+  private val lazyImplementation = lazy {
     DefaultNativePrimerModule(
       reactContext = reactContext,
       json = json,
@@ -20,6 +20,7 @@ class NativePrimerModule(private val reactContext: ReactApplicationContext, priv
       }
     )
   }
+  private val implementation by lazyImplementation
 
   override fun configure(settings: String?, promise: Promise) {
     implementation.configure(settingsStr = settings, promise = promise)
@@ -121,6 +122,6 @@ class NativePrimerModule(private val reactContext: ReactApplicationContext, priv
 
   override fun invalidate() {
     super.invalidate()
-    implementation.invalidate()
+    if (lazyImplementation.isInitialized()) implementation.invalidate()
   }
 }

--- a/android/src/newarch/java/com/primerioreactnative/NativePrimerModule.kt
+++ b/android/src/newarch/java/com/primerioreactnative/NativePrimerModule.kt
@@ -118,4 +118,9 @@ class NativePrimerModule(private val reactContext: ReactApplicationContext, priv
     const val EVENT_TYPE_KEY = "eventType"
     const val DATA_KEY = "data"
   }
+
+  override fun invalidate() {
+    super.invalidate()
+    implementation.invalidate()
+  }
 }

--- a/android/src/oldarch/java/com/primerioreactnative/NativePrimerModule.kt
+++ b/android/src/oldarch/java/com/primerioreactnative/NativePrimerModule.kt
@@ -138,4 +138,9 @@ class NativePrimerModule(private val reactContext: ReactApplicationContext, priv
 
   @ReactMethod
   fun removeListeners(count: Int?) = Unit
+
+  override fun invalidate() {
+    super.invalidate()
+    implementation.invalidate()
+  }
 }

--- a/android/src/oldarch/java/com/primerioreactnative/NativePrimerModule.kt
+++ b/android/src/oldarch/java/com/primerioreactnative/NativePrimerModule.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.json.Json
 @ReactModule(name = DefaultNativePrimerModule.NAME)
 class NativePrimerModule(private val reactContext: ReactApplicationContext, private val json: Json) :
   ReactContextBaseJavaModule(reactContext) {
-  private val implementation by lazy {
+  private val lazyImplementation = lazy {
     DefaultNativePrimerModule(
       reactContext = reactContext,
       json = json,
@@ -22,6 +22,7 @@ class NativePrimerModule(private val reactContext: ReactApplicationContext, priv
       }
     )
   }
+  private val implementation by lazyImplementation
 
   override fun getName(): String {
     return DefaultNativePrimerModule.NAME
@@ -141,6 +142,6 @@ class NativePrimerModule(private val reactContext: ReactApplicationContext, priv
 
   override fun invalidate() {
     super.invalidate()
-    implementation.invalidate()
+    if (lazyImplementation.isInitialized()) implementation.invalidate()
   }
 }


### PR DESCRIPTION
## Summary

On Android, closing the checkout also told the native SDK to forget how to reach the bridge. Nothing could reach the merchant's callbacks again until `Primer.configure()` was called. An app that configures once at startup therefore got a working first checkout and a silent one after that, with nothing logged to explain it.

iOS never behaved this way, so the same JavaScript produced different results on the two platforms.

The SDK's own close command does not drop the listener by default. The bridge was passing an extra flag to make it do so. Releasing the listener is a separate call the SDK provides for when you are finished with it.

What changed:

* Closing the checkout no longer drops the listener, on either close path.
* The hook that dropped it when the shopper closed the sheet is removed. That was the only thing it did, and by that point the sheet has already gone, so what was left of the call was a repeated analytics event and an error in the log.
* The listener is released when React Native destroys the bridge, which is when it is genuinely finished with. A bridge that never attached one skips this, so one on its way out cannot disconnect its replacement.

JavaScript still removes its own listeners on `Primer.dismiss()` (#413), so nothing fires between closing one checkout and opening the next.

## Jira

[ORC-8335](https://primerapi.atlassian.net/browse/ORC-8335)

## Test plan

Checked on the Android emulator with temporary logging on both the JavaScript and native side, so each step was observed rather than assumed.

- [x] Configure once, show, close, show again without configuring, close. Both closes deliver `onDismiss`. The native log shows a single attach and no second one, so the connection really did survive the first close. Before this change the second close delivered nothing.
- [x] Headless, Drop-in, Headless. One listener per event name at every transition, and a payment in the final Headless mode produces exactly one callback (ESC-852).
- [x] Reload after using a checkout: the bridge is destroyed and the listener released.
- [x] Two reloads with no checkout in between: both bridges skip the release, since neither had attached.
- [x] Same flows on iOS, unchanged.


[ORC-8335]: https://primerapi.atlassian.net/browse/ORC-8335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ