### PR TITLE
refactor(components): read the card number trailing icon top to bottom (ORC-8401)

### DIFF
--- a/src/Components/inputs/PrimerCardNumberInput.tsx
+++ b/src/Components/inputs/PrimerCardNumberInput.tsx
@@ -76,6 +76,50 @@ export const PrimerCardNumberInput = forwardRef<PrimerTextInputRef, PrimerCardNu
       lastSelectionRef.current = e.nativeEvent.selection;
     };
 
+    // Three mutually exclusive trailing states, read top to bottom.
+    const renderTrailingContent = () => {
+      const testID = (suffix: string) => (rest.testID ? `${rest.testID}-${suffix}` : undefined);
+
+      if (showSelector) {
+        return <PrimerCardNetworkSelector testID={testID('network-selector')} />;
+      }
+
+      if (abbreviation) {
+        return (
+          <View
+            style={[
+              styles.abbreviationChip,
+              {
+                borderColor: tokens.colors.borderOutlinedDefault,
+                borderRadius: tokens.radii.small,
+                borderWidth: tokens.widths.default,
+              },
+            ]}
+            testID={testID('network-abbreviation')}
+          >
+            <Text
+              style={{
+                color: tokens.colors.textPrimary,
+                fontFamily: tokens.typography.fontFamily,
+                fontSize: tokens.typography.bodySmall.fontSize,
+              }}
+            >
+              {abbreviation}
+            </Text>
+          </View>
+        );
+      }
+
+      return (
+        <Image
+          source={iconSource ?? placeholderSource}
+          style={styles.placeholder}
+          resizeMode="contain"
+          testID={testID('network-icon')}
+        />
+      );
+    };
+
     return (
       <PrimerTextInput
         ref={innerRef}
@@ -90,40 +134,7 @@ export const PrimerCardNumberInput = forwardRef<PrimerTextInputRef, PrimerCardNu
         placeholder={resolvedPlaceholder}
         error={cardForm.errors.cardNumber}
         onSelectionChange={handleSelectionChange}
-        trailingContent={
-          showSelector ? (
-            <PrimerCardNetworkSelector testID={rest.testID ? `${rest.testID}-network-selector` : undefined} />
-          ) : abbreviation ? (
-            <View
-              style={[
-                styles.abbreviationChip,
-                {
-                  borderColor: tokens.colors.borderOutlinedDefault,
-                  borderRadius: tokens.radii.small,
-                  borderWidth: tokens.widths.default,
-                },
-              ]}
-              testID={rest.testID ? `${rest.testID}-network-abbreviation` : undefined}
-            >
-              <Text
-                style={{
-                  color: tokens.colors.textPrimary,
-                  fontFamily: tokens.typography.fontFamily,
-                  fontSize: tokens.typography.bodySmall.fontSize,
-                }}
-              >
-                {abbreviation}
-              </Text>
-            </View>
-          ) : (
-            <Image
-              source={iconSource ?? placeholderSource}
-              style={styles.placeholder}
-              resizeMode="contain"
-              testID={rest.testID ? `${rest.testID}-network-icon` : undefined}
-            />
-          )
-        }
+        trailingContent={renderTrailingContent()}
         {...rest}
       />
     );


### PR DESCRIPTION
[ORC-8401](https://primerapi.atlassian.net/browse/ORC-8401)

# What this PR does

The card number field picks one of three things to show on the right: the network selector, a two letter chip, or the network icon. That choice was a ternary inside a ternary inside a prop, with about thirty lines of JSX in the middle of it, so you had to unpick the nesting to see which case you were in.

It moves into a function with three early returns. Same three cases, read top to bottom.

Sonar flagged it on #415, and Niall agreed it was worth doing, but that PR had already merged by the time we picked it up.

# Notable decisions

The `testID` suffix was repeated three times with the same guard around it. It is a small local helper now, and produces the same strings, so anything matching on `-network-selector`, `-network-abbreviation` or `-network-icon` still matches.

Nothing else changes. Same elements, same props, same order.

# How to test?

Type a card number and watch the right hand side: the icon for a recognised network, the two letter chip when we have no icon for it, and the selector for a co-badged card.


[ORC-8401]: https://primerapi.atlassian.net/browse/ORC-8401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ