### PR TITLE
fix: fire onDismiss when the app closes checkout (ORC-8227)

### DIFF
--- a/src/Primer.ts
+++ b/src/Primer.ts
@@ -312,8 +312,6 @@ export const Primer: IPrimer = {
   },
 
   dismiss(): void {
-    RNPrimerHeadlessUniversalCheckout.removeAllListeners();
-    RNPrimer.removeAllListeners();
     RNPrimer.dismiss();
   },
 };

--- a/src/__tests__/Primer.dismiss.test.ts
+++ b/src/__tests__/Primer.dismiss.test.ts
@@ -167,6 +167,90 @@ const resetCounter = (module: CountedModule) => {
 const lastImplementedCallbacks = (): Record<string, boolean> =>
   JSON.parse(dropInModule.setImplementedRNCallbacks.mock.lastCall?.[0] ?? '{}');
 
+describe('Primer.dismiss onDismiss — ORC-8227', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    registry.length = 0;
+    [dropInModule, headlessModule, hostModule].forEach(resetCounter);
+  });
+
+  afterEach(async () => {
+    Primer.cleanUp();
+    await PrimerHeadlessUniversalCheckout.cleanUp();
+  });
+
+  it('fires onDismiss when the app closes checkout with dismiss()', async () => {
+    const onDismiss = jest.fn();
+    await Primer.configure({ onDismiss });
+    await Primer.showUniversalCheckout('tok-1');
+
+    Primer.dismiss();
+    // native reports the close after the call returns
+    emit('onDismiss', {});
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleanUp() switches everything off, including onDismiss', async () => {
+    const onDismiss = jest.fn();
+    const onError = jest.fn();
+    await Primer.configure({ onDismiss, onError });
+    await Primer.showUniversalCheckout('tok-1');
+
+    Primer.cleanUp();
+    emit('onDismiss', {});
+    emit('onError', payloadError);
+
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+    expect(registry).toHaveLength(0);
+    expect(dropInModule.listenerCount).toBe(0);
+    expect(dropInModule.overRemovals).toBe(0);
+  });
+
+  it('dismiss() leaves a running Headless session alone', async () => {
+    const headlessOnError = jest.fn();
+    await PrimerHeadlessUniversalCheckout.startWithClientToken('tok-h', {
+      headlessUniversalCheckoutCallbacks: { onError: headlessOnError },
+    });
+
+    Primer.dismiss();
+    emit('onError', payloadError);
+
+    expect(headlessOnError).toHaveBeenCalledTimes(1);
+    expect(headlessModule.listenerCount).toBe(1);
+  });
+
+  it.each<[string, () => Promise<void>]>([
+    ['showUniversalCheckout', () => Primer.showUniversalCheckout('tok-d')],
+    ['showVaultManager', () => Primer.showVaultManager('tok-d')],
+    ['showPaymentMethod', () => Primer.showPaymentMethod('PAYMENT_CARD', 'CHECKOUT', 'tok-d')],
+  ])('%s() clears the previous session before registering its own', async (_label, show) => {
+    await PrimerHeadlessUniversalCheckout.startWithClientToken('tok-h', {
+      headlessUniversalCheckoutCallbacks: { onError: jest.fn() },
+    });
+    expect(headlessModule.listenerCount).toBe(1);
+
+    await Primer.configure({ onError: jest.fn() });
+    await show();
+
+    expect(headlessModule.listenerCount).toBe(0);
+    expect(dropInModule.listenerCount).toBe(1);
+    expect(dropInModule.overRemovals).toBe(0);
+    expect(headlessModule.overRemovals).toBe(0);
+  });
+
+  it('fires onDismiss when the shopper closes the sheet', async () => {
+    const onDismiss = jest.fn();
+    await Primer.configure({ onDismiss });
+    await Primer.showUniversalCheckout('tok-1');
+
+    emit('onDismiss', {});
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('Primer.dismiss / cleanUp listener teardown — ESC-1131', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -175,11 +259,29 @@ describe('Primer.dismiss / cleanUp listener teardown — ESC-1131', () => {
   });
 
   afterEach(async () => {
-    Primer.dismiss();
+    Primer.cleanUp();
     await PrimerHeadlessUniversalCheckout.cleanUp();
   });
 
-  it('Drop-in only: dismiss() removes only Drop-in listeners and never touches the Headless native counter', async () => {
+  it('repeated show/dismiss cycles leave nothing behind', async () => {
+    await Primer.configure({ onError: jest.fn(), onCheckoutComplete: jest.fn() });
+
+    for (let i = 0; i < 10; i++) {
+      await Primer.showUniversalCheckout(`tok-${i}`);
+      Primer.dismiss();
+    }
+
+    await Primer.showUniversalCheckout('tok-last');
+
+    expect(registry).toHaveLength(2);
+    expect(dropInModule.listenerCount).toBe(2);
+    expect(dropInModule.overRemovals).toBe(0);
+    expect(headlessModule.listenerCount).toBe(0);
+    expect(headlessModule.overRemovals).toBe(0);
+    expect(hostModule.overRemovals).toBe(0);
+  });
+
+  it('Drop-in only: dismiss() never touches the Headless native counter', async () => {
     await Primer.configure({ onError: jest.fn(), onCheckoutComplete: jest.fn() });
     await Primer.showUniversalCheckout('tok-1');
     expect(dropInModule.listenerCount).toBe(2);
@@ -189,8 +291,11 @@ describe('Primer.dismiss / cleanUp listener teardown — ESC-1131', () => {
     expect(headlessModule.removeListeners).not.toHaveBeenCalled();
     expect(headlessModule.overRemovals).toBe(0);
     expect(dropInModule.overRemovals).toBe(0);
-    expect(dropInModule.listenerCount).toBe(0);
-    expect(registry).toHaveLength(0);
+
+    // the next show drains and re-registers, so nothing accumulates
+    await Primer.showUniversalCheckout('tok-2');
+    expect(dropInModule.listenerCount).toBe(2);
+    expect(dropInModule.overRemovals).toBe(0);
   });
 
   it.each<[string, () => void]>([

--- a/src/__tests__/Primer.modeSwitch.test.ts
+++ b/src/__tests__/Primer.modeSwitch.test.ts
@@ -190,7 +190,7 @@ describe('Primer mode switch — ESC-852', () => {
     expect(dropInModule.dismiss).toHaveBeenCalledTimes(1);
   });
 
-  it('Primer.dismiss drains both mode subscription arrays', async () => {
+  it('Primer.dismiss closes checkout and leaves the next show to drain', async () => {
     await PrimerHeadlessUniversalCheckout.startWithClientToken('tok-h', {
       headlessUniversalCheckoutCallbacks: { onError: jest.fn() },
     } as any);
@@ -199,9 +199,12 @@ describe('Primer mode switch — ESC-852', () => {
 
     Primer.dismiss();
 
-    expect(dropInEmitter()._subs.length).toBe(0);
-    expect(headlessEmitter()._subs.length).toBe(0);
     expect(dropInModule.dismiss).toHaveBeenCalledTimes(1);
+
+    await Primer.showUniversalCheckout('tok-d2');
+
+    expect(headlessEmitter()._subs.length).toBe(0);
+    expect(dropInEmitter()._subs.filter((s) => s.eventType === 'onError')).toHaveLength(1);
   });
 
   it('HeadlessUniversalCheckout.cleanUp drains headless subscriptions and calls native cleanUp', async () => {


### PR DESCRIPTION
## Summary

`onDismiss` never fired when the merchant's app closed checkout with `Primer.dismiss()`. It fired fine when the shopper closed the sheet.

`dismiss()` removed its listeners and then asked native to close. Native reports the close afterwards, so the listener was already gone.

Now `dismiss()` only closes. Removing the listeners was never needed there, because opening checkout already clears the previous session first. `cleanUp()` is unchanged and still switches everything off.

Present since at least 2.42.2.

## Jira

[ORC-8227](https://primerapi.atlassian.net/browse/ORC-8227)

## Test plan

- [x] New tests, failing before the change and passing after. 44 tests, 7 suites. `yarn typescript` and `yarn lint` clean.
- [x] iOS and Android: no `onDismiss` on 2.47.0, `onDismiss` after the fix.


[ORC-8227]: https://primerapi.atlassian.net/browse/ORC-8227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ